### PR TITLE
Fix ValidationRules (RULES.SYMBOL)

### DIFF
--- a/src/Game/UI/TextEntry.cs
+++ b/src/Game/UI/TextEntry.cs
@@ -142,7 +142,8 @@ namespace ClassicUO.Game.UI
                 {
                     allowChar = false;
 
-                    if ((ValidationRules & (uint)Constants.RULES.SYMBOL) != 0 && (c1 >= 33 && c1 <= 47))
+                    // https://www.dotnetperls.com/ascii-table
+                    if ((ValidationRules & (uint)Constants.RULES.SYMBOL) != 0 && ((c1 >= 33 && c1 <= 47) || (c1 >= 58 && c1 <= 64) || (c1 >= 91 && c1 <= 96) || (c1 >= 123 && c1 <= 126)) )
                         allowChar = true;
                     if ((ValidationRules & (uint)Constants.RULES.NUMERIC) != 0 && (c1 >= 48 && c1 <= 57))
                         allowChar = true;
@@ -178,7 +179,7 @@ namespace ClassicUO.Game.UI
 
                         var c1 = (int)Convert.ToChar(c);
 
-                        if ((ValidationRules & (uint)Constants.RULES.SYMBOL) != 0 && (c1 >= 33 && c1 <= 47))
+                        if ((ValidationRules & (uint)Constants.RULES.SYMBOL) != 0 && ((c1 >= 33 && c1 <= 47) || (c1 >= 58 && c1 <= 64) || (c1 >= 91 && c1 <= 96) || (c1 >= 123 && c1 <= 126)) )
                             allowChar = true;
                         if ((ValidationRules & (uint)Constants.RULES.NUMERIC) != 0 && (c1 >= 48 && c1 <= 57))
                             allowChar = true;


### PR DESCRIPTION
### Add to SYMBOL list:

58 : 3A
59 ; 3B
60 < 3C
61 = 3D
62 > 3E
63 ? 3F
64 @ 40
91 [ 5B
92 \ 5C
93 ] 5D
94 ^ 5E
95 _ 5F
96 ` 60
123 { 7B
124 | 7C
125 } 7D
126 ~ 7E

its fix problem 

![409ws8k](https://user-images.githubusercontent.com/1370602/53667161-d6437d00-3c78-11e9-8c1e-d2fb65e355d1.png)

I think bad idea use this list, with ServUO

![409wtzx](https://user-images.githubusercontent.com/1370602/53667195-f2471e80-3c78-11e9-93b0-728c11402e02.png)
https://github.com/ServUO/ServUO/blob/01d7378e6aa463822cb229e3244766354e8f9700/Scripts/Accounting/AccountHandler.cs#L100

because the original client allows them to be used (7.0.18)