### PR TITLE
DebugGump() small display mode dclick & CloseWithRightClick

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -53,8 +53,6 @@ namespace ClassicUO.Configuration
         [JsonProperty]
         public string CharacterName { get; }
 
-
-
         // sounds
         [JsonProperty] public bool EnableSound { get; set; } = true;
         [JsonProperty] public int SoundVolume { get; set; } = 100;
@@ -125,7 +123,6 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool TopbarGumpIsDisabled { get; set; } = false;
 
         [JsonProperty] public int MaxFPS { get; set; } = 60;
-
 
         public void Save(List<Gump> gumps = null)
         {

--- a/src/Game/UI/Gumps/DebugGump.cs
+++ b/src/Game/UI/Gumps/DebugGump.cs
@@ -16,16 +16,20 @@ namespace ClassicUO.Game.UI.Gumps
         private readonly Label _label;
         private readonly AlphaBlendControl _trans;
 
+        private bool _fullDisplayMode = true;
+
         private const string DEBUG_STRING_0 = "- FPS: {0}, Scale: {1}\n";
         private const string DEBUG_STRING_1 = "- Mobiles: {0}   Items: {1}   Statics: {2}   Multi: {3}   Lands: {4}   Effects: {5}\n";
         private const string DEBUG_STRING_2 = "- CharPos: {0}\n- Mouse: {1}\n- InGamePos: {2}\n";
         private const string DEBUG_STRING_3 = "- Selected: {0}";
 
+        private const string DEBUG_STRING_SMALL = "FPS: {0}";
+
         public DebugGump() : base(0, 0)
         {
             CanMove = true;
             CanCloseWithEsc = false;
-            CanCloseWithRightClick = false;
+            CanCloseWithRightClick = true;
             AcceptMouseInput = true;
             AcceptKeyboardInput = false;
 
@@ -46,6 +50,16 @@ namespace ClassicUO.Game.UI.Gumps
             WantUpdateSize = false;
         }
 
+        protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)
+        {
+            if (button == MouseButton.Left)
+            {
+                _fullDisplayMode = (_fullDisplayMode) ? false : true;
+                return true;
+            }
+
+            return false;
+        }
 
         public override void Update(double totalMS, double frameMS)
         {
@@ -60,10 +74,15 @@ namespace ClassicUO.Game.UI.Gumps
             _sb.Clear();
             GameScene scene = Engine.SceneManager.GetScene<GameScene>();
 
-            _sb.AppendFormat(DEBUG_STRING_0, Engine.CurrentFPS, !World.InGame ? 1f : Engine.Profile.Current.ScaleZoom);
-            _sb.AppendFormat(DEBUG_STRING_1, Engine.DebugInfo.MobilesRendered, Engine.DebugInfo.ItemsRendered, Engine.DebugInfo.StaticsRendered, Engine.DebugInfo.MultiRendered, Engine.DebugInfo.LandsRendered, Engine.DebugInfo.EffectsRendered);
-            _sb.AppendFormat(DEBUG_STRING_2, World.InGame ? World.Player.Position : Position.INVALID, Mouse.Position, scene?.SelectedObject?.Position ?? Position.INVALID);
-            _sb.AppendFormat(DEBUG_STRING_3, ReadObject(scene?.SelectedObject));
+            if (_fullDisplayMode)
+            {
+                _sb.AppendFormat(DEBUG_STRING_0, Engine.CurrentFPS, !World.InGame ? 1f : Engine.Profile.Current.ScaleZoom);
+                _sb.AppendFormat(DEBUG_STRING_1, Engine.DebugInfo.MobilesRendered, Engine.DebugInfo.ItemsRendered, Engine.DebugInfo.StaticsRendered, Engine.DebugInfo.MultiRendered, Engine.DebugInfo.LandsRendered, Engine.DebugInfo.EffectsRendered);
+                _sb.AppendFormat(DEBUG_STRING_2, World.InGame ? World.Player.Position : Position.INVALID, Mouse.Position, scene?.SelectedObject?.Position ?? Position.INVALID);
+                _sb.AppendFormat(DEBUG_STRING_3, ReadObject(scene?.SelectedObject));
+            }
+            else
+                _sb.AppendFormat(DEBUG_STRING_SMALL, Engine.CurrentFPS);
 
             _label.Text = _sb.ToString();
 
@@ -72,9 +91,8 @@ namespace ClassicUO.Game.UI.Gumps
 
         private string ReadObject(GameObject obj)
         {
-            if (obj != null)
+            if (obj != null && _fullDisplayMode)
             {
-
                 switch (obj)
                 {
                     case Mobile mob:
@@ -96,10 +114,8 @@ namespace ClassicUO.Game.UI.Gumps
                     case Land land:
                         return string.Format("Static ({0})  flags: {1}", land.Graphic, land.TileData.Flags);
                 }
-
             }
             return string.Empty;
-
         }
     }
 }

--- a/src/Game/UI/Gumps/TopBarGump.cs
+++ b/src/Game/UI/Gumps/TopBarGump.cs
@@ -213,13 +213,9 @@ namespace ClassicUO.Game.UI.Gumps
                     DebugGump debugGump = Engine.UI.GetByLocalSerial<DebugGump>();
 
                     if (debugGump == null)
-                    {
-                        // dont consider this case
-                    }
+                        Engine.UI.Add(new DebugGump());
                     else
-                    {
                         debugGump.IsVisible = !debugGump.IsVisible;
-                    }
 
                     break;
             }


### PR DESCRIPTION
- "Debug" button in top menu - restore DebugGump() 
- Left DClick changes the display mode (full/small)
- Right Click - close debug gump

![3zwn7ad](https://user-images.githubusercontent.com/1370602/52082621-eeef4300-25a5-11e9-990d-c67ba55b16fc.jpg)

I think it is very convenient.
