### PR TITLE
Fixes Input issue when Page 2 larger than Page 1 of gump

### DIFF
--- a/src/Game/UI/Controls/Control.cs
+++ b/src/Game/UI/Controls/Control.cs
@@ -369,6 +369,8 @@ namespace ClassicUO.Game.UI.Controls
 
         public virtual void OnPageChanged()
         {
+            //Update size as pages may vary in size.
+            WantUpdateSize = true;
         }
 
         private void DrawDebug(UltimaBatcher2D batcher, int x, int y)


### PR DESCRIPTION
Example gump that has this behavior is https://github.com/runuo/runuo/blob/master/Scripts/Engines/ConPVP/ReadyUpGump.cs#L197

where the second page can be lots taller than the first depending on rules selected.