### PR TITLE
Pathfinding stam fix + remove LoginCharacter additional logic

### DIFF
--- a/src/Game/Pathfinder.cs
+++ b/src/Game/Pathfinder.cs
@@ -726,6 +726,9 @@ namespace ClassicUO.Game
 
         public static bool WalkTo(int x, int y, int z, int distance)
         {
+            if (World.Player.Stamina == 0 || World.Player.IsParalyzed)
+                return false;
+
             for (int i = 0; i < PATHFINDER_MAX_NODES; i++)
             {
                 if (_openList[i] == null)

--- a/src/Game/UI/Gumps/Login/CharacterSelectionGump.cs
+++ b/src/Game/UI/Gumps/Login/CharacterSelectionGump.cs
@@ -117,12 +117,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
         protected override void OnKeyDown(SDL.SDL_Keycode key, SDL.SDL_Keymod mod)
         {
             if (key == SDL.SDL_Keycode.SDLK_RETURN || key == SDL.SDL_Keycode.SDLK_KP_ENTER)
-            {
-                if (_selectedCharacter == 0)
-                    OnButtonClick((int)Buttons.New);
-                else
-                    LoginCharacter(_selectedCharacter);
-            }
+                LoginCharacter(_selectedCharacter);
         }
 
         public override void OnButtonClick(int buttonID)


### PR DESCRIPTION
### + Pathfinding now does not go when stamina is zero or char IsParalyzed

https://i.imgur.com/zp2Md7Q.gif
https://i.imgur.com/TWPI3wD.gif

### + fix LoginCharacter(_selectedCharacter);

Returned the code to the old state due to suspicion of a bug. This code is no longer required. if there are no players in the account, the player creation window will open automatically.