### PR TITLE
Professions Gump

### DIFF
--- a/src/Game/UI/Gumps/CharCreation/CharCreationGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CharCreationGump.cs
@@ -32,8 +32,9 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         public enum CharCreationStep
         {
 			Appearence = 0,
-			ChooseTrade = 1,
-			ChooseCity = 2,
+			ChooseProfession = 1,
+			ChooseTrade = 2,
+			ChooseCity = 3,
 		}
 
         private PlayerMobile _character;
@@ -42,8 +43,9 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         private readonly LoginScene loginScene;
 
 	    private CityInfo _startingCity;
+		private ProfessionInfo _selectedProfession;
 
-        public CharCreationGump() : base(0, 0)
+		public CharCreationGump() : base(0, 0)
         {
             loginScene = Engine.SceneManager.GetScene<LoginScene>();
             Add(new CreateCharAppearanceGump(), 1);
@@ -54,7 +56,7 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         public void SetCharacter(PlayerMobile character)
         {
             _character = character;
-            SetStep(CharCreationStep.ChooseTrade);
+			SetStep(CharCreationStep.ChooseProfession);
 		}
 
 	    public void SetAttributes()
@@ -66,6 +68,13 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
 	    {
 		    _startingCity = city;
 	    }
+
+		public void SetProfession(ProfessionInfo info)
+		{
+			_selectedProfession = info;
+
+			SetStep(CharCreationStep.ChooseTrade);
+		}
 
 		public void CreateCharacter()
         {
@@ -102,25 +111,35 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
                     ChangePage(1);
 
                     break;
-                case CharCreationStep.ChooseTrade:
+				case CharCreationStep.ChooseProfession:
 					var existing = Children.FirstOrDefault(page => page.Page == 2);
-
-	                if (existing != null)
-		                Remove(existing);
-
-					Add(new CreateCharTradeGump(_character), 2);
-
-                    ChangePage(2);
-	                break;
-				case CharCreationStep.ChooseCity:
-					existing = Children.FirstOrDefault(page => page.Page == 3);
 
 					if (existing != null)
 						Remove(existing);
 
-					Add(new CreateCharCityGump(), 3);
+					Add(new CreateCharProfessionGump(), 2);
 
-					ChangePage(3);
+					ChangePage(2);
+					break;
+				case CharCreationStep.ChooseTrade:
+					existing = Children.FirstOrDefault(page => page.Page == 3);
+
+	                if (existing != null)
+		                Remove(existing);
+
+					Add(new CreateCharTradeGump(_character, _selectedProfession), 3);
+
+                    ChangePage(3);
+	                break;
+				case CharCreationStep.ChooseCity:
+					existing = Children.FirstOrDefault(page => page.Page == 4);
+
+					if (existing != null)
+						Remove(existing);
+
+					Add(new CreateCharCityGump(), 4);
+
+					ChangePage(4);
 					break;
             }
         }

--- a/src/Game/UI/Gumps/CharCreation/CreateCharProfessionGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharProfessionGump.cs
@@ -1,13 +1,128 @@
-﻿using ClassicUO.IO;
+﻿using ClassicUO.Game.UI.Controls;
+using ClassicUO.Input;
+using ClassicUO.IO;
 using ClassicUO.Utility;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
 namespace ClassicUO.Game.UI.Gumps.CharCreation
 {
-    internal class CreateCharProfessionGump
+    internal class CreateCharProfessionGump : Gump
     {
-        private enum PROF_TYPE
+		public CreateCharProfessionGump() : base(0, 0)
+		{
+			var professions = new List<ProfessionInfo>();
+
+			/* Parse the prof.txt if one is available. */
+			// TODO: Move this to FileManager for parsing at load time. Leave it here for now to test.
+			var professionFilePath = $@"{FileManager.UoFolderPath}\prof.txt";
+			var professionFile = new FileInfo(professionFilePath);
+
+			if (professionFile.Exists)
+			{
+				var professionParser = new TextFileParser(professionFile, new char[] { '\t', '\r', '\n' }, new char[] { }, new char[] { '"', '"' });
+				var tokens = professionParser.ReadTokens();
+
+				var index = 0;
+
+				while (index < tokens.Count)
+				{
+					var currentToken = tokens[index];
+
+					index++;
+
+					if (String.IsNullOrEmpty(currentToken))
+						continue;
+
+					if (!currentToken.StartsWith("begin", StringComparison.OrdinalIgnoreCase))
+						continue;
+
+					if (ProfessionInfo.TryReadSection(tokens, ref index, out var info))
+						professions.Add(info);
+				}
+			}
+
+			professions.Add(new ProfessionInfo()
+			{
+				Name = "Advanced",
+				Localization = 1061176,
+				Description = 1061226,
+				Graphic = 5504,
+			});
+
+			/* Build the gump */
+			Add(new ResizePic(2600)
+			{
+				X = 100,
+				Y = 80,
+				Width = 470,
+				Height = 372,
+			});
+
+			Add(new GumpPic(291, 42, 0x0589, 0));
+			Add(new GumpPic(214, 58, 0x058B, 0));
+			Add(new GumpPic(300, 51, 0x15A9, 0));
+
+			var localization = FileManager.Cliloc;
+
+			Add(new Label(localization.Translate(3000326), false, 0, font: 2)
+			{
+				X = 158,
+				Y = 132,
+			});
+
+			for (int i = 0; i < professions.Count; i++)
+			{
+				var cx = i % 2;
+				var cy = i / 2;
+
+				Add(new ProfessionInfoGump(professions[i])
+				{
+					X = 145 + (cx * 195),
+					Y = 168 + (cy * 70),
+
+					Selected = SelectProfession,
+				});
+			}
+
+			Add(new Button((int)Buttons.Prev, 0x15A1, 0x15A3, 0x15A2)
+			{
+				X = 586,
+				Y = 445,
+				ButtonAction = ButtonAction.Activate
+			});
+		}
+
+		public void SelectProfession(ProfessionInfo info)
+		{
+			var charCreationGump = Engine.UI.GetByLocalSerial<CharCreationGump>();
+
+			if (charCreationGump != null)
+				charCreationGump.SetProfession(info);
+		}
+
+		public override void OnButtonClick(int buttonID)
+		{
+			var charCreationGump = Engine.UI.GetByLocalSerial<CharCreationGump>();
+
+			switch ((Buttons)buttonID)
+			{
+				case Buttons.Prev:
+				charCreationGump.StepBack();
+				break;
+			}
+
+			base.OnButtonClick(buttonID);
+		}
+
+		private enum Buttons
+		{
+			Prev,
+		}
+
+
+		private enum PROF_TYPE
         {
             NO_PROF = 0,
             CATEGORY,
@@ -336,4 +451,109 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
             return result;
         }
     }
+
+	internal class ProfessionInfoGump : Control
+	{
+		private ProfessionInfo _info;
+
+		public Action<ProfessionInfo> Selected;
+
+		public ProfessionInfoGump(ProfessionInfo info)
+		{
+			_info = info;
+
+			var localization = FileManager.Cliloc;
+
+			var background = new ResizePic(3000)
+			{
+				Width = 175,
+				Height = 34,
+			};
+			background.SetTooltip(localization.Translate(info.Description));
+
+			Add(background);
+
+			Add(new Label(localization.Translate(info.Localization), true, 0x00, font: 1)
+			{
+				X = 7,
+				Y = 8,
+			});
+
+			Add(new GumpPic(121, -12, info.Graphic, 0));
+		}
+
+		protected override void OnMouseClick(int x, int y, MouseButton button)
+		{
+			base.OnMouseClick(x, y, button);
+
+			if (button == MouseButton.Left)
+			{
+				if (Selected != null)
+					Selected(_info);
+			}
+		}
+	}
+
+	internal class ProfessionInfo
+	{
+		public static bool TryReadSection(List<string> list, ref int index, out ProfessionInfo info)
+		{
+			info = new ProfessionInfo();
+
+			while (index < list.Count)
+			{
+				var currentToken = list[index].ToLower();
+
+				if (currentToken.StartsWith("end", StringComparison.OrdinalIgnoreCase))
+					break;
+
+				switch (currentToken)
+				{
+					case "name":
+					{
+						info.Name = list[++index];
+						break;
+					}
+					case "nameid":
+					{
+						info.Localization = int.Parse(list[++index]);
+						break;
+					}
+					case "descid":
+					{
+						info.Description = int.Parse(list[++index]);
+						break;
+					}
+					case "gump":
+					{
+						info.Graphic = (Graphic)int.Parse(list[++index]);
+						break;
+					}
+					case "skill":
+					{
+						info.Skills.Add(list[++index], int.Parse(list[++index]));
+						break;
+					}
+					case "stat":
+					{
+						info.Stats.Add(list[++index], int.Parse(list[++index]));
+						break;
+					}
+				}
+
+				index++;
+			}
+
+			return true;
+		}
+
+		public string Name { get; set; }
+		public int Localization { get; set; }
+		public int Description { get; set; }
+
+		public Graphic Graphic { get; set; }
+
+		public Dictionary<string, int> Skills { get; set; } = new Dictionary<string, int>();
+		public Dictionary<string, int> Stats { get; set; } = new Dictionary<string, int>();
+	}
 }

--- a/src/Game/UI/Gumps/CharCreation/CreateCharTradeGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharTradeGump.cs
@@ -19,6 +19,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -37,7 +38,7 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         private readonly PlayerMobile _character;
         private readonly Combobox[] _skills;
 
-        public CreateCharTradeGump(PlayerMobile character) : base(0, 0)
+        public CreateCharTradeGump(PlayerMobile character, ProfessionInfo profession) : base(0, 0)
         {
             _character = character;
 
@@ -107,7 +108,80 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
                 y += 70;
             }
 
-            Add(new Button((int) Buttons.Prev, 0x15A1, 0x15A3, 0x15A2)
+			if (profession.Skills.Any())
+			{
+				for (int i = 0; i < skillCount; i++)
+					_skillSliders[i].Value = 0;
+
+				int GetSkillIndex(string name)
+				{
+					/* Not sure if other cases exist. 
+					 * 7.0.20.0 has a specific function to convert string -> index for each skill in prof.txt. */
+					if (String.Equals(name, "Blacksmith", StringComparison.CurrentCulture))
+						name = "Blacksmithy";
+					else if (String.Equals(name, "AnimalLore", StringComparison.CurrentCulture))
+						name = "Animal Lore";
+					else if (String.Equals(name, "ItemID", StringComparison.CurrentCulture))
+						name = "Item Identification";
+					else if (String.Equals(name, "ArmsLore", StringComparison.CurrentCulture))
+						name = "Arms Lore";
+					else if (String.Equals(name, "Bowcraft", StringComparison.CurrentCulture))
+						name = "Bowcraft/Fletching";
+					else if (String.Equals(name, "DetectHidden", StringComparison.CurrentCulture))
+						name = "Detecting Hidden";
+					else if (String.Equals(name, "Enticement", StringComparison.CurrentCulture))
+						name = "Discordance";
+					else if (String.Equals(name, "EvaluateIntelligence", StringComparison.CurrentCulture))
+						name = "Evaluating Intelligence";
+					else if (String.Equals(name, "ForensicEvaluation", StringComparison.CurrentCulture))
+						name = "Forensic Evaluation";
+					else if (String.Equals(name, "ResistingSpells", StringComparison.CurrentCulture))
+						name = "Resisting Spells";
+					else if (String.Equals(name, "SpiritSpeak", StringComparison.CurrentCulture))
+						name = "Spirit Speak";
+					else if (String.Equals(name, "AnimalTaming", StringComparison.CurrentCulture))
+						name = "Animal Taming";
+					else if (String.Equals(name, "TasteIdentification", StringComparison.CurrentCulture))
+						name = "Taste Identification";
+					else if (String.Equals(name, "MaceFighting", StringComparison.CurrentCulture))
+						name = "Mace Fighting";
+					else if (String.Equals(name, "Disarm", StringComparison.CurrentCulture))
+						name = "Remove Trap";
+
+					return Array.IndexOf(skillList, name);
+				}
+
+				var skillIndex = 0;
+				foreach (var skillKVP in profession.Skills)
+				{
+					var skillCombo = _skills[skillIndex];
+					var skillSlider = _skillSliders[skillIndex];
+
+					var index = GetSkillIndex(skillKVP.Key);
+
+					if (index > 0)
+					{
+						skillCombo.SelectedIndex = index;
+						skillSlider.Value = skillKVP.Value;
+					}
+
+					skillIndex++;
+				}
+			}
+
+			if (profession.Stats.Count > 0)
+			{
+				if (profession.Stats.TryGetValue("Str", out var str))
+					_attributeSliders[0].Value = str;
+
+				if (profession.Stats.TryGetValue("Dex", out var dex))
+					_attributeSliders[1].Value = dex;
+
+				if (profession.Stats.TryGetValue("Int", out var intell))
+					_attributeSliders[2].Value = intell;
+			}
+
+			Add(new Button((int) Buttons.Prev, 0x15A1, 0x15A3, 0x15A2)
             {
                 X = 586, Y = 445, ButtonAction = ButtonAction.Activate
             });

--- a/src/IO/Resources/SkillsLoader.cs
+++ b/src/IO/Resources/SkillsLoader.cs
@@ -47,7 +47,7 @@ namespace ClassicUO.IO.Resources
                     return default;
 
 	            var hasAction = _file.ReadBool();
-	            var name = Encoding.UTF8.GetString(_file.ReadArray<byte>(length - 1));
+	            var name = Encoding.UTF8.GetString(_file.ReadArray<byte>(length - 1)).TrimEnd('\0');
 
 				_skills[index] = new SkillEntry(index, name, hasAction); 
             }

--- a/src/Utility/TextFileParser.cs
+++ b/src/Utility/TextFileParser.cs
@@ -17,10 +17,8 @@ namespace ClassicUO.Utility
 
         public TextFileParser(FileInfo file, char[] delimiters, char[] comments, char[] quotes)
         {
-			/*
             if (file.Length > 1M)
                 throw new InternalBufferOverflowException();
-			*/
             _Delimiters = delimiters;
             _Comments = comments;
             _Quotes = quotes;

--- a/src/Utility/TextFileParser.cs
+++ b/src/Utility/TextFileParser.cs
@@ -17,8 +17,10 @@ namespace ClassicUO.Utility
 
         public TextFileParser(FileInfo file, char[] delimiters, char[] comments, char[] quotes)
         {
+			/*
             if (file.Length > 1M)
                 throw new InternalBufferOverflowException();
+			*/
             _Delimiters = delimiters;
             _Comments = comments;
             _Quotes = quotes;


### PR DESCRIPTION
Implements the professions gump during character creation. I think Fwiffo has thorough parsing from Orion that should be used in the future. This commit will at least give some functionality.

Closes #236

The implementation differs slightly from 7.0.20.0. Selecting the profession does not automatically proceed to city selection. Rather, it configures the skill/attribute selection screen. I did this to further allow customization of a template if a player intended.

(Ignore the yellow font.)
![image](https://user-images.githubusercontent.com/1934897/52903621-25f06600-31ee-11e9-805f-c3aec07965a0.png)
