### PR TITLE
Underscore as valid input

### DIFF
--- a/src/Game/UI/TextEntry.cs
+++ b/src/Game/UI/TextEntry.cs
@@ -142,7 +142,7 @@ namespace ClassicUO.Game.UI
                 {
                     allowChar = false;
 
-                    if ((ValidationRules & (uint)Constants.RULES.SYMBOL) != 0 && (c1 >= 33 && c1 <= 47))
+                    if ((ValidationRules & (uint)Constants.RULES.SYMBOL) != 0 && ((c1 >= 33 && c1 <= 47) || c1 == 95))
                         allowChar = true;
                     if ((ValidationRules & (uint)Constants.RULES.NUMERIC) != 0 && (c1 >= 48 && c1 <= 57))
                         allowChar = true;
@@ -178,7 +178,7 @@ namespace ClassicUO.Game.UI
 
                         var c1 = (int)Convert.ToChar(c);
 
-                        if ((ValidationRules & (uint)Constants.RULES.SYMBOL) != 0 && (c1 >= 33 && c1 <= 47))
+                        if ((ValidationRules & (uint)Constants.RULES.SYMBOL) != 0 && ((c1 >= 33 && c1 <= 47) || c1 == 95))
                             allowChar = true;
                         if ((ValidationRules & (uint)Constants.RULES.NUMERIC) != 0 && (c1 >= 48 && c1 <= 57))
                             allowChar = true;


### PR DESCRIPTION
The underscore character ("_") is a valid input for account names. Not sure if this was the best way to implement, or to create another Constants.RULES category.