### PR TITLE
Dispose SplitMenuGump instances when the associated ItemGump instance is disposed

### DIFF
--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -576,6 +576,19 @@ namespace ClassicUO.Game.Managers
             return gump;
         }
 
+        public ChildType GetChildByLocalSerial<ParentType, ChildType>(Serial parentSerial, Serial childSerial) 
+            where ParentType : Control
+            where ChildType : Control
+        {
+            ParentType parent = GetByLocalSerial<ParentType>(parentSerial);
+            if(parent != null)
+            {
+                return parent.Children.OfType<ChildType>().FirstOrDefault(s => !s.IsDisposed && s.LocalSerial == childSerial);
+            }
+
+            return null;
+        }
+
         public T GetByLocalSerial<T>(Serial? serial = null) where T : Control
         {
             return _gumps.OfType<T>().FirstOrDefault(s => !s.IsDisposed && (!serial.HasValue || s.LocalSerial == serial));

--- a/src/Game/UI/Controls/Control.cs
+++ b/src/Game/UI/Controls/Control.cs
@@ -436,6 +436,8 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
+        public event EventHandler Disposed;
+
         internal event EventHandler<MouseEventArgs> MouseDown, MouseUp, MouseMove, MouseOver, MouseEnter, MouseExit, MouseClick, DragBegin, DragEnd;
 
         internal event EventHandler<MouseWheelEventArgs> MouseWheel;
@@ -874,6 +876,7 @@ namespace ClassicUO.Game.UI.Controls
 
             IsDisposed = true;
 
+            Disposed.Raise();
         }
     }
 }

--- a/src/Game/UI/Controls/ItemGump.cs
+++ b/src/Game/UI/Controls/ItemGump.cs
@@ -56,6 +56,7 @@ namespace ClassicUO.Game.UI.Controls
             Texture = texture;
             Width = texture.Width;
             Height = texture.Height;
+            LocalSerial = Item.Serial;
 
             Item.Disposed += ItemOnDisposed;
 

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -198,6 +198,8 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     if (child.Container == _item)
                         Engine.UI.GetByLocalSerial<ContainerGump>(child)?.Dispose();
+
+                    child.Dispose();
                 }
 
                 if (_data.ClosedSound != 0)

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -196,7 +196,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 foreach (Item child in _item.Items)
                 {
-                    if (child.Container == _item)
+                    if (child.Container == _item && !child.IsDisposed)
                         child.Dispose();
                 }
 

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -196,8 +196,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                 foreach (Item child in _item.Items)
                 {
-                    if (child.Container == _item && !child.IsDisposed)
-                        child.Dispose();
+                    if (child.Container == _item)
+                        Engine.UI.GetByLocalSerial<ContainerGump>(child)?.Dispose();
                 }
 
                 if (_data.ClosedSound != 0)

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -197,9 +197,7 @@ namespace ClassicUO.Game.UI.Gumps
                 foreach (Item child in _item.Items)
                 {
                     if (child.Container == _item)
-                        Engine.UI.GetByLocalSerial<ContainerGump>(child)?.Dispose();
-
-                    child.Dispose();
+                        child.Dispose();
                 }
 
                 if (_data.ClosedSound != 0)

--- a/src/Game/UI/Gumps/SplitMenuGump.cs
+++ b/src/Game/UI/Gumps/SplitMenuGump.cs
@@ -125,6 +125,11 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             _lastValue = _slider.Value;
+
+            if (this.Item.IsDisposed)
+            {
+                Dispose();
+            }
         }
 
         public override void Dispose()

--- a/src/Game/UI/Gumps/SplitMenuGump.cs
+++ b/src/Game/UI/Gumps/SplitMenuGump.cs
@@ -19,6 +19,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #endregion
 
+using System;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
@@ -34,12 +35,20 @@ namespace ClassicUO.Game.UI.Gumps
         private readonly Button _okButton;
         private readonly TextBox _textBox;
         private readonly Point _offsert;
+        private readonly WeakReference _itemGump;
 
         private bool _firstChange;
 
         public SplitMenuGump(Item item, Point offset) : base(item, 0)
         {
             Item = item;
+
+            ItemGump itemGump = Engine.UI.GetChildByLocalSerial<ContainerGump, ItemGump>(item.Container, item.Serial);
+            if(itemGump != null)
+            {
+                _itemGump = new WeakReference(itemGump);
+                itemGump.Disposed += ItemGumpOnDisposed;
+            }
             _offsert = offset;
 
             CanMove = true;
@@ -68,6 +77,12 @@ namespace ClassicUO.Game.UI.Gumps
         }
 
         public Item Item { get; }
+
+        private void ItemGumpOnDisposed(object sender, EventArgs e)
+        {
+            Dispose();
+        }
+
 
         private void OkButtonOnMouseClick(object sender, MouseEventArgs e)
         {
@@ -125,16 +140,21 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             _lastValue = _slider.Value;
-
-            if (this.Item.IsDisposed)
-            {
-                Dispose();
-            }
         }
 
         public override void Dispose()
         {
             _okButton.MouseClick -= OkButtonOnMouseClick;
+
+            if(_itemGump != null && _itemGump.IsAlive)
+            {
+                ItemGump gump = _itemGump.Target as ItemGump;
+                if (gump != null)
+                {
+                    gump.Disposed -= ItemGumpOnDisposed;
+                }
+            }
+
             base.Dispose();
         }
 

--- a/src/Network/Plugin.cs
+++ b/src/Network/Plugin.cs
@@ -124,6 +124,13 @@ namespace ClassicUO.Network
             //Marshal.WriteIntPtr(headerPtr, SDL.SDL_GL_GetCurrentWindow());
             //Marshal.WriteIntPtr(headerPtr, Marshal.GetFunctionPointerForDelegate(_getUoFilePath));
 
+            SDL.SDL_SysWMinfo info = new SDL.SDL_SysWMinfo();
+            SDL.SDL_VERSION(out info.version);
+            SDL.SDL_GetWindowWMInfo(SDL.SDL_GL_GetCurrentWindow(), ref info);
+
+            IntPtr hwnd = IntPtr.Zero;
+            if (info.subsystem == SDL.SDL_SYSWM_TYPE.SDL_SYSWM_WINDOWS)
+                hwnd = info.info.win.window;
 
             PluginHeader header = new PluginHeader
             {
@@ -134,7 +141,7 @@ namespace ClassicUO.Network
                 GetPlayerPosition = Marshal.GetFunctionPointerForDelegate(_getPlayerPosition),
                 CastSpell = Marshal.GetFunctionPointerForDelegate(_castSpell),
                 GetStaticImage = Marshal.GetFunctionPointerForDelegate(_getStaticImage),
-                HWND = SDL.SDL_GL_GetCurrentWindow(),
+                HWND = hwnd,
                 GetUOFilePath = Marshal.GetFunctionPointerForDelegate(_getUoFilePath)
             };
 


### PR DESCRIPTION
This behavior matches client 7.0.15.1.