### PR TITLE
Remove "Shift to Walk" (for both mouse and keyboard move)

### DIFF
--- a/src/Game/GameObjects/PlayerMobile.cs
+++ b/src/Game/GameObjects/PlayerMobile.cs
@@ -1696,7 +1696,7 @@ namespace ClassicUO.Game.GameObjects
             if (SpeedMode >= CharacterSpeedType.CantRun || Stamina <= 1 && !IsDead)
                 run = false;
             else if (!run)
-                run = Engine.Profile.Current.AlwaysRun && !Keyboard.Shift;
+                run = Engine.Profile.Current.AlwaysRun;
 
             int x = X;
             int y = Y;

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -106,15 +106,7 @@ namespace ClassicUO.Game.Scenes
                     direction = _numPadDirection;
                 }
 
-                if (_isShiftDown)
-                {
-                    World.Player.Walk(direction, false);
-                }
-                else
-                {
-                    World.Player.Walk(direction, true);
-                }
-
+                World.Player.Walk(direction, Engine.Profile.Current.AlwaysRun);
             }
         }
 


### PR DESCRIPTION
Hard coded Shift-to-Walk has caused undesirable effects, main example is slowing the player when using Ctrl+Shift while running.

The macro system has AlwaysRun as a toggle key which satisfies people who want to use Always Run but also walk when they need to.