### PR TITLE
Targeting health gump for provocation fix

### DIFF
--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -504,15 +504,6 @@ namespace ClassicUO.Game.UI.Gumps
                 _textBox.IsEditable = false;
         }
 
-        protected override void OnMouseDown(int x, int y, MouseButton button)
-        {
-            if (TargetManager.IsTargeting)
-            {
-                TargetManager.TargetGameObject(Mobile);
-                Mouse.LastLeftButtonClickTime = 0;
-            }
-        }
-
         protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)
         {
             if (Mobile != null)


### PR DESCRIPTION
Provocation skill didn't work when using the health bar as target (works fine when targeting directly the creature).

Video: https://youtu.be/x9K0WNmIIQs

What happens:

1. Client to server: use skill provocation
2. Server to client: please select first target
3. Client to server: send first target
4. Server to client: please select second target
5. Client to server: send first target again

It happens because both `OnMouseDown` and `OnMouseClick` handles Targeting and it happens so fast that it does this sequence:

1. Client: `OnMouseDown` (send first target to server)
2. Server: Ok, please select 2nd target
3. Client: `OnMouseClick` (send "second" target to server which is still the first target)