### PR TITLE
Quick fix for 'Pets disappear offscreen' issue #276

### DIFF
--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1663,7 +1663,10 @@ namespace ClassicUO.Network
             Direction dir = direction & Direction.Up;
             bool isrun = (direction & Direction.Running) != 0;
 
-            if (World.Get(mobile) == null)
+            //Quick fix for 'Pets disappear offscreen' #276 on github issues
+            bool mobileHasInvalidPosition = mobile != null && mobile.X == 65535 && mobile.Y == 65535 && mobile.Z == 0;
+
+            if (World.Get(mobile) == null || mobileHasInvalidPosition)
             {
                 mobile.Position = new Position((ushort)x, (ushort)y, z);
                 mobile.Direction = dir;


### PR DESCRIPTION
Was able to reproduce the 'Pets disappear offscreen' issue #276 
Here is a video reproducing the issue: http://recordit.co/oJIyqc2pej

The client was still receiving UpdateCharacter packets for the pet but the pet's position was not properly updating and was stuck at x:65535 y:65535 z:0

Now UpdateCharacter will detect if the mobile's position is ever invalid and force a new Position update from the packet's x/y/z values