### PR TITLE
debugGump.Dispose();

### DIFF
--- a/src/Game/UI/Gumps/TopBarGump.cs
+++ b/src/Game/UI/Gumps/TopBarGump.cs
@@ -215,7 +215,7 @@ namespace ClassicUO.Game.UI.Gumps
                     if (debugGump == null)
                         Engine.UI.Add(new DebugGump());
                     else
-                        debugGump.IsVisible = !debugGump.IsVisible;
+                        debugGump.Dispose();
 
                     break;
             }


### PR DESCRIPTION
I confirm the problem, it is reproduced only for this gamp. I make a temporary patch, then I will take a closer look at why this is happening.

![3zyf5zg](https://user-images.githubusercontent.com/1370602/52143700-ced28900-2664-11e9-81a7-1f64a1d7d482.png)

