### PR TITLE
Fixes crash for overhead nametags with HTML formatting.

### DIFF
--- a/src/IO/Resources/FontsLoader.cs
+++ b/src/IO/Resources/FontsLoader.cs
@@ -1541,6 +1541,8 @@ namespace ClassicUO.IO.Resources
                         }
 
                         i = lastSpace + 1;
+                        if (i >= len)
+                            break;
                         si = htmlData[i].Char;
                         solidWidth = htmlData[i].Flags & UOFONT_SOLID;
 


### PR DESCRIPTION
Strings like 
`<BASEFONT COLOR=#FFFF00> Moonglow - First Bank Of Moonglow And Tinkerguild - Banker <BASEFONT COLOR=#FFFFFF>`
were crashing.

`[ERROR] FATAL UNHANDLED EXCEPTION: System.IndexOutOfRangeException: Index was outside the bounds of the array.
  at ClassicUO.IO.Resources.FontsLoader.GetInfoHTML (System.Byte font, System.String str, System.Int32 len, ClassicUO.IO.Resources.TEXT_ALIGN_TYPE align, System.UInt16 flags, System.Int32 width) [0x00411] in <2a10acae77b141a9a8a53541fc0dd17a>:0 
  at ClassicUO.IO.Resources.FontsLoader.GetInfoUnicode (System.Byte font, System.String str, System.Int32 len, ClassicUO.IO.Resources.TEXT_ALIGN_TYPE align, System.UInt16 flags, System.Int32 width) [0x0006e] in <2a10acae77b141a9a8a53541fc0dd17a>:0 
  at ClassicUO.IO.Resources.FontsLoader.GetWidthExUnicode (System.Byte font, System.String text, System.Int32 maxwidth, ClassicUO.IO.Resources.TEXT_ALIGN_TYPE align, System.UInt16 flags) [0x00034] in <2a10acae77b141a9a8a53541fc0dd17a>:0 
  at ClassicUO.Game.UI.Gumps.NameOverheadGump.SetName () [0x000d8] in <2a10acae77b141a9a8a53541fc0dd17a>:0 
  at ClassicUO.Game.UI.Gumps.NameOverheadGump.Draw (ClassicUO.Renderer.Batcher2D batcher, System.Int32 x, System.Int32 y) [0x00009] in <2a10acae77b141a9a8a53541fc0dd17a>:0 
  at ClassicUO.Game.Managers.UIManager.Draw (ClassicUO.Renderer.Batcher2D batcher) [0x00056] in <2a10acae77b141a9a8a53541fc0dd17a>:0 
  at ClassicUO.Engine.Draw (Microsoft.Xna.Framework.GameTime gameTime) [0x000a7] in <2a10acae77b141a9a8a53541fc0dd17a>:0 
`
