### PR TITLE
Fix autologin bug

### DIFF
--- a/src/Game/Scenes/LoginScene.cs
+++ b/src/Game/Scenes/LoginScene.cs
@@ -432,17 +432,22 @@ namespace ClassicUO.Game.Scenes
 				    if (Engine.GlobalSettings.AutoLogin && _isFirstLogin)
 				    {
 				        _isFirstLogin = false;
+                        bool haveAnyCharacter = false;
 
                         for (byte i = 0; i < Characters.Length; i++)
-				        {
-				            if (Characters[i].Length > 0 && Characters[i] == Engine.GlobalSettings.LastCharacterName)
+                        {
+                            if (Characters[i].Length > 0)
 				            {
-				                SelectCharacter(i);
-                                return;
+                                haveAnyCharacter = true;
+                                if (Characters[i] == Engine.GlobalSettings.LastCharacterName)
+                                {
+                                    SelectCharacter(i);
+                                    return;
+                                }
 				            }
 				        }
 
-                        if (Characters.Length != 0)
+                        if (haveAnyCharacter)
                             SelectCharacter(0);
 				    }
 


### PR DESCRIPTION
If character have been deleted on the account (or they are not have) => UO window crash.
(Characters.Length != 0) - not correct (contains char slots, not real characters)