### PR TITLE
If the mobile has no graphic assigned, don't draw it

### DIFF
--- a/src/Game/Views/MobileView.cs
+++ b/src/Game/Views/MobileView.cs
@@ -62,7 +62,8 @@ namespace ClassicUO.Game.Views
             IsFlipped = mirror;
             SetupLayers(dir, mobile, out int mountOffset);
 
-
+            if (mobile.Graphic == 0)
+                return false;
 
             AnimationFrameTexture bodyFrame = FileManager.Animations.GetTexture(_frames[0].Hash);
 


### PR DESCRIPTION
Discovered on UOR test shard a mobile with no graphic or name assigned, but it had a valid serial and it would cause a crash.