### PR TITLE
Changed auto-follow to mimic standard client behavior

### DIFF
--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -577,8 +577,12 @@ namespace ClassicUO.Game.Scenes
 
                     if (distance > World.ViewRange)
                         StopFollowing();
-                    else if (distance > 1)
+                    else if (distance > 3)
                         Pathfinder.WalkTo(follow.X, follow.Y, follow.Z, 1);
+                }
+                else
+                {
+                    StopFollowing();
                 }
             }
 

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -266,7 +266,7 @@ namespace ClassicUO.Game.Scenes
 
                         if (Keyboard.Alt)
                         {
-                            World.Player.AddOverhead(MessageType.Regular, "Now following!", 3, 0, false);
+                            World.Player.AddOverhead(MessageType.Regular, "Now following.", 3, 0, false);
                             _followingMode = true;
                             _followingTarget = ent;
                         }
@@ -350,7 +350,7 @@ namespace ClassicUO.Game.Scenes
                 _followingMode = false;
                 _followingTarget = Serial.INVALID;
                 Pathfinder.StopAutoWalk();
-                World.Player.AddOverhead(MessageType.Regular, "Stop following!", 3, 0, false);
+                World.Player.AddOverhead(MessageType.Regular, "Stopped following.", 3, 0, false);
             }
         }
 


### PR DESCRIPTION
- Follower doesn't start following again until more than 3 tiles away
- When follower is out of range (gating, for example) stop following
- Follow overhead message text matches standard client