### PR TITLE
Quest Arrows, Skill Buttons

### DIFF
--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Game\Managers\JournalManager.cs" />
     <Compile Include="Game\GameObjects\MovingEffect.cs" />
     <Compile Include="Game\Managers\WalkerManager.cs" />
+    <Compile Include="Game\UI\Gumps\QuestArrowGump.cs" />
     <Compile Include="Game\UI\Gumps\RacialAbilitiesBookGump.cs" />
     <Compile Include="Game\UI\Gumps\TargetLineGump.cs" />
     <Compile Include="Game\UI\Gumps\UseAbilityButtonGump.cs" />

--- a/src/Game/GameActions.cs
+++ b/src/Game/GameActions.cs
@@ -282,5 +282,7 @@ namespace ClassicUO.Game
 
         public static void UseAbility(byte index)
             => Socket.Send(new PUseCombatAbility(index));
+
+	    public static void QuestArrow(bool rightClick) => Socket.Send(new PClickQuestArrow(rightClick));
     }
 }

--- a/src/Game/GameObjects/PlayerMobile.cs
+++ b/src/Game/GameObjects/PlayerMobile.cs
@@ -95,7 +95,7 @@ namespace ClassicUO.Game.GameObjects
             for (int i = 0; i < _sklls.Length; i++)
             {
                 SkillEntry skill = FileManager.Skills.GetSkill(i);
-                _sklls[i] = new Skill(skill.Name, skill.Index, skill.HasButton);
+                _sklls[i] = new Skill(skill.Name, skill.Index, skill.HasAction);
             }
 
             if (serial.IsValid)

--- a/src/Game/UI/Gumps/QuestArrowGump.cs
+++ b/src/Game/UI/Gumps/QuestArrowGump.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Input;
+using ClassicUO.IO;
+using Microsoft.Xna.Framework;
+
+namespace ClassicUO.Game.UI.Gumps
+{
+	internal class QuestArrowGump : Gump
+	{
+		public QuestArrowGump(Serial serial, int mx, int my) : base(serial, serial)
+		{
+			CanMove = false;
+			CanCloseWithRightClick = false;
+			
+			AcceptMouseInput = true;
+
+			var screenLeft = Engine.Profile.Current.GameWindowPosition.X;
+			var screenTop = Engine.Profile.Current.GameWindowPosition.Y;
+
+			int screenRight = screenLeft + Engine.Profile.Current.GameWindowSize.X;
+			int screenBottom = screenTop + Engine.Profile.Current.GameWindowSize.Y;
+
+			int screenCenterX = (screenRight - screenLeft) / 2;
+			int screenCenterY = (screenBottom - screenTop) / 2;
+
+			int playerX = World.Player.X;
+			int playerY = World.Player.Y;
+
+			int offsetX = mx - playerX;
+			int offsetY = my - playerY;
+
+			int drawX = screenLeft + (int)(screenCenterX + (offsetX - offsetY) * 22) + 3;
+			int drawY = screenTop + (int)(screenCenterY + (offsetX + offsetY) * 22) + 3;
+
+			var direction = DirectionHelper.DirectionFromPoints(
+				new Point(screenCenterX, screenCenterY), 
+				new Point(drawX, drawY));
+
+			var graphic = (uint)0x1194;
+
+			if (direction >= Direction.North && direction <= Direction.West)
+				graphic = 0x1195 + (uint)direction;
+
+			AddChildren(new GumpPic(0, 0, (Graphic)graphic, 0));
+
+			var size = FileManager.Gumps.GetTexture(graphic).Bounds;
+
+			drawX -= (size.Width / 2);
+			drawY -= (size.Height / 2);
+
+			var xOffsetTable = new[] { -0.5, -0.75, -0.5,  0.0,  0.5, 0.75, 0.5, 0.0 };
+			var yOffsetTable = new[] {  0.5,  0.0, -0.5, -0.75, -0.5, 0.0, 0.5, 0.75 };
+
+			var directionint = (int)direction;
+
+			drawX += (int)(xOffsetTable[(int)direction] * (size.Width + 22));
+			drawY += (int)(yOffsetTable[(int)direction] * (size.Height + 22));
+
+			if (drawX < screenLeft) drawX = screenLeft;
+			if (drawY < screenTop) drawY = screenTop;
+
+			if (drawX + size.Width > screenRight)
+				drawX = (screenRight - size.Width);
+
+			if (drawY + size.Height > screenBottom)
+				drawY = (screenBottom - size.Height);
+
+			X = drawX;
+			Y = drawY;
+		}
+
+		protected override void OnMouseClick(int x, int y, MouseButton button)
+		{
+			var leftClick = button == MouseButton.Left;
+			var rightClick = button == MouseButton.Right;
+
+			if (leftClick || rightClick)
+				GameActions.QuestArrow(rightClick);
+		}
+	}
+}

--- a/src/IO/Resources/SkillsLoader.cs
+++ b/src/IO/Resources/SkillsLoader.cs
@@ -46,7 +46,10 @@ namespace ClassicUO.IO.Resources
                 if (length == 0)
                     return default;
 
-                _skills[index] = new SkillEntry(index, Encoding.UTF8.GetString(_file.ReadArray<byte>(length - 1)), _file.ReadBool()); 
+	            var hasAction = _file.ReadBool();
+	            var name = Encoding.UTF8.GetString(_file.ReadArray<byte>(length - 1));
+
+				_skills[index] = new SkillEntry(index, name, hasAction); 
             }
 
             return value;
@@ -55,15 +58,15 @@ namespace ClassicUO.IO.Resources
 
     internal readonly struct SkillEntry
     {
-        public SkillEntry(int index, string name, bool hasbutton)
+        public SkillEntry(int index, string name, bool hasAction)
         {
             Index = index;
             Name = name;
-            HasButton = hasbutton;
+            HasAction = hasAction;
         }
 
         public readonly int Index;
         public readonly string Name;
-        public readonly bool HasButton;
+        public readonly bool HasAction;
     }
 }

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1753,6 +1753,21 @@ namespace ClassicUO.Network
 
         private static void DisplayQuestArrow(Packet p)
         {
+			var ui = Engine.UI;
+			
+			var display = p.ReadBool();
+			var mx = p.ReadUShort();
+			var my = p.ReadUShort();
+			
+			var serial = default(Serial);
+			
+			if (FileManager.ClientVersion >= ClientVersions.CV_7090)
+			    serial = p.ReadUInt();
+			
+			ui.GetByLocalSerial<QuestArrowGump>(serial)?.Dispose();
+			
+			if (display)
+			    ui.Add(new QuestArrowGump(serial, mx, my));
         }
 
         private static void UltimaMessengerR(Packet p)

--- a/src/Network/Packets.cs
+++ b/src/Network/Packets.cs
@@ -695,7 +695,16 @@ namespace ClassicUO.Network
         }
     }
 
-    internal sealed class PCloseStatusBarGump : PacketWriter
+	internal sealed class PClickQuestArrow : PacketWriter
+	{
+		public PClickQuestArrow(bool rightClick) : base(0xBF)
+		{
+			WriteUShort(0x07);
+			WriteBool(rightClick);
+		}
+	}
+
+	internal sealed class PCloseStatusBarGump : PacketWriter
     {
         public PCloseStatusBarGump(Serial serial) : base(0xBF)
         {


### PR DESCRIPTION
Implements quest arrows (resolves https://github.com/andreakarasho/ClassicUO/issues/154). The implementation differs from the original clients, which I don't believe account for map Z values.


Additionally fixes invalid SkillEntry reads, the action should be read prior to skill name.