### PR TITLE
Textmaps crash fix

### DIFF
--- a/Game/Map/Tile.cs
+++ b/Game/Map/Tile.cs
@@ -33,6 +33,7 @@ namespace ClassicUO.Game.Map
 {
     public sealed class Tile : GameObject
     {
+        public static readonly HashSet<ushort> _Stretchables = new HashSet<ushort>();
         private static readonly List<GameObject> _itemsAtZ = new List<GameObject>();
         private readonly List<GameObject> _objectsOnTile;
         private readonly List<Static> _statics = new List<Static>();
@@ -49,7 +50,7 @@ namespace ClassicUO.Game.Map
 
         public bool IsIgnored => Graphic < 3 || Graphic == 0x1DB || Graphic >= 0x1AE && Graphic <= 0x1B5;
 
-        public bool IsStretched { get; set; }
+        public bool IsStretched { get { return _Stretchables.Contains(Graphic); } }
 
         public IReadOnlyList<GameObject> ObjectsOnTiles
         {

--- a/Game/Views/TileView.cs
+++ b/Game/Views/TileView.cs
@@ -51,7 +51,7 @@ namespace ClassicUO.Game.Views
 
         public TileView(Tile tile) : base(tile)
         {
-            tile.IsStretched = tile.TileData.TexID > 0; // !(tile.TileData.TexID <= 0 && TileData.IsWet((long) tile.TileData.Flags));
+            //tile.IsStretched = tile.TileData.TexID > 0; // !(tile.TileData.TexID <= 0 && TileData.IsWet((long) tile.TileData.Flags));
             AllowedToDraw = !tile.IsIgnored;
             tile.AverageZ = SortZ;
             tile.MinZ = tile.Position.Z;

--- a/IO/Resources/TexmapTextures.cs
+++ b/IO/Resources/TexmapTextures.cs
@@ -84,6 +84,15 @@ namespace ClassicUO.IO.Resources
                     }
                 }
             }
+            if (ClassicUO.Game.Map.Tile._Stretchables.Count == 0)
+            {
+                for (int i = TEXTMAP_COUNT - 1; i >= 0; --i)
+                {
+                    (int length, int extra, bool patched) = _file.SeekByEntryIndex(i);
+                    if (length > 0)
+                        ClassicUO.Game.Map.Tile._Stretchables.Add((ushort)i);
+                }
+            }
         }
 
         public static SpriteTexture GetTextmapTexture(ushort g)

--- a/IO/Resources/TileData.cs
+++ b/IO/Resources/TileData.cs
@@ -74,6 +74,8 @@ namespace ClassicUO.IO.Resources
 
             for (int i = 0; i < staticscount; i++)
             {
+                if(tiledata.Position >= tiledata.Length)
+                    goto END_2;
                 tiledata.Skip(4);
 
                 for (int j = 0; j < 32; j++)


### PR DESCRIPTION
- we can't trust the textmaps, not every landtile is stretchable, so we create a stretchables hashset beforehand, and use that hashset to check if we can use the textures or not.

- solved a bug where if at end of tiledata, it could cause a crash