### PR TITLE
Fix for 'Pets disappear offscreen' #276 on github issues

### DIFF
--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1663,7 +1663,10 @@ namespace ClassicUO.Network
             Direction dir = direction & Direction.Up;
             bool isrun = (direction & Direction.Running) != 0;
 
-            if (World.Get(mobile) == null)
+            //Fix for 'Pets disappear offscreen' #276 on github issues
+            bool mobileHasInvalidPosition = mobile != null && mobile.X == 65535 && mobile.Y == 65535 && mobile.Z == 0;
+
+            if (World.Get(mobile) == null || mobileHasInvalidPosition)
             {
                 mobile.Position = new Position((ushort)x, (ushort)y, z);
                 mobile.Direction = dir;


### PR DESCRIPTION
I was able to reproduce issue #276, here is a video http://recordit.co/oJIyqc2pej

My steps were:

1) Tame a drake and have it follow you 
2) get on a horse 
3) run  north until the drake falls behind you 
4) stop when the drake disappears for a few frames
5) run South and the drake will not be visible

CUO was still receiving UpdateCharacter packets for the drake but it's position was never updating.

Adding a check for an invalidPosition fixes the issue but I still need to investigate if maybe there is a bug in mobile.EnqueueStep that failed to update the mobile's position.