### PR TITLE
Systemchat fixes & minors

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -148,6 +148,9 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool ActivateChatAdditionalButtons { get; set; } = true;
         [JsonProperty] public bool ActivateChatShiftEnterSupport { get; set; } = true;
 
+        // Experimental
+        [JsonProperty] public bool EnableSelectionArea { get; set; } = false;
+
         [JsonProperty] public int MaxFPS { get; set; } = 60;
 
         [JsonProperty]

--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -134,9 +134,6 @@ namespace ClassicUO.Configuration
         [JsonProperty] public Point TopbarGumpPosition { get; set; } = new Point(0, 0);
         [JsonProperty] public bool TopbarGumpIsMinimized { get; set; }
         [JsonProperty] public bool TopbarGumpIsDisabled { get; set; }
-        [JsonProperty] public Point DebugGumpPosition { get; set; } = new Point(0, 0);
-        [JsonProperty] public bool DebugGumpIsMinimized { get; set; }
-        [JsonProperty] public bool DebugGumpIsDisabled { get; set; }
         [JsonProperty] public bool UseCustomLightLevel { get; set; }
         [JsonProperty] public byte LightLevel { get; set; }
         [JsonProperty] public int CloseHealthBarType { get; set; } // 0 = none, 1 == not exists, 2 == is dead
@@ -150,6 +147,10 @@ namespace ClassicUO.Configuration
 
         // Experimental
         [JsonProperty] public bool EnableSelectionArea { get; set; } = false;
+        [JsonProperty] public bool DebugGumpIsDisabled { get; set; } = false;
+        [JsonProperty] public Point DebugGumpPosition { get; set; } = new Point(25, 25);
+        [JsonProperty] public bool DebugGumpIsMinimized { get; set; } = true;
+
 
         [JsonProperty] public int MaxFPS { get; set; } = 60;
 

--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -42,7 +42,6 @@ namespace ClassicUO.Game.Managers
         private Macro _firstNode;
         private MacroObject _lastMacro;
         private long _nextTimer;
-        private SystemChatControl systemchat;
 
         private WorldViewportGump viewport;
 
@@ -248,17 +247,7 @@ namespace ClassicUO.Game.Managers
                         string s = SDL.SDL_GetClipboardText();
 
                         if (!string.IsNullOrEmpty(s))
-                        {
-                            viewport = Engine.UI.GetByLocalSerial<WorldViewportGump>();
-
-                            if (viewport != null)
-                            {
-                                systemchat = viewport.FindControls<SystemChatControl>().SingleOrDefault();
-
-                                if (systemchat != null)
-                                    systemchat.textBox.Text += s;
-                            }
-                        }
+                            Engine.UI.SystemChat.textBox.Text += s;
                     }
 
                     break;
@@ -909,14 +898,10 @@ namespace ClassicUO.Game.Managers
 
                 case MacroType.DefaultScale:
                     Engine.SceneManager.GetScene<GameScene>().Scale = 1;
-
                     break;
 
                 case MacroType.ToggleChatVisibility:
-                    viewport = Engine.UI.GetByLocalSerial<WorldViewportGump>();
-                    systemchat = viewport?.FindControls<SystemChatControl>().SingleOrDefault();
-                    systemchat?.ToggleChatVisibility();
-
+                    Engine.UI.SystemChat?.ToggleChatVisibility();
                     break;
             }
 

--- a/src/Game/Managers/TargetManager.cs
+++ b/src/Game/Managers/TargetManager.cs
@@ -116,8 +116,6 @@ namespace ClassicUO.Game.Managers
             MultiTargetInfo = new MultiTargetInfo(model, x, y, z);
         }
 
-
-
         private static void TargetXYZ(GameObject selectedEntity)
         {
             Graphic modelNumber = 0;

--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -234,6 +234,8 @@ namespace ClassicUO.Game.Managers
 
         public GameCursor GameCursor { get; private set; }
 
+        public SystemChatControl SystemChat { get; set; }
+
         public Control KeyboardFocusControl
         {
             get

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -470,10 +470,7 @@ namespace ClassicUO.Game.Scenes
                     World.Player.Walk(dWalk, false);
                 else
                 {
-                    WorldViewportGump vp = Engine.UI.GetByLocalSerial<WorldViewportGump>();
-                    SystemChatControl chat = vp?.FindControls<SystemChatControl>().SingleOrDefault();
-
-                    if (chat != null && chat.textBox.Text.Length == 0)
+                    if (Engine.UI.SystemChat?.textBox.Text.Length == 0)
                         World.Player.Walk(dWalk, false);
                 }
             }

--- a/src/Game/UI/AbstractEntry.cs
+++ b/src/Game/UI/AbstractEntry.cs
@@ -244,7 +244,7 @@ namespace ClassicUO.Game.UI
             if (oldPos != CaretIndex)
                 UpdateCaretPosition();
 
-            if (mouseclick)
+            if (mouseclick && (World.InGame && Engine.Profile.Current.EnableSelectionArea))
             {
                 _selectionArea = (x, y);
                 _isSelection = true;

--- a/src/Game/UI/Gumps/DebugGump.cs
+++ b/src/Game/UI/Gumps/DebugGump.cs
@@ -32,8 +32,6 @@ namespace ClassicUO.Game.UI.Gumps
 
             _fullDisplayMode = !Engine.Profile.Current.DebugGumpIsMinimized;
 
-            Engine.Profile.Current.DebugGumpIsDisabled = false;
-
             Width = 500;
             Height = 275;
 
@@ -138,12 +136,6 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             return string.Empty;
-        }
-
-        protected override void CloseWithRightClick()
-        {
-            Engine.Profile.Current.DebugGumpIsDisabled = true;
-            base.CloseWithRightClick();
         }
 
         protected override void OnDragEnd(int x, int y)

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -21,9 +21,7 @@
 
 #endregion
 
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
@@ -64,6 +62,8 @@ namespace ClassicUO.Game.UI.Gumps
         private Serial _partyMemeberSerial;
         private Label _partyNameLabel;
         private TextBox _textBox;
+
+        private bool _targetBroke = false;
 
         public HealthBarGump(Mobile mob) : this()
         {
@@ -181,7 +181,6 @@ namespace ClassicUO.Game.UI.Gumps
                 if (!_isDead && Mobile.IsDead && Engine.Profile.Current.CloseHealthBarType == 2) // is dead
                 {
                     Dispose();
-
                     return;
                 }
 
@@ -476,8 +475,6 @@ namespace ClassicUO.Game.UI.Gumps
             return max;
         }
 
-        private bool _targetBroke = false;
-
         private void TextBoxOnMouseClick(object sender, MouseEventArgs e)
         {
             if (TargetManager.IsTargeting)
@@ -525,8 +522,6 @@ namespace ClassicUO.Game.UI.Gumps
                     Dispose();
                 }
             }
-
-
             return true;
         }
 
@@ -545,12 +540,14 @@ namespace ClassicUO.Game.UI.Gumps
 
         protected override void OnMouseEnter(int x, int y)
         {
-            if ((TargetManager.IsTargeting || World.Player.InWarMode) && Mobile != null) SelectedObject.Object = Mobile;
+            if ((TargetManager.IsTargeting || World.Player.InWarMode) && Mobile != null)
+                SelectedObject.Object = Mobile;
         }
 
         protected override void OnMouseExit(int x, int y)
         {
-            if (Mobile != null && Mobile.IsSelected) SelectedObject.Object = null;
+            if (Mobile != null && Mobile.IsSelected)
+                SelectedObject.Object = null;
         }
 
         private enum ButtonParty

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -22,7 +22,7 @@
 #endregion
 
 using System.IO;
-
+using System.Linq;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
@@ -498,6 +498,8 @@ namespace ClassicUO.Game.UI.Gumps
             }
             else if (_canChangeName)
                 _textBox.IsEditable = false;
+
+            _textBox.SetKeyboardFocus();
         }
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)
@@ -529,6 +531,7 @@ namespace ClassicUO.Game.UI.Gumps
             if ((key == SDL.SDL_Keycode.SDLK_RETURN || key == SDL.SDL_Keycode.SDLK_KP_ENTER) && _textBox.IsEditable)
             {
                 GameActions.Rename(Mobile, _textBox.Text);
+                Engine.UI.SystemChat?.SetFocus();
                 _textBox.IsEditable = false;
             }
         }

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using ClassicUO.Game.Data;
@@ -459,20 +460,6 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
-        private void TextBoxOnMouseClick(object sender, MouseEventArgs e)
-        {
-            if (TargetManager.IsTargeting)
-            {
-                TargetManager.TargetGameObject(Mobile);
-                Mouse.LastLeftButtonClickTime = 0;
-            }
-            else if (_canChangeName)
-            {
-                _textBox.IsEditable = true;
-                _textBox.SetKeyboardFocus();
-            }
-        }
-
         private static int CalculatePercents(int max, int current, int maxValue)
         {
             if (max > 0)
@@ -489,17 +476,37 @@ namespace ClassicUO.Game.UI.Gumps
             return max;
         }
 
-        protected override void OnMouseClick(int x, int y, MouseButton button)
+        private bool _targetBroke = false;
+
+        private void TextBoxOnMouseClick(object sender, MouseEventArgs e)
         {
             if (TargetManager.IsTargeting)
             {
                 TargetManager.TargetGameObject(Mobile);
                 Mouse.LastLeftButtonClickTime = 0;
             }
-            else if (_canChangeName)
-                _textBox.IsEditable = false;
+            else if (_canChangeName && !_targetBroke)
+            {
+                _textBox.IsEditable = true;
+                _textBox.SetKeyboardFocus();
+            }
 
-            _textBox.SetKeyboardFocus();
+            _targetBroke = false;
+        }
+
+        protected override void OnMouseClick(int x, int y, MouseButton button)
+        {
+            if (TargetManager.IsTargeting)
+            {
+                _targetBroke = true;
+                TargetManager.TargetGameObject(Mobile);
+                Mouse.LastLeftButtonClickTime = 0;
+            }
+            else if (_canChangeName)
+            {
+                _textBox.IsEditable = false;
+                Engine.UI.SystemChat.SetFocus();
+            }
         }
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -467,7 +467,10 @@ namespace ClassicUO.Game.UI.Gumps
                 Mouse.LastLeftButtonClickTime = 0;
             }
             else if (_canChangeName)
+            {
                 _textBox.IsEditable = true;
+                _textBox.SetKeyboardFocus();
+            }
         }
 
         private static int CalculatePercents(int max, int current, int maxValue)

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -111,7 +111,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (IsDisposed)
                 return;
-
+            
             bool inparty = World.Party.GetPartyMember(_partyMemeberSerial) != null;
 
             Hue textColor = 0x0386;
@@ -307,12 +307,13 @@ namespace ClassicUO.Game.UI.Gumps
                     _oldStam = stam;
                 }
             }
+
+            _textBox.Height = 15;
         }
 
         public override void Dispose()
         {
             if (FileManager.ClientVersion >= ClientVersions.CV_200 && World.InGame && Mobile != null) NetClient.Socket.Send(new PCloseStatusBarGump(Mobile));
-
             base.Dispose();
         }
 
@@ -445,7 +446,7 @@ namespace ClassicUO.Game.UI.Gumps
                         X = 16,
                         Y = 14,
                         Width = 120,
-                        Height = 30,
+                        Height = 15,
                         IsEditable = false,
                         AcceptMouseInput = _canChangeName,
                         AcceptKeyboardInput = _canChangeName,

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -54,6 +54,9 @@ namespace ClassicUO.Game.UI.Gumps
         //counters
         private Checkbox _enableCounters, _highlightOnUse;
 
+        //experimental
+        private Checkbox _enableSelectionArea;
+
         // sounds
         private Checkbox _enableSounds, _enableMusic, _footStepsSound, _combatMusic, _musicInBackground, _loginMusic;
         private RadioButton _fieldsToTile, _staticFields, _normalFields;
@@ -129,8 +132,8 @@ namespace ClassicUO.Game.UI.Gumps
             Add(new NiceButton(10, 10 + 30 * 5, 140, 25, ButtonAction.SwitchPage, "Fonts") {ButtonParameter = 6});
             Add(new NiceButton(10, 10 + 30 * 6, 140, 25, ButtonAction.SwitchPage, "Speech") {ButtonParameter = 7});
             Add(new NiceButton(10, 10 + 30 * 7, 140, 25, ButtonAction.SwitchPage, "Combat") {ButtonParameter = 8});
-            Add(new NiceButton(10, 10 + 30 * 8, 140, 25, ButtonAction.SwitchPage, "Counters") {ButtonParameter = 9});
-
+            Add(new NiceButton(10, 10 + 30 * 8, 140, 25, ButtonAction.SwitchPage, "Counters") { ButtonParameter = 9 });
+            Add(new NiceButton(10, 10 + 30 * 9, 140, 25, ButtonAction.SwitchPage, "Experimental") { ButtonParameter = 10 });
 
             Add(new Line(160, 5, 1, HEIGHT - 10, Color.Gray.PackedValue));
 
@@ -171,6 +174,7 @@ namespace ClassicUO.Game.UI.Gumps
             BuildCombat();
             BuildTooltip();
             BuildCounters();
+            BuildExperimental();
 
             ChangePage(1);
         }
@@ -863,6 +867,15 @@ namespace ClassicUO.Game.UI.Gumps
             Add(rightArea, PAGE);
         }
 
+        private void BuildExperimental()
+        {
+            const int PAGE = 10;
+            ScrollArea rightArea = new ScrollArea(190, 20, WIDTH - 210, 420, true);
+
+            _enableSelectionArea = CreateCheckBox(rightArea, "Enable Selection Area", Engine.Profile.Current.EnableSelectionArea, 0, 0);
+
+            Add(rightArea, PAGE);
+        }
         public override void OnButtonClick(int buttonID)
         {
             if (buttonID == (int) Buttons.Last + 1)
@@ -1032,6 +1045,11 @@ namespace ClassicUO.Game.UI.Gumps
                     _columns.Text = "1";
                     _rows.Text = "1";
                     _cellSize.Value = 40;
+
+                    break;
+
+                case 10:
+                    _enableSelectionArea.IsChecked = false;
 
                     break;
             }
@@ -1306,6 +1324,8 @@ namespace ClassicUO.Game.UI.Gumps
                     counterGump.IsEnabled = counterGump.IsVisible = Engine.Profile.Current.CounterBarEnabled;
             }
 
+            // experimental
+            Engine.Profile.Current.EnableSelectionArea = _enableSelectionArea.IsChecked;
 
             Engine.Profile.Current?.Save(Engine.UI.Gumps.OfType<Gump>().Where(s => s.CanBeSaved).Reverse().ToList());
         }

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -888,38 +888,26 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 case Buttons.Cancel:
                     Dispose();
-
                     break;
+
                 case Buttons.Apply:
                     Apply();
-
                     break;
+
                 case Buttons.Default:
                     SetDefault();
-
                     break;
+
                 case Buttons.Ok:
                     Apply();
                     Dispose();
-
                     break;
+
                 case Buttons.NewMacro:
-
                     break;
+
                 case Buttons.DeleteMacro:
-
                     break;
-
-                //case Buttons.SpeechColor: break;
-                //case Buttons.EmoteColor: break;
-                //case Buttons.PartyMessageColor: break;
-                //case Buttons.GuildMessageColor: break;
-                //case Buttons.AllyMessageColor: break;
-                //case Buttons.InnocentColor: break;
-                //case Buttons.FriendColor: break;
-                //case Buttons.CriminalColor: break;
-                //case Buttons.EnemyColor: break;
-                //case Buttons.MurdererColor: break;
             }
         }
 
@@ -1245,10 +1233,8 @@ namespace ClassicUO.Game.UI.Gumps
                 World.Light.Personal = World.Light.RealPersonal;
             }
 
-
             Engine.Profile.Current.ShadowsEnabled = _enableShadows.IsChecked;
             Engine.Profile.Current.AuraUnderFeetType = _auraType.SelectedIndex;
-
 
             // fonts
             var _fontValue = _fontSelectorChat.GetSelectedFont();
@@ -1272,7 +1258,6 @@ namespace ClassicUO.Game.UI.Gumps
             // macros
             Engine.Profile.Current.Macros = Engine.SceneManager.GetScene<GameScene>().Macros.GetAllMacros().ToArray();
 
-
             // counters
 
             bool before = Engine.Profile.Current.CounterBarEnabled;
@@ -1281,7 +1266,6 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.CounterBarRows = int.Parse(_rows.Text);
             Engine.Profile.Current.CounterBarColumns = int.Parse(_columns.Text);
             Engine.Profile.Current.CounterBarHighlightOnUse = _highlightOnUse.IsChecked;
-
 
             CounterBarGump counterGump = Engine.UI.GetByLocalSerial<CounterBarGump>();
 

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -55,7 +55,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _enableCounters, _highlightOnUse;
 
         //experimental
-        private Checkbox _enableSelectionArea;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled;
 
         // sounds
         private Checkbox _enableSounds, _enableMusic, _footStepsSound, _combatMusic, _musicInBackground, _loginMusic;
@@ -873,6 +873,7 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea(190, 20, WIDTH - 210, 420, true);
 
             _enableSelectionArea = CreateCheckBox(rightArea, "Enable Selection Area", Engine.Profile.Current.EnableSelectionArea, 0, 0);
+            _debugGumpIsDisabled = CreateCheckBox(rightArea, "Disable Debug Gump", Engine.Profile.Current.DebugGumpIsDisabled, 0, 0);
 
             Add(rightArea, PAGE);
         }
@@ -1034,6 +1035,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 case 10:
                     _enableSelectionArea.IsChecked = false;
+                    _debugGumpIsDisabled.IsChecked = false;
 
                     break;
             }
@@ -1287,6 +1289,36 @@ namespace ClassicUO.Game.UI.Gumps
 
             // experimental
             Engine.Profile.Current.EnableSelectionArea = _enableSelectionArea.IsChecked;
+
+            if (Engine.Profile.Current.DebugGumpIsDisabled != _debugGumpIsDisabled.IsChecked)
+            {
+                DebugGump debugGump = Engine.UI.GetByLocalSerial<DebugGump>();
+
+                if (_debugGumpIsDisabled.IsChecked)
+                {
+                    if (debugGump != null)
+                        debugGump.IsVisible = false;
+                }
+                else
+                {
+                    if (debugGump == null)
+                    {
+                        debugGump = new DebugGump
+                        {
+                            X = Engine.Profile.Current.DebugGumpPosition.X,
+                            Y = Engine.Profile.Current.DebugGumpPosition.Y
+                        };
+                        Engine.UI.Add(debugGump);
+                    }
+                    else
+                    {
+                        debugGump.IsVisible = true;
+                        debugGump.SetInScreen();
+                    }
+                }
+
+                Engine.Profile.Current.DebugGumpIsDisabled = _debugGumpIsDisabled.IsChecked;
+            }
 
             Engine.Profile.Current?.Save(Engine.UI.Gumps.OfType<Gump>().Where(s => s.CanBeSaved).Reverse().ToList());
         }

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -1016,11 +1016,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                     _chatAfterEnter.IsChecked = false;
 
-                    WorldViewportGump vp = Engine.UI.GetByLocalSerial<WorldViewportGump>();
-                    SystemChatControl systemchat = vp?.FindControls<SystemChatControl>().SingleOrDefault();
-
-                    if (systemchat != null)
-                        systemchat.IsActive = !_chatAfterEnter.IsChecked;
+                    Engine.UI.SystemChat.IsActive = !_chatAfterEnter.IsChecked;
 
                     _chatIgnodeHotkeysCheckbox.IsChecked = true;
                     _chatIgnodeHotkeysPluginsCheckbox.IsChecked = true;
@@ -1130,11 +1126,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (Engine.Profile.Current.ActivateChatAfterEnter != _chatAfterEnter.IsChecked)
             {
-                SystemChatControl systemchat = vp?.FindControls<SystemChatControl>().SingleOrDefault();
-
-                if (systemchat != null)
-                    systemchat.IsActive = !_chatAfterEnter.IsChecked;
-
+                Engine.UI.SystemChat.IsActive = !_chatAfterEnter.IsChecked;
                 Engine.Profile.Current.ActivateChatAfterEnter = _chatAfterEnter.IsChecked;
             }
 
@@ -1264,23 +1256,8 @@ namespace ClassicUO.Game.UI.Gumps
             if (Engine.Profile.Current.ChatFont != _fontValue)
             {
                 Engine.Profile.Current.ChatFont = _fontValue;
-
                 WorldViewportGump viewport = Engine.UI.GetByLocalSerial<WorldViewportGump>();
-
-                if (viewport != null)
-                {
-                    SystemChatControl systemchat = viewport.FindControls<SystemChatControl>().SingleOrDefault();
-
-                    if (systemchat != null)
-                    {
-                        viewport.ReloadChatControl(new SystemChatControl(
-                                                                         5,
-                                                                         5,
-                                                                         Engine.Profile.Current.GameWindowSize.X,
-                                                                         Engine.Profile.Current.GameWindowSize.Y
-                                                                        ));
-                    }
-                }
+                viewport?.ReloadChatControl(new SystemChatControl(5, 5, Engine.Profile.Current.GameWindowSize.X, Engine.Profile.Current.GameWindowSize.Y));
             }
 
             // combat

--- a/src/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/Game/UI/Gumps/SystemChatControl.cs
@@ -114,16 +114,23 @@ namespace ClassicUO.Game.UI.Gumps
             IsActive = !Engine.Profile.Current.ActivateChatAfterEnter;
         }
 
+        public void SetFocus()
+        {
+            textBox.IsEditable = true;
+            textBox.SetKeyboardFocus();
+            textBox.IsEditable = _isActive;
+        }
+
         public bool IsActive
         {
             get => _isActive;
             set
             {
-                _isActive = value;
+                _isActive = textBox.IsEditable = value;
 
-                if (value)
+                if (_isActive)
                 {
-                    Engine.Profile.Current.ActivateChatStatus = _trans.IsVisible = value;
+                    Engine.Profile.Current.ActivateChatStatus = _trans.IsVisible = true;
                     _trans.Y = textBox.Y;
                     textBox.Width = _trans.Width;
                     textBox.SetText(string.Empty);
@@ -132,12 +139,10 @@ namespace ClassicUO.Game.UI.Gumps
                 else
                 {
                     int height = FileManager.Fonts.GetHeightUnicode(Engine.Profile.Current.ChatFont, "123ABC", Width, 0, (ushort) (FontStyle.BlackBorder | FontStyle.Fixed));
-                    Engine.Profile.Current.ActivateChatStatus = value;
+                    Engine.Profile.Current.ActivateChatStatus = false;
                     textBox.Width = 1;
                     _trans.Y = textBox.Y + height + 3;
                 }
-
-                textBox.IsEditable = _isActive ? true : false;
             }
         }
 

--- a/src/Game/UI/Gumps/TopBarGump.cs
+++ b/src/Game/UI/Gumps/TopBarGump.cs
@@ -237,7 +237,6 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                     else
                     {
-                        Engine.Profile.Current.DebugGumpIsDisabled = debugGump.IsVisible;
                         debugGump.IsVisible = !debugGump.IsVisible;
                         debugGump.SetInScreen();
                     }

--- a/src/Game/UI/Gumps/WorldViewportGump.cs
+++ b/src/Game/UI/Gumps/WorldViewportGump.cs
@@ -85,7 +85,9 @@ namespace ClassicUO.Game.UI.Gumps
             Height = _worldHeight + BORDER_HEIGHT * 2;
             _border = new GameBorder(0, 0, Width, Height, 4);
             _viewport = new WorldViewport(scene, BORDER_WIDTH, BORDER_HEIGHT, _worldWidth, _worldHeight);
-            _systemChatControl = new SystemChatControl(BORDER_WIDTH, BORDER_HEIGHT, _worldWidth, _worldHeight);
+
+            Engine.UI.SystemChat = _systemChatControl = new SystemChatControl(BORDER_WIDTH, BORDER_HEIGHT, _worldWidth, _worldHeight);
+
             Add(_border);
             Add(_button);
             Add(_viewport);
@@ -192,7 +194,7 @@ namespace ClassicUO.Game.UI.Gumps
         public void ReloadChatControl(SystemChatControl chat)
         {
             _systemChatControl.Dispose();
-            _systemChatControl = chat;
+            Engine.UI.SystemChat = _systemChatControl = chat;
             Add(_systemChatControl);
             Resize();
         }


### PR DESCRIPTION

**1. You can disable DebugGump with options menu (experemental)**
Closing gump with mouse or "Debug button" does not save variable

![41ivCDb](https://user-images.githubusercontent.com/1370602/56870350-db257280-6a16-11e9-8037-d7d3c0e8b884.jpg)

**2. Fixed "3 clicks bug" mobile renamed**
https://i.imgur.com/cxjz9tH.gifv

**3. Disable selection area (disable by def)**
![41ivGk1](https://user-images.githubusercontent.com/1370602/56870355-eb3d5200-6a16-11e9-9b72-23aafb3d4ff0.jpg)
![41ivH0N](https://user-images.githubusercontent.com/1370602/56870356-eb3d5200-6a16-11e9-990a-4e6e320a6315.jpg)

**4. Name height reduced in HealthBar**
This will reduce chance of miss when trying to move gump.

![41iv3Px](https://user-images.githubusercontent.com/1370602/56870364-fdb78b80-6a16-11e9-8f34-dc6969d05568.jpg)
![41it00E](https://user-images.githubusercontent.com/1370602/56870365-fdb78b80-6a16-11e9-8c48-d31fd37d80e5.jpg)

**5. Focus off in text field is disabled if you are using a spell or skill #450**
https://i.imgur.com/wXQuuSF.gifv

**6. Many fixes related to "Enable chat after Enter"**
Now focus should not disappear if you drag gump. 
If you complete renaming mob - focus will return system chat and etc.

