### PR TITLE
Fix player movement if console is not empty

### DIFF
--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -40,6 +40,8 @@ using Microsoft.Xna.Framework;
 
 using SDL2;
 
+using System.Diagnostics;
+
 using Multi = ClassicUO.Game.GameObjects.Multi;
 
 namespace ClassicUO.Game.Scenes
@@ -392,13 +394,21 @@ namespace ClassicUO.Game.Scenes
                 TargetManager.CancelTarget();
 
 	        _isShiftDown = Input.Keyboard.IsModPressed(e.keysym.mod, SDL.SDL_Keymod.KMOD_SHIFT);
-
+            
             if (e.keysym.sym == SDL.SDL_Keycode.SDLK_TAB)
                 if (!World.Player.InWarMode && Engine.Profile.Current.HoldDownKeyTab)
                     GameActions.SetWarMode(true);
 
             if (_keycodeDirection.TryGetValue(e.keysym.sym, out Direction dWalk))
-                World.Player.Walk(dWalk, false);
+            {
+                WorldViewportGump viewport = Engine.UI.GetByLocalSerial<WorldViewportGump>();
+                if (viewport != null)
+                {
+                    SystemChatControl chat = viewport.FindControls<SystemChatControl>().SingleOrDefault();
+                    if (chat != null && chat.textBox.Text.Length == 0)
+                        World.Player.Walk(dWalk, false);
+                }
+            }
 
             if ((e.keysym.mod & SDL2.SDL.SDL_Keymod.KMOD_NUM) != SDL2.SDL.SDL_Keymod.KMOD_NUM)
                 if (_keycodeDirectionNum.TryGetValue(e.keysym.sym, out Direction dWalkN))

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -40,8 +40,6 @@ using Microsoft.Xna.Framework;
 
 using SDL2;
 
-using System.Diagnostics;
-
 using Multi = ClassicUO.Game.GameObjects.Multi;
 
 namespace ClassicUO.Game.Scenes

--- a/src/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/Game/UI/Gumps/SystemChatControl.cs
@@ -59,9 +59,9 @@ namespace ClassicUO.Game.UI.Gumps
         private readonly Label _currentChatModeLabel;
         private int _messageHistoryIndex = -1;
         private ChatMode _mode = ChatMode.Default;
-        private readonly TextBox _textBox;
         private readonly AlphaBlendControl _trans;
 
+        public readonly TextBox textBox;
 
         public SystemChatControl(int x, int y, int w, int h)
         {
@@ -77,7 +77,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             int height = FileManager.Fonts.GetHeightUnicode(1, "ABC", Width, 0, (ushort)(FontStyle.BlackBorder | FontStyle.Fixed));
 
-            _textBox = new TextBox(1, MAX_MESSAGE_LENGHT, Width, Width, true, FontStyle.BlackBorder | FontStyle.Fixed, 33)
+            textBox = new TextBox(1, MAX_MESSAGE_LENGHT, Width, Width, true, FontStyle.BlackBorder | FontStyle.Fixed, 33)
             {
                 X = 0,
                 Y = Height - height - 3,
@@ -87,17 +87,17 @@ namespace ClassicUO.Game.UI.Gumps
 
             Add(_trans = new AlphaBlendControl
             {
-                X = _textBox.X,
-                Y = _textBox.Y,
+                X = textBox.X,
+                Y = textBox.Y,
                 Width = Width,
                 Height = height + 5
             });
-            Add(_textBox);
+            Add(textBox);
 
             Add(_currentChatModeLabel = new Label(string.Empty, true, 0, style: FontStyle.BlackBorder)
             {
-                X = _textBox.X,
-                Y = _textBox.Y,
+                X = textBox.X,
+                Y = textBox.Y,
                 IsVisible = false
             });
             WantUpdateSize = false;
@@ -117,8 +117,8 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     case ChatMode.Default:
                         DisposeChatModePrefix();
-                        _textBox.Hue = Engine.Profile.Current.SpeechHue;
-                        _textBox.SetText(string.Empty);
+                        textBox.Hue = Engine.Profile.Current.SpeechHue;
+                        textBox.SetText(string.Empty);
 
                         break;
                     case ChatMode.Whisper:
@@ -190,10 +190,10 @@ namespace ClassicUO.Game.UI.Gumps
                 _currentChatModeLabel.Hue = hue;
                 _currentChatModeLabel.Text = labelText;
                 _currentChatModeLabel.IsVisible = true;
-                _currentChatModeLabel.Location = _textBox.Location;
-                _textBox.X = _currentChatModeLabel.Width;
-                _textBox.Hue = hue;
-                _textBox.SetText(string.Empty);
+                _currentChatModeLabel.Location = textBox.Location;
+                textBox.X = _currentChatModeLabel.Width;
+                textBox.Hue = hue;
+                textBox.SetText(string.Empty);
             }
         }
 
@@ -201,8 +201,8 @@ namespace ClassicUO.Game.UI.Gumps
         {
             if (_currentChatModeLabel.IsVisible)
             {
-                _textBox.Hue = 33;
-                _textBox.X -= _currentChatModeLabel.Width;
+                textBox.Hue = 33;
+                textBox.X -= _currentChatModeLabel.Width;
                 _currentChatModeLabel.IsVisible = false;
             }
         }
@@ -217,13 +217,13 @@ namespace ClassicUO.Game.UI.Gumps
 
         internal void Resize()
         {
-            if (_textBox != null)
+            if (textBox != null)
             {
                 int height = FileManager.Fonts.GetHeightUnicode(1, "ABC", Width, 0, (ushort) (FontStyle.BlackBorder | FontStyle.Fixed));
-                _textBox.Y = Height - height - 3;
-                _textBox.Width = Width;
-                _textBox.Height = height - 3;
-                _trans.Location = _textBox.Location;
+                textBox.Y = Height - height - 3;
+                textBox.Width = Width;
+                textBox.Height = height - 3;
+                _trans.Location = textBox.Location;
                 _trans.Width = Width;
                 _trans.Height = height + 5;
             }
@@ -232,7 +232,7 @@ namespace ClassicUO.Game.UI.Gumps
         protected override void OnInitialize()
         {
             base.OnInitialize();
-            _textBox.SetKeyboardFocus();
+            textBox.SetKeyboardFocus();
         }
 
         public override void Update(double totalMS, double frameMS)
@@ -247,9 +247,9 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (Mode == ChatMode.Default)
             {
-                if (_textBox.Text.Length == 1)
+                if (textBox.Text.Length == 1)
                 {
-                    switch (_textBox.Text[0])
+                    switch (textBox.Text[0])
                     {
                         case ';':
                             Mode = ChatMode.Whisper;
@@ -273,13 +273,13 @@ namespace ClassicUO.Game.UI.Gumps
                             break;
                     }
                 }
-                else if (_textBox.Text.Length == 2 && _textBox.Text[0] == ':' && _textBox.Text[1] == ' ')
+                else if (textBox.Text.Length == 2 && textBox.Text[0] == ':' && textBox.Text[1] == ' ')
                     Mode = ChatMode.Emote;
             }
 
-            if (Engine.Profile.Current.SpeechHue != _textBox.Hue)
+            if (Engine.Profile.Current.SpeechHue != textBox.Hue)
             {
-                _textBox.Hue = Engine.Profile.Current.SpeechHue;
+                textBox.Hue = Engine.Profile.Current.SpeechHue;
             }
 
             base.Update(totalMS, frameMS);
@@ -287,7 +287,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override bool Draw(Batcher2D batcher, Point position, Vector3? hue = null)
         {
-            int y = _textBox.Y + position.Y - 20;
+            int y = textBox.Y + position.Y - 20;
 
             for (int i = _textEntries.Count - 1; i >= 0; i--)
             {
@@ -309,7 +309,7 @@ namespace ClassicUO.Game.UI.Gumps
                     if (_messageHistoryIndex > 0)
                         _messageHistoryIndex--;
                     Mode = _messageHistory[_messageHistoryIndex].Item1;
-                    _textBox.SetText(_messageHistory[_messageHistoryIndex].Item2);
+                    textBox.SetText(_messageHistory[_messageHistoryIndex].Item2);
 
                     break;
                 case SDL.SDL_Keycode.SDLK_w when Input.Keyboard.IsModPressed(mod, SDL.SDL_Keymod.KMOD_CTRL):
@@ -318,13 +318,13 @@ namespace ClassicUO.Game.UI.Gumps
                     {
                         _messageHistoryIndex++;
                         Mode = _messageHistory[_messageHistoryIndex].Item1;
-                        _textBox.SetText(_messageHistory[_messageHistoryIndex].Item2);
+                        textBox.SetText(_messageHistory[_messageHistoryIndex].Item2);
                     }
                     else
-                        _textBox.SetText(string.Empty);
+                        textBox.SetText(string.Empty);
 
                     break;
-                case SDL.SDL_Keycode.SDLK_BACKSPACE when Input.Keyboard.IsModPressed(mod, SDL.SDL_Keymod.KMOD_NONE) && string.IsNullOrEmpty(_textBox.Text):
+                case SDL.SDL_Keycode.SDLK_BACKSPACE when Input.Keyboard.IsModPressed(mod, SDL.SDL_Keymod.KMOD_NONE) && string.IsNullOrEmpty(textBox.Text):
                     Mode = ChatMode.Default;
 
                     break;
@@ -343,7 +343,7 @@ namespace ClassicUO.Game.UI.Gumps
             if (string.IsNullOrEmpty(text))
                 return;
             ChatMode sentMode = Mode;
-            _textBox.SetText(string.Empty);
+            textBox.SetText(string.Empty);
             _messageHistory.Add(new Tuple<ChatMode, string>(Mode, text));
             _messageHistoryIndex = _messageHistory.Count;
             Mode = ChatMode.Default;


### PR DESCRIPTION
Disable player movement using buttons if SystemChatControl->TextArea have a text. 
This hotfix does not apply to SDLK_KP_*.