### PR TITLE
Added additional options to healthbar mouseover highlight

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -101,6 +101,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool HighlightMobilesByFlags { get; set; } = true;
         [JsonProperty] public bool ShowMobilesHP { get; set; }
         [JsonProperty] public int MobileHPType { get; set; } // 0 = %, 1 = line, 2 = both
+        [JsonProperty] public int MobileHealthBarHighlight { get; set; } // 0 = never, 1 = targeting, 2 = war-mode, 3 = always
         [JsonProperty] public bool DrawRoofs { get; set; } = true;
         [JsonProperty] public bool TreeToStumps { get; set; }
         [JsonProperty] public bool EnableCaveBorder { get; set; }

--- a/src/Game/GameObjects/Views/MobileView.cs
+++ b/src/Game/GameObjects/Views/MobileView.cs
@@ -75,7 +75,10 @@ namespace ClassicUO.Game.GameObjects
             }
 
             bool isAttack = Serial == World.LastAttack;
-            bool isUnderMouse = IsSelected && (TargetManager.IsTargeting || World.Player.InWarMode);
+            bool isUnderMouse = IsSelected && Engine.Profile.Current.MobileHealthBarHighlight != 0 &&
+                                ((TargetManager.IsTargeting && Engine.Profile.Current.MobileHealthBarHighlight == 1) ||
+                                 (World.Player.InWarMode && Engine.Profile.Current.MobileHealthBarHighlight == 2) ||
+                                 (Engine.Profile.Current.MobileHealthBarHighlight == 3));
             //bool needHpLine = false;
 
             if (this != World.Player && (isAttack || isUnderMouse || TargetManager.LastGameObject == Serial))

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -546,7 +546,10 @@ namespace ClassicUO.Game.UI.Gumps
 
         protected override void OnMouseEnter(int x, int y)
         {
-            if ((TargetManager.IsTargeting || World.Player.InWarMode) && Mobile != null)
+            if ((Engine.Profile.Current.MobileHealthBarHighlight != 0 &&
+                 ((TargetManager.IsTargeting && Engine.Profile.Current.MobileHealthBarHighlight == 1) ||
+                  (World.Player.InWarMode && Engine.Profile.Current.MobileHealthBarHighlight == 2) ||
+                  (Engine.Profile.Current.MobileHealthBarHighlight == 3))) && Mobile != null)
             {
                 Mobile.IsSelected = true;
             }

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -73,7 +73,7 @@ namespace ClassicUO.Game.UI.Gumps
         // GameWindowSize
         private TextBox _gameWindowWidth;
         private Checkbox _highlightObjects, /*_smoothMovements,*/ _enablePathfind, _alwaysRun, _preloadMaps, _showHpMobile, _highlightByState, _drawRoofs, _treeToStumps, _hideVegetation, _noColorOutOfRangeObjects, _useCircleOfTransparency, _enableTopbar, _holdDownKeyTab, _holdDownKeyAlt, _chatAfterEnter, _chatIgnodeHotkeysCheckbox, _chatIgnodeHotkeysPluginsCheckbox, _chatAdditionalButtonsCheckbox, _chatShiftEnterCheckbox, _enableCaveBorder;
-        private Combobox _hpComboBox, _healtbarType;
+        private Combobox _hpComboBox, _healtbarType, _mobileHealthBarHighlight;
 
         // combat & spells
         private ColorBox _innocentColorPickerBox, _friendColorPickerBox, _crimialColorPickerBox, _genericColorPickerBox, _enemyColorPickerBox, _murdererColorPickerBox, _neutralColorPickerBox, _beneficColorPickerBox, _harmfulColorPickerBox;
@@ -324,6 +324,29 @@ namespace ClassicUO.Game.UI.Gumps
                 IsChecked = Engine.Profile.Current.UseCircleOfTransparency
             };
             hpAreaItem.Add(_useCircleOfTransparency);
+
+            // HealthBar Highlight
+
+            mode = Engine.Profile.Current.MobileHealthBarHighlight;
+
+            if (mode < 0 || mode > 2)
+                mode = 3;
+
+            text = new Label("Highlight on health bar mouseover:", true, HUE_FONT, font: FONT)
+            {
+                Y = _useCircleOfTransparency.Bounds.Bottom + 10
+            };
+            hpAreaItem.Add(text);
+
+            _mobileHealthBarHighlight = new Combobox(text.Bounds.Right + 10,
+                _useCircleOfTransparency.Bounds.Bottom + 10, 130, new[]
+                {
+                    "Never", "Targeting", "Warmode", "Always"
+                }, mode);
+
+            hpAreaItem.Add(_mobileHealthBarHighlight);
+
+            // HealthBar Highlight End
 
             rightArea.Add(hpAreaItem);
             Add(rightArea, PAGE);
@@ -961,6 +984,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _useCircleOfTransparency.IsChecked = false;
                     _preloadMaps.IsChecked = false;
                     _healtbarType.SelectedIndex = 0;
+                    _mobileHealthBarHighlight.SelectedIndex = 3;
 
                     break;
                 case 2: // sounds
@@ -1114,6 +1138,7 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.NoColorObjectsOutOfRange = _noColorOutOfRangeObjects.IsChecked;
             Engine.Profile.Current.UseCircleOfTransparency = _useCircleOfTransparency.IsChecked;
             Engine.Profile.Current.CircleOfTransparencyRadius = _circleOfTranspRadius.Value;
+            Engine.Profile.Current.MobileHealthBarHighlight = _mobileHealthBarHighlight.SelectedIndex;
 
             // sounds
             Engine.Profile.Current.EnableSound = _enableSounds.IsChecked;


### PR DESCRIPTION
On the standard client, it will always highlight on mouseover regardless of mobile state. This commit gives CUO that option along with additional options (never, warmode, targeting and always)