### PR TITLE
Warmode

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -111,6 +111,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool EnablePathfind { get; set; } = true;
         [JsonProperty] public bool AlwaysRun { get; set; }
         [JsonProperty] public bool SmoothMovements { get; set; } = true;
+        [JsonProperty] public bool HoldDownKeyTab { get; set; } = true;
 
         // general
         [JsonProperty] public Point ContainerDefaultPosition { get; set; } = new Point(24, 24);

--- a/src/Game/GameActions.cs
+++ b/src/Game/GameActions.cs
@@ -45,10 +45,10 @@ namespace ClassicUO.Game
 
         public static void ToggleWarMode()
         {
-            Socket.Send(new PChangeWarMode((World.Player.Flags & Flags.WarMode) == 0));
+            SetWarMode(!World.Player.InWarMode);
         }
 
-	    public static void SetWarMode(bool state)
+        public static void SetWarMode(bool state)
 	    {
 		    Socket.Send(new PChangeWarMode(state));
 	    }

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -394,7 +394,7 @@ namespace ClassicUO.Game.Scenes
 	        _isShiftDown = Input.Keyboard.IsModPressed(e.keysym.mod, SDL.SDL_Keymod.KMOD_SHIFT);
 
             if (e.keysym.sym == SDL.SDL_Keycode.SDLK_TAB)
-                if (!World.Player.InWarMode)
+                if (!World.Player.InWarMode && Engine.Profile.Current.HoldDownKeyTab)
                     GameActions.SetWarMode(true);
 
             if (_keycodeDirection.TryGetValue(e.keysym.sym, out Direction dWalk))
@@ -411,8 +411,13 @@ namespace ClassicUO.Game.Scenes
 
 			if (e.keysym.sym == SDL.SDL_Keycode.SDLK_TAB)
 			{
-				if (World.Player.InWarMode)
-					GameActions.SetWarMode(false);
+                if (Engine.Profile.Current.HoldDownKeyTab)
+                {
+                    if (World.Player.InWarMode)
+                        GameActions.SetWarMode(false);
+                }
+                else
+                    GameActions.ToggleWarMode();
 			}
 		}
     }

--- a/src/Game/UI/Gumps/OptionsGump1.cs
+++ b/src/Game/UI/Gumps/OptionsGump1.cs
@@ -41,7 +41,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         // general
         private HSliderBar _sliderFPS, _sliderFPSLogin, _circleOfTranspRadius;
-        private Checkbox _highlightObjects, /*_smoothMovements,*/ _enablePathfind, _alwaysRun, _preloadMaps, _showHpMobile, _highlightByState, _drawRoofs, _treeToStumps, _hideVegetation, _noColorOutOfRangeObjects, _useCircleOfTransparency, _enableTopbar;
+        private Checkbox _highlightObjects, /*_smoothMovements,*/ _enablePathfind, _alwaysRun, _preloadMaps, _showHpMobile, _highlightByState, _drawRoofs, _treeToStumps, _hideVegetation, _noColorOutOfRangeObjects, _useCircleOfTransparency, _enableTopbar, _holdDownKeyTab;
         private Combobox _hpComboBox;
         private RadioButton _fieldsToTile, _staticFields, _normalFields;
 
@@ -202,6 +202,7 @@ namespace ClassicUO.Game.UI.Gumps
             _alwaysRun = CreateCheckBox(rightArea, "Always run", Engine.Profile.Current.AlwaysRun, 0, 0);
             _preloadMaps = CreateCheckBox(rightArea, "Preload maps (it increases the RAM usage)", Engine.GlobalSettings.PreloadMaps, 0, 0);
             _enableTopbar = CreateCheckBox(rightArea, "Disable the Menu Bar", Engine.Profile.Current.TopbarGumpIsDisabled, 0, 0);
+            _holdDownKeyTab = CreateCheckBox(rightArea, "Hold down TAB key for combat", Engine.Profile.Current.HoldDownKeyTab, 0, 0);
 
             // show % hp mobile
             ScrollAreaItem hpAreaItem = new ScrollAreaItem();
@@ -565,6 +566,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _sliderFPSLogin.Value = 60;
                     _highlightObjects.IsChecked = true;
                     _enableTopbar.IsChecked = false;
+                    _holdDownKeyTab.IsChecked = true;
                     //_smoothMovements.IsChecked = true;
                     _enablePathfind.IsChecked = true;
                     _alwaysRun.IsChecked = false;
@@ -650,6 +652,7 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.ShowMobilesHP = _showHpMobile.IsChecked;
             Engine.Profile.Current.HighlightMobilesByFlags = _highlightByState.IsChecked;
             Engine.Profile.Current.MobileHPType = _hpComboBox.SelectedIndex;
+            Engine.Profile.Current.HoldDownKeyTab = _holdDownKeyTab.IsChecked;
 
             if (Engine.Profile.Current.DrawRoofs != _drawRoofs.IsChecked)
             {


### PR DESCRIPTION
- Hold down TAB key for combat, instead of tapping it to toggle combat mode (options)
- Fix paperdoll button problem in ToggleWarMode()