### PR TITLE
Create profession gump

### DIFF
--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Game\UI\Controls\TextureControl.cs" />
     <Compile Include="Game\UI\Gumps\BulletinBoardGump.cs" />
     <Compile Include="Game\UI\Gumps\CharCreation\CreateCharCityGump.cs" />
+    <Compile Include="Game\UI\Gumps\CharCreation\CreateCharProfessionGump.cs" />
     <Compile Include="Game\UI\Gumps\CombatBookGump.cs" />
     <Compile Include="Game\UI\Gumps\Login\LoginBackground.cs" />
     <Compile Include="Game\UI\Gumps\DebugGump.cs" />

--- a/src/Game/UI/Gumps/CharCreation/CharCreationGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CharCreationGump.cs
@@ -32,8 +32,9 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         public enum CharCreationStep
         {
 			Appearence = 0,
-			ChooseTrade = 1,
-			ChooseCity = 2,
+			ChooseProfession = 1,
+			ChooseTrade = 2,
+			ChooseCity = 3,
 		}
 
         private PlayerMobile _character;
@@ -42,6 +43,8 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         private readonly LoginScene loginScene;
 
 	    private CityInfo _startingCity;
+
+		private ProfessionInfo _selectedProfession;
 
         public CharCreationGump() : base(0, 0)
         {
@@ -54,7 +57,7 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         public void SetCharacter(PlayerMobile character)
         {
             _character = character;
-            SetStep(CharCreationStep.ChooseTrade);
+            SetStep(CharCreationStep.ChooseProfession);
 		}
 
 	    public void SetAttributes()
@@ -66,6 +69,13 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
 	    {
 		    _startingCity = city;
 	    }
+
+		public void SetProfession(ProfessionInfo info)
+		{
+			_selectedProfession = info;
+
+			SetStep(CharCreationStep.ChooseTrade);
+		}
 
 		public void CreateCharacter()
         {
@@ -102,25 +112,37 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
                     ChangePage(1);
 
                     break;
-                case CharCreationStep.ChooseTrade:
+
+				case CharCreationStep.ChooseProfession:
 					var existing = Children.FirstOrDefault(page => page.Page == 2);
-
-	                if (existing != null)
-		                Remove(existing);
-
-					Add(new CreateCharTradeGump(_character), 2);
-
-                    ChangePage(2);
-	                break;
-				case CharCreationStep.ChooseCity:
-					existing = Children.FirstOrDefault(page => page.Page == 3);
 
 					if (existing != null)
 						Remove(existing);
 
-					Add(new CreateCharCityGump(), 3);
+					Add(new CreateCharProfessionGump(), 2);
 
-					ChangePage(3);
+					ChangePage(2);
+					break;
+
+				case CharCreationStep.ChooseTrade:
+					existing = Children.FirstOrDefault(page => page.Page == 3);
+
+	                if (existing != null)
+		                Remove(existing);
+
+					Add(new CreateCharTradeGump(_character, _selectedProfession), 3);
+
+                    ChangePage(3);
+	                break;
+				case CharCreationStep.ChooseCity:
+					existing = Children.FirstOrDefault(page => page.Page == 4);
+
+					if (existing != null)
+						Remove(existing);
+
+					Add(new CreateCharCityGump(), 4);
+
+					ChangePage(4);
 					break;
             }
         }

--- a/src/Game/UI/Gumps/CharCreation/CreateCharProfessionGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharProfessionGump.cs
@@ -1,0 +1,224 @@
+﻿using ClassicUO.Game.UI.Controls;
+using ClassicUO.Input;
+using ClassicUO.IO;
+using ClassicUO.Utility;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ClassicUO.Game.UI.Gumps.CharCreation
+{
+	internal class CreateCharProfessionGump : Gump
+	{
+		public CreateCharProfessionGump() : base(0, 0)
+		{
+			var professions = new List<ProfessionInfo>();
+
+			/* Parse the prof.txt if one is available. */
+			// TODO: Move this to FileManager for parsing at load time. Leave it here for now to test.
+			var professionFilePath = $@"{FileManager.UoFolderPath}\prof.txt";
+			var professionFile = new FileInfo(professionFilePath);
+
+			if (professionFile.Exists)
+			{
+				var professionParser = new TextFileParser(professionFile, new char[] { '\t', '\r', '\n' }, new char[] { }, new char[] { '"', '"' });
+				var tokens = professionParser.ReadTokens();
+
+				var index = 0;
+
+				while (index < tokens.Count)
+				{
+					var currentToken = tokens[index];
+
+					index++;
+
+					if (String.IsNullOrEmpty(currentToken))
+						continue;
+
+					if (!currentToken.StartsWith("begin", StringComparison.OrdinalIgnoreCase))
+						continue;
+
+					if (ProfessionInfo.TryReadSection(tokens, ref index, out var info))
+						professions.Add(info);
+				}
+			}
+
+			professions.Add(new ProfessionInfo()
+			{
+				Name = "Advanced",
+				Localization = 1061176,
+				Description = 1061226,
+				Graphic = 5504,
+			});
+
+			X = 100;
+			Y = 80;
+
+			/* Build the gump */
+			Add(new ResizePic(2600)
+			{
+				Width = 470, Height = 372,
+			});
+
+			Add(new GumpPic(113, -23, 1419, 0));
+			Add(new GumpPic(190, -36, 1417, 0));
+			Add(new GumpPic(199, -27, 5546, 0));
+
+			var localization = FileManager.Cliloc;
+
+			Add(new Label(localization.Translate(3000326), false, 0, font: 2)
+			{
+				X = 58, Y = 52,
+			});
+
+			for (int i = 0; i < professions.Count; i++)
+			{
+				var cx = i % 2;
+				var cy = i / 2;
+
+				Add(new ProfessionInfoGump(professions[i])
+				{
+					X = 45 + (cx * 195),
+					Y = 88 + (cy * 70),
+
+					Selected = SelectProfession,
+				});
+			}
+
+			Add(new Button((int) Buttons.Prev, 0x15A1, 0x15A3, 0x15A2)
+            {
+                X = 586, Y = 445, ButtonAction = ButtonAction.Activate
+            });
+		}
+
+		public void SelectProfession(ProfessionInfo info)
+		{
+			var charCreationGump = Engine.UI.GetByLocalSerial<CharCreationGump>();
+
+			if (charCreationGump != null)
+				charCreationGump.SetProfession(info);
+		}
+
+		public override void OnButtonClick(int buttonID)
+		{
+			var charCreationGump = Engine.UI.GetByLocalSerial<CharCreationGump>();
+
+			switch ((Buttons)buttonID)
+			{
+				case Buttons.Prev:
+					charCreationGump.StepBack();
+					break;
+			}
+
+			base.OnButtonClick(buttonID);
+		}
+
+		private enum Buttons
+		{
+			Prev,
+		}
+	}
+
+	internal class ProfessionInfoGump : Control
+	{
+		private ProfessionInfo _info;
+
+		public Action<ProfessionInfo> Selected;
+
+		public ProfessionInfoGump(ProfessionInfo info)
+		{
+			_info = info;
+
+			Add(new ResizePic(3000)
+			{
+				Width = 175, Height = 34,
+			});
+
+			var localization = FileManager.Cliloc;
+
+			Add(new Label(localization.Translate(info.Localization), true, 0x00, font: 1)
+			{
+				X = 7, Y = 8,
+			});
+
+			Add(new GumpPic(121, -12, info.Graphic, 0));
+
+			SetTooltip(localization.Translate(info.Description));
+		}
+
+		protected override void OnMouseClick(int x, int y, MouseButton button)
+		{
+			base.OnMouseClick(x, y, button);
+
+			if (button == MouseButton.Left)
+			{
+				if (Selected != null)
+					Selected(_info);
+			}
+		}
+	}
+
+	internal class ProfessionInfo
+	{
+		public static bool TryReadSection(List<string> list, ref int index, out ProfessionInfo info)
+		{
+			info = new ProfessionInfo();
+
+			while (index < list.Count)
+			{
+				var currentToken = list[index].ToLower();
+
+				if (currentToken.StartsWith("end", StringComparison.OrdinalIgnoreCase))
+					break;
+
+				switch (currentToken)
+				{
+					case "name":
+					{
+						info.Name = list[++index];
+						break;
+					}
+					case "nameid":
+					{
+						info.Localization = int.Parse(list[++index]);
+						break;
+					}
+					case "descid":
+					{
+						info.Description = int.Parse(list[++index]);
+						break;
+					}
+					case "gump":
+					{
+						info.Graphic = (Graphic)int.Parse(list[++index]);
+						break;
+					}
+					case "skill":
+					{
+						info.Skills.Add(list[++index], int.Parse(list[++index]));
+						break;
+					}
+					case "stat":
+					{
+						info.Stats.Add(list[++index], int.Parse(list[++index]));
+						break;
+					}
+				}
+
+				index++;
+			}
+
+			return true;
+		}
+
+		public string Name { get; set; }
+		public int Localization { get; set; }
+		public int Description { get; set; }
+
+		public Graphic Graphic { get; set; }
+
+		public Dictionary<string, int> Skills { get; set; } = new Dictionary<string, int>();
+		public Dictionary<string, int> Stats { get; set; } = new Dictionary<string, int>();
+	}
+
+}

--- a/src/Game/UI/Gumps/CharCreation/CreateCharProfessionGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharProfessionGump.cs
@@ -51,24 +51,22 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
 				Graphic = 5504,
 			});
 
-			X = 100;
-			Y = 80;
-
 			/* Build the gump */
 			Add(new ResizePic(2600)
 			{
+				X = 100, Y = 80,
 				Width = 470, Height = 372,
 			});
 
-			Add(new GumpPic(113, -23, 1419, 0));
-			Add(new GumpPic(190, -36, 1417, 0));
-			Add(new GumpPic(199, -27, 5546, 0));
+			Add(new GumpPic(291, 42, 0x0589, 0));
+			Add(new GumpPic(214, 58, 0x058B, 0));
+			Add(new GumpPic(300, 51, 0x15A9, 0));
 
 			var localization = FileManager.Cliloc;
 
 			Add(new Label(localization.Translate(3000326), false, 0, font: 2)
 			{
-				X = 58, Y = 52,
+				X = 158, Y = 132,
 			});
 
 			for (int i = 0; i < professions.Count; i++)
@@ -78,8 +76,8 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
 
 				Add(new ProfessionInfoGump(professions[i])
 				{
-					X = 45 + (cx * 195),
-					Y = 88 + (cy * 70),
+					X = 145 + (cx * 195),
+					Y = 168 + (cy * 70),
 
 					Selected = SelectProfession,
 				});
@@ -129,12 +127,16 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
 		{
 			_info = info;
 
-			Add(new ResizePic(3000)
-			{
-				Width = 175, Height = 34,
-			});
-
 			var localization = FileManager.Cliloc;
+
+			var background = new ResizePic(3000)
+			{
+				Width = 175,
+				Height = 34,
+			};
+			background.SetTooltip(localization.Translate(info.Description));
+
+			Add(background);
 
 			Add(new Label(localization.Translate(info.Localization), true, 0x00, font: 1)
 			{
@@ -142,8 +144,6 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
 			});
 
 			Add(new GumpPic(121, -12, info.Graphic, 0));
-
-			SetTooltip(localization.Translate(info.Description));
 		}
 
 		protected override void OnMouseClick(int x, int y, MouseButton button)

--- a/src/Game/UI/Gumps/CharCreation/CreateCharProfessionGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharProfessionGump.cs
@@ -1,5 +1,4 @@
-﻿<<<<<<< .mine
-using ClassicUO.Game.UI.Controls;
+﻿using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
 using ClassicUO.IO;
 using ClassicUO.Utility;
@@ -116,6 +115,335 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
 		{
 			Prev,
 		}
+
+		private enum PROF_TYPE
+		{
+			NO_PROF = 0,
+			CATEGORY,
+			PROFESSION
+		}
+
+		private enum PM_CODE
+		{
+			BEGIN = 1,
+			NAME,
+			TRUENAME,
+			DESC,
+			TOPLEVEL,
+			GUMP,
+			TYPE,
+			CHILDREN,
+			SKILL,
+			STAT,
+			STR,
+			INT,
+			DEX,
+			END,
+			TRUE,
+			CATEGORY,
+			NAME_CLILOC_ID,
+			DESCRIPTION_CLILOC_ID
+		};
+
+		private readonly string[] _Keys = {
+			"begin", "name", "truename", "desc", "toplevel", "gump", "type",     "children", "skill",
+			"stat",  "str",  "int",      "dex",  "end",      "true", "category", "nameid",   "descid"
+		};
+
+		private int GetKeyCode(string key)
+		{
+			if (string.IsNullOrEmpty(key))
+			{
+				return 0;
+			}
+
+			key = key.ToLowerInvariant();
+			int result = 0;
+
+			for (int i = 0; i < _Keys.Length && result <= 0; i++)
+			{
+				if (key == _Keys[i])
+				{
+					result = i + 1;
+				}
+			}
+
+			return result;
+		}
+
+		private bool ParseFilePart(FileInfo fi)
+		{
+			List<string> childrens = new List<string>();
+			string name = string.Empty;
+			string trueName = string.Empty;
+			int nameClilocID = 0;
+			int descriptionIndex = 0;
+			ushort gump = 0;
+			bool topLevel = false;
+			int[] skillIndex = new int[4] { 0xFF, 0xFF, 0xFF, 0xFF };
+			int[] skillValue = new int[4] { 0, 0, 0, 0 };
+			int[] stats = new int[3] { 0, 0, 0 };
+
+			bool exit = false;
+
+			TextFileParser file = new TextFileParser(fi, new char[] { '\t', ',' }, new char[] { '#', ';' }, new char[] { '"', '"' });
+			while (!file.IsEOF() && !exit)
+			{
+				List<string> strings = file.ReadTokens();
+
+				if (strings.Count < 1)
+				{
+					continue;
+				}
+
+				int code = GetKeyCode(strings[0]);
+
+				switch ((PM_CODE)code)
+				{
+					case PM_CODE.BEGIN:
+					case PM_CODE.END:
+					{
+						exit = true;
+						break;
+					}
+					case PM_CODE.NAME:
+					{
+						name = strings[1];
+						break;
+					}
+					case PM_CODE.TRUENAME:
+					{
+						trueName = strings[1];
+						break;
+					}
+					case PM_CODE.DESC:
+					{
+						int.TryParse(strings[1], out descriptionIndex);
+						break;
+					}
+					case PM_CODE.TOPLEVEL:
+					{
+						topLevel = (GetKeyCode(strings[1]) == (int)PM_CODE.TRUE);
+						break;
+					}
+					case PM_CODE.GUMP:
+					{
+						ushort.TryParse(strings[1], out gump);
+
+						/*g_Orion.ExecuteGump(gump);
+                        g_Orion.ExecuteGump(gump + 1);*/
+						break;
+					}
+					case PM_CODE.TYPE:
+					{
+						if (GetKeyCode(strings[1]) == (int)PM_CODE.CATEGORY)
+						{
+						}
+						else
+						{
+						}
+
+						break;
+					}
+					case PM_CODE.CHILDREN:
+					{
+						/*IFOR(j, 1, (int)strings.size())
+                        childrens.push_back(strings[j]);*/
+
+						break;
+					}
+					case PM_CODE.SKILL:
+					{
+						for (int i = 0; i < 4 && i < strings.Count && strings.Count > 2; i++)
+						{
+							for (int j = 0; j < 54; j++)
+							{
+								/*CSkill* skillPtr = g_SkillsManager.Get((uint)j);
+
+                                if (skillPtr != NULL && strings[1] == skillPtr->Name)
+                                {
+                                    skillIndex[i] = j;
+                                    skillValue[i] = atoi(strings[2].c_str());
+                                }*/
+							}
+						}
+
+						break;
+					}
+					case PM_CODE.STAT:
+					{
+						if (strings.Count > 2)
+						{
+							code = GetKeyCode(strings[1]);
+							int.TryParse(strings[2], out int val);
+
+							if ((PM_CODE)code == PM_CODE.STR)
+							{
+								stats[0] = val;
+							}
+							else if ((PM_CODE)code == PM_CODE.INT)
+							{
+								stats[1] = val;
+							}
+							else if ((PM_CODE)code == PM_CODE.DEX)
+							{
+								stats[2] = val;
+							}
+						}
+
+						break;
+					}
+					case PM_CODE.NAME_CLILOC_ID:
+					{
+						int.TryParse(strings[1], out nameClilocID);
+						name = FileManager.Cliloc.GetString(nameClilocID).ToUpperInvariant();
+						break;
+					}
+					case PM_CODE.DESCRIPTION_CLILOC_ID:
+					{
+						//descriptionClilocID = atoi(strings[1].c_str());
+						break;
+					}
+					default:
+					break;
+				}
+			}
+
+			/*CBaseProfession* obj = NULL;
+
+            if (type == PROF_TYPE.CATEGORY)
+            {
+                CProfessionCategory* temp = new CProfessionCategory();
+
+                IFOR(i, 0, (int)childrens.size())
+                    temp->AddChildren(childrens[i]);
+
+                obj = temp;
+            }
+            else if (type == PROF_TYPE.PROFESSION)
+            {
+                CProfession* temp = new CProfession();
+
+                temp->Str = stats[0];
+                temp->Int = stats[1];
+                temp->Dex = stats[2];
+
+                IFOR(i, 0, 4)
+                {
+                    temp->SetSkillIndex((int)i, (uchar)skillIndex[i]);
+                    temp->SetSkillValue((int)i, (uchar)skillValue[i]);
+                }
+
+                obj = temp;
+            }
+
+            bool result = (type != PROF_TYPE.NO_PROF);
+
+            if (obj != NULL)
+            {
+                obj->NameClilocID = nameClilocID;
+                obj->Name = name;
+                obj->TrueName = trueName;
+                obj->DescriptionClilocID = descriptionClilocID;
+                obj->DescriptionIndex = descriptionIndex;
+                obj->TopLevel = topLevel;
+                obj->Gump = gump;
+                obj->Type = type;
+
+                if (topLevel)
+                    m_Items->Add(obj);
+                else
+                {
+                    CBaseProfession* parent = (CBaseProfession*)(m_Items);
+
+                    while (parent != NULL)
+                    {
+                        result = AddChild(parent, obj);
+
+                        if (result)
+                            break;
+
+                        parent = (CBaseProfession*)parent->m_Next;
+                    }
+
+                    if (!result)
+                        delete obj;
+                }
+            }*/
+
+			return false;//result;
+		}
+
+		private bool Load()
+		{
+			bool result = false;
+
+			/*CProfessionCategory* head = new CProfessionCategory();
+            head->TrueName = "parent";
+            head->Name = "Parent";
+            head->DescriptionIndex = -2;
+            head->Type = PROF_TYPE.CATEGORY;
+            head->Gump = 0x15A9;
+            head->TopLevel = true;
+            Add(head);*/
+
+			FileInfo file = new FileInfo(Path.Combine(FileManager.UoFolderPath, "Prof.txt"));
+			//what if file doesn't exist? we skip section completely...directly into advanced selection
+			TextFileParser read = new TextFileParser(file, new char[] { ' ', '\t', ',' }, new char[] { '#', ';' }, new char[] { '"', '"' });
+
+			if (!read.IsEOF())
+			{
+				while (!read.IsEOF())
+				{
+					List<string> strings = read.ReadTokens();
+
+					if (strings.Count > 0)
+					{
+						if (strings[0].ToLowerInvariant() == "begin")
+						{
+							result = ParseFilePart(file);
+
+							if (!result)
+							{
+								break;
+							}
+						}
+					}
+				}
+
+
+				/*g_Orion.ExecuteGump(0x15A9);
+                g_Orion.ExecuteGump(0x15AA);
+
+                CProfession* apc = new CProfession();
+                apc->TrueName = "advanced";
+                apc->Name = "Advanced";
+                apc->Type = PT_PROFESSION;
+                apc->Gump = 0x15A9;
+                apc->DescriptionIndex = -1;
+                apc->SetSkillIndex(0, 0xFF);
+                apc->SetSkillIndex(1, 0xFF);
+                apc->SetSkillIndex(2, 0xFF);
+                apc->SetSkillIndex(3, 0xFF);
+
+                apc->Str = 44;
+                apc->Int = 10;
+                apc->Dex = 11;
+
+                apc->SetSkillValue(0, 50);
+                apc->SetSkillValue(1, 50);
+                apc->SetSkillValue(2, 0);
+                apc->SetSkillValue(3, 0);
+
+                head->Add(apc);
+
+                LoadProfessionDescription();*/
+			}
+			/*else
+                LOG("Could not find prof.txt in your UO directory. Character creation professions loading failed.\n");*/
+
+			return result;
+		}
 	}
 
 	internal class ProfessionInfoGump : Control
@@ -223,459 +551,3 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
 	}
 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-=======
-using ClassicUO.IO;
-using ClassicUO.Utility;
-using System.Collections.Generic;
-using System.IO;
-
-namespace ClassicUO.Game.UI.Gumps.CharCreation
-{
-    internal class CreateCharProfessionGump
-    {
-        private enum PROF_TYPE
-        {
-            NO_PROF = 0,
-            CATEGORY,
-            PROFESSION
-        }
-
-        private enum PM_CODE
-        {
-            BEGIN = 1,
-            NAME,
-            TRUENAME,
-            DESC,
-            TOPLEVEL,
-            GUMP,
-            TYPE,
-            CHILDREN,
-            SKILL,
-            STAT,
-            STR,
-            INT,
-            DEX,
-            END,
-            TRUE,
-            CATEGORY,
-            NAME_CLILOC_ID,
-            DESCRIPTION_CLILOC_ID
-        };
-
-        private readonly string[] _Keys = {
-            "begin", "name", "truename", "desc", "toplevel", "gump", "type",     "children", "skill",
-            "stat",  "str",  "int",      "dex",  "end",      "true", "category", "nameid",   "descid"
-        };
-
-        private int GetKeyCode(string key)
-        {
-            if (string.IsNullOrEmpty(key))
-            {
-                return 0;
-            }
-
-            key = key.ToLowerInvariant();
-            int result = 0;
-
-            for (int i = 0; i < _Keys.Length && result <= 0; i++)
-            {
-                if (key == _Keys[i])
-                {
-                    result = i + 1;
-                }
-            }
-
-            return result;
-        }
-
-        private bool ParseFilePart(FileInfo fi)
-        {
-            List<string> childrens = new List<string>();
-            string name = string.Empty;
-            string trueName = string.Empty;
-            int nameClilocID = 0;
-            int descriptionIndex = 0;
-            ushort gump = 0;
-            bool topLevel = false;
-            int[] skillIndex = new int[4] { 0xFF, 0xFF, 0xFF, 0xFF };
-            int[] skillValue = new int[4] { 0, 0, 0, 0 };
-            int[] stats = new int[3] { 0, 0, 0 };
-
-            bool exit = false;
-
-            TextFileParser file = new TextFileParser(fi, new char[] { '\t', ',' }, new char[] { '#', ';' }, new char[] { '"', '"' });
-            while (!file.IsEOF() && !exit)
-            {
-                List<string> strings = file.ReadTokens();
-
-                if (strings.Count < 1)
-                {
-                    continue;
-                }
-
-                int code = GetKeyCode(strings[0]);
-
-                switch ((PM_CODE)code)
-                {
-                    case PM_CODE.BEGIN:
-                    case PM_CODE.END:
-                    {
-                        exit = true;
-                        break;
-                    }
-                    case PM_CODE.NAME:
-                    {
-                        name = strings[1];
-                        break;
-                    }
-                    case PM_CODE.TRUENAME:
-                    {
-                        trueName = strings[1];
-                        break;
-                    }
-                    case PM_CODE.DESC:
-                    {
-                        int.TryParse(strings[1], out descriptionIndex);
-                        break;
-                    }
-                    case PM_CODE.TOPLEVEL:
-                    {
-                        topLevel = (GetKeyCode(strings[1]) == (int)PM_CODE.TRUE);
-                        break;
-                    }
-                    case PM_CODE.GUMP:
-                    {
-                        ushort.TryParse(strings[1], out gump);
-
-                        /*g_Orion.ExecuteGump(gump);
-                        g_Orion.ExecuteGump(gump + 1);*/
-                        break;
-                    }
-                    case PM_CODE.TYPE:
-                    {
-                        if (GetKeyCode(strings[1]) == (int)PM_CODE.CATEGORY)
-                        {
-                        }
-                        else
-                        {
-                        }
-
-                        break;
-                    }
-                    case PM_CODE.CHILDREN:
-                    {
-                        /*IFOR(j, 1, (int)strings.size())
-                        childrens.push_back(strings[j]);*/
-
-                        break;
-                    }
-                    case PM_CODE.SKILL:
-                    {
-                        for (int i = 0; i < 4 && i < strings.Count && strings.Count > 2; i++)
-                        {
-                            for (int j = 0; j < 54; j++)
-                            {
-                                /*CSkill* skillPtr = g_SkillsManager.Get((uint)j);
-
-                                if (skillPtr != NULL && strings[1] == skillPtr->Name)
-                                {
-                                    skillIndex[i] = j;
-                                    skillValue[i] = atoi(strings[2].c_str());
-                                }*/
-                            }
-                        }
-
-                        break;
-                    }
-                    case PM_CODE.STAT:
-                    {
-                        if (strings.Count > 2)
-                        {
-                            code = GetKeyCode(strings[1]);
-                            int.TryParse(strings[2], out int val);
-
-                            if ((PM_CODE)code == PM_CODE.STR)
-                            {
-                                stats[0] = val;
-                            }
-                            else if ((PM_CODE)code == PM_CODE.INT)
-                            {
-                                stats[1] = val;
-                            }
-                            else if ((PM_CODE)code == PM_CODE.DEX)
-                            {
-                                stats[2] = val;
-                            }
-                        }
-
-                        break;
-                    }
-                    case PM_CODE.NAME_CLILOC_ID:
-                    {
-                        int.TryParse(strings[1], out nameClilocID);
-                        name = FileManager.Cliloc.GetString(nameClilocID).ToUpperInvariant();
-                        break;
-                    }
-                    case PM_CODE.DESCRIPTION_CLILOC_ID:
-                    {
-                        //descriptionClilocID = atoi(strings[1].c_str());
-                        break;
-                    }
-                    default:
-                        break;
-                }
-            }
-
-            /*CBaseProfession* obj = NULL;
-
-            if (type == PROF_TYPE.CATEGORY)
-            {
-                CProfessionCategory* temp = new CProfessionCategory();
-
-                IFOR(i, 0, (int)childrens.size())
-                    temp->AddChildren(childrens[i]);
-
-                obj = temp;
-            }
-            else if (type == PROF_TYPE.PROFESSION)
-            {
-                CProfession* temp = new CProfession();
-
-                temp->Str = stats[0];
-                temp->Int = stats[1];
-                temp->Dex = stats[2];
-
-                IFOR(i, 0, 4)
-                {
-                    temp->SetSkillIndex((int)i, (uchar)skillIndex[i]);
-                    temp->SetSkillValue((int)i, (uchar)skillValue[i]);
-                }
-
-                obj = temp;
-            }
-
-            bool result = (type != PROF_TYPE.NO_PROF);
-
-            if (obj != NULL)
-            {
-                obj->NameClilocID = nameClilocID;
-                obj->Name = name;
-                obj->TrueName = trueName;
-                obj->DescriptionClilocID = descriptionClilocID;
-                obj->DescriptionIndex = descriptionIndex;
-                obj->TopLevel = topLevel;
-                obj->Gump = gump;
-                obj->Type = type;
-
-                if (topLevel)
-                    m_Items->Add(obj);
-                else
-                {
-                    CBaseProfession* parent = (CBaseProfession*)(m_Items);
-
-                    while (parent != NULL)
-                    {
-                        result = AddChild(parent, obj);
-
-                        if (result)
-                            break;
-
-                        parent = (CBaseProfession*)parent->m_Next;
-                    }
-
-                    if (!result)
-                        delete obj;
-                }
-            }*/
-
-            return false;//result;
-        }
-
-        private bool Load()
-        {
-            bool result = false;
-
-            /*CProfessionCategory* head = new CProfessionCategory();
-            head->TrueName = "parent";
-            head->Name = "Parent";
-            head->DescriptionIndex = -2;
-            head->Type = PROF_TYPE.CATEGORY;
-            head->Gump = 0x15A9;
-            head->TopLevel = true;
-            Add(head);*/
-
-            FileInfo file = new FileInfo(Path.Combine(FileManager.UoFolderPath, "Prof.txt"));
-            //what if file doesn't exist? we skip section completely...directly into advanced selection
-            TextFileParser read = new TextFileParser(file, new char[] { ' ', '\t', ',' }, new char[] { '#', ';' }, new char[] { '"', '"' });
-
-            if (!read.IsEOF())
-            {
-                while (!read.IsEOF())
-                {
-                    List<string> strings = read.ReadTokens();
-
-                    if (strings.Count > 0)
-                    {
-                        if (strings[0].ToLowerInvariant() == "begin")
-                        {
-                            result = ParseFilePart(file);
-
-                            if (!result)
-                            {
-                                break;
-                            }
-                        }
-                    }
-                }
-
-
-                /*g_Orion.ExecuteGump(0x15A9);
-                g_Orion.ExecuteGump(0x15AA);
-
-                CProfession* apc = new CProfession();
-                apc->TrueName = "advanced";
-                apc->Name = "Advanced";
-                apc->Type = PT_PROFESSION;
-                apc->Gump = 0x15A9;
-                apc->DescriptionIndex = -1;
-                apc->SetSkillIndex(0, 0xFF);
-                apc->SetSkillIndex(1, 0xFF);
-                apc->SetSkillIndex(2, 0xFF);
-                apc->SetSkillIndex(3, 0xFF);
-
-                apc->Str = 44;
-                apc->Int = 10;
-                apc->Dex = 11;
-
-                apc->SetSkillValue(0, 50);
-                apc->SetSkillValue(1, 50);
-                apc->SetSkillValue(2, 0);
-                apc->SetSkillValue(3, 0);
-
-                head->Add(apc);
-
-                LoadProfessionDescription();*/
-            }
-            /*else
-                LOG("Could not find prof.txt in your UO directory. Character creation professions loading failed.\n");*/
-
-            return result;
-        }
-    }
-}
->>>>>>> .theirs

--- a/src/Game/UI/Gumps/CharCreation/CreateCharTradeGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharTradeGump.cs
@@ -19,6 +19,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -37,7 +38,7 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         private readonly PlayerMobile _character;
         private readonly Combobox[] _skills;
 
-        public CreateCharTradeGump(PlayerMobile character) : base(0, 0)
+        public CreateCharTradeGump(PlayerMobile character, ProfessionInfo profession) : base(0, 0)
         {
             _character = character;
 
@@ -107,7 +108,80 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
                 y += 70;
             }
 
-            Add(new Button((int) Buttons.Prev, 0x15A1, 0x15A3, 0x15A2)
+			if (profession.Skills.Any())
+			{
+				for (int i = 0; i < skillCount; i++)
+					_skillSliders[i].Value = 0;
+
+				int GetSkillIndex(string name)
+				{
+					/* Not sure if other cases exist. 
+					 * 7.0.20.0 has a specific function to convert string -> index for each skill in prof.txt. */
+					if (String.Equals(name, "Blacksmith", StringComparison.CurrentCulture))
+						name = "Blacksmithy";
+					else if (String.Equals(name, "AnimalLore", StringComparison.CurrentCulture))
+						name = "Animal Lore";
+					else if (String.Equals(name, "ItemID", StringComparison.CurrentCulture))
+						name = "Item Identification";
+					else if (String.Equals(name, "ArmsLore", StringComparison.CurrentCulture))
+						name = "Arms Lore";
+					else if (String.Equals(name, "Bowcraft", StringComparison.CurrentCulture))
+						name = "Bowcraft/Fletching";
+					else if (String.Equals(name, "DetectHidden", StringComparison.CurrentCulture))
+						name = "Detecting Hidden";
+					else if (String.Equals(name, "Enticement", StringComparison.CurrentCulture))
+						name = "Discordance";
+					else if (String.Equals(name, "EvaluateIntelligence", StringComparison.CurrentCulture))
+						name = "Evaluating Intelligence";
+					else if (String.Equals(name, "ForensicEvaluation", StringComparison.CurrentCulture))
+						name = "Forensic Evaluation";
+					else if (String.Equals(name, "ResistingSpells", StringComparison.CurrentCulture))
+						name = "Resisting Spells";
+					else if (String.Equals(name, "SpiritSpeak", StringComparison.CurrentCulture))
+						name = "Spirit Speak";
+					else if (String.Equals(name, "AnimalTaming", StringComparison.CurrentCulture))
+						name = "Animal Taming";
+					else if (String.Equals(name, "TasteIdentification", StringComparison.CurrentCulture))
+						name = "Taste Identification";
+					else if (String.Equals(name, "MaceFighting", StringComparison.CurrentCulture))
+						name = "Mace Fighting";
+					else if (String.Equals(name, "Disarm", StringComparison.CurrentCulture))
+						name = "Remove Trap";
+
+					return Array.IndexOf(skillList, name);
+				}
+
+				var skillIndex = 0;
+				foreach (var skillKVP in profession.Skills)
+				{
+					var skillCombo = _skills[skillIndex];
+					var skillSlider = _skillSliders[skillIndex];
+
+					var index = GetSkillIndex(skillKVP.Key);
+
+					if (index > 0)
+					{
+						skillCombo.SelectedIndex = index;
+						skillSlider.Value = skillKVP.Value;
+					}
+
+					skillIndex++;
+				}
+			}
+
+			if (profession.Stats.Count > 0)
+			{
+				if (profession.Stats.TryGetValue("Str", out var str))
+					_attributeSliders[0].Value = str;
+
+				if (profession.Stats.TryGetValue("Dex", out var dex))
+					_attributeSliders[1].Value = dex;
+
+				if (profession.Stats.TryGetValue("Int", out var intell))
+					_attributeSliders[2].Value = intell;
+			}
+
+			Add(new Button((int) Buttons.Prev, 0x15A1, 0x15A3, 0x15A2)
             {
                 X = 586, Y = 445, ButtonAction = ButtonAction.Activate
             });
@@ -134,7 +208,7 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
                         _skillSliders[i].AddParisSlider(_skillSliders[j]);
                 }
             }
-        }
+		}
 
         public override void OnButtonClick(int buttonID)
         {

--- a/src/IO/Resources/SkillsLoader.cs
+++ b/src/IO/Resources/SkillsLoader.cs
@@ -47,7 +47,7 @@ namespace ClassicUO.IO.Resources
                     return default;
 
 	            var hasAction = _file.ReadBool();
-	            var name = Encoding.UTF8.GetString(_file.ReadArray<byte>(length - 1));
+	            var name = Encoding.UTF8.GetString(_file.ReadArray<byte>(length - 1)).TrimEnd('\0');
 
 				_skills[index] = new SkillEntry(index, name, hasAction); 
             }

--- a/src/Utility/TextFileParser.cs
+++ b/src/Utility/TextFileParser.cs
@@ -17,8 +17,6 @@ namespace ClassicUO.Utility
 
         public TextFileParser(FileInfo file, char[] delimiters, char[] comments, char[] quotes)
         {
-            if (file.Length > 1M)
-                throw new InternalBufferOverflowException();
             _Delimiters = delimiters;
             _Comments = comments;
             _Quotes = quotes;


### PR DESCRIPTION
Implements the professions gump during character creation.
Closes #236 

The implementation differs slightly from 7.0.20.0. Selecting the profession does not automatically proceed to city selection. Rather, it configures the skill/attribute selection screen. I did this to further allow customization of a template if a player intended.
