### PR TITLE
Prevent pasting non-text into client

### DIFF
--- a/src/Game/UI/Controls/TextBox.cs
+++ b/src/Game/UI/Controls/TextBox.cs
@@ -153,6 +153,9 @@ namespace ClassicUO.Game.UI.Controls
             int oldidx = _entry.CaretIndex;
             if (Input.Keyboard.IsModPressed(mod, SDL.SDL_Keymod.KMOD_CTRL) && key == SDL.SDL_Keycode.SDLK_v)//paste
             {
+                if (SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_FALSE)
+                    return;
+
                 s = SDL.SDL_GetClipboardText();
                 if(!string.IsNullOrEmpty(s))
                 {


### PR DESCRIPTION
If you had something that wasn't text (ie: an image) in your clipboard, it would crash. This will do a simple check and prevent that.