### PR TITLE
Support for plugins (ie: Razor) to update CUO's title window

### DIFF
--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -104,6 +104,8 @@ namespace ClassicUO
 
         public bool IsQuitted { get; private set; }
 
+        public bool DisableUpdateWindowCaption { get; set; }
+
         private SpriteBatch _spriteBatch;
 
         private Engine(string[] args)
@@ -803,7 +805,7 @@ namespace ClassicUO
 
         private void UpdateWindowCaption(GameTime gameTime)
         {
-            if (!_settings.Profiler)
+            if (!_settings.Profiler || DisableUpdateWindowCaption)
                 return;
 
             double timeDraw = Profiler.GetContext("RenderFrame").TimeInContext;

--- a/src/Network/Plugin.cs
+++ b/src/Network/Plugin.cs
@@ -226,8 +226,17 @@ namespace ClassicUO.Network
 
         private static void SetWindowTitle(string str)
         {
-            Engine.Instance.Window.Title = str;
+            if (string.IsNullOrEmpty(str))
+            {
+                Engine.Instance.DisableUpdateWindowCaption = false;
+            }
+            else
+            {
+                Engine.Instance.DisableUpdateWindowCaption = true;
+                Engine.Instance.Window.Title = str;
+            }
         }
+
         private static void GetStaticImage(ushort g, ref ArtInfo info)
         {
             FileManager.Art.TryGetEntryInfo(g, out long address, out long size, out long compressedsize);


### PR DESCRIPTION
When the plugin detects text coming in to change the window title, disable via a toggle the FPS, draw, etc info.  If a null or empty value is set via the plugin API, toggle is back on.

Doesn't support color coding, images, etc yet. Just basic text.