### PR TITLE
Fix for pathfinding diagonals (and therefore autowalk)

### DIFF
--- a/src/Game/Pathfinder.cs
+++ b/src/Game/Pathfinder.cs
@@ -490,7 +490,7 @@ namespace ClassicUO.Game
 
         private static int GetGoalDistCost(Point point, int cost)
         {
-            return (Math.Abs(_endPoint.X - point.X) + Math.Abs(_endPoint.Y - point.Y)) * cost;
+            return Math.Max(Math.Abs(_endPoint.X - point.X), Math.Abs(_endPoint.Y - point.Y));
         }
 
         private static bool DoesNotExistOnOpenList(int x, int y, int z)
@@ -638,11 +638,11 @@ namespace ClassicUO.Game
                         int wantY = node.Y;
                         GetNewXY((byte) wantDirection, ref wantX, ref wantY);
 
-                        if (x != wantY || y != wantY)
+                        if (x != wantX || y != wantY)
                             diagonal = -1;
                     }
 
-                    if (diagonal >= 0 && AddNodeToList(0, (int) direction, x, y, z, node, 1 + diagonal) != -1)
+                    if (diagonal >= 0 && AddNodeToList(0, (int)direction, x, y, z, node, 1) != -1)
                         found = true;
                 }
             }


### PR DESCRIPTION
At the moment, pathfinder will not move diagonally because of a typo (comparing x to wantY instead of wantX), and also because diagonals have higher 'cost' even though they shouldn't on the UO grid.

It's not perfect, some unnecessary zig-zagging towards walls at times and too many turns being made, but it's a lot better. Next step would be to potentially prefer routes with less changes of direction.