### PR TITLE
[Bugfix] Doors open on DIrection Change, and Dont open corpses with Target Cursor up

### DIFF
--- a/src/Game/GameObjects/Entity.cs
+++ b/src/Game/GameObjects/Entity.cs
@@ -124,6 +124,7 @@ namespace ClassicUO.Game.GameObjects
                 {
                     _direction = value;
                     _delta |= Delta.Position;
+                    OnDirectionChanged();
                 }
             }
         }

--- a/src/Game/GameObjects/GameObject.cs
+++ b/src/Game/GameObjects/GameObject.cs
@@ -242,7 +242,9 @@ namespace ClassicUO.Game.GameObjects
         protected virtual void OnPositionChanged()
         {
         }
-
+        protected virtual void OnDirectionChanged()
+        {
+        }
 
         public virtual void Destroy()
         {

--- a/src/Game/GameObjects/PlayerMobile.cs
+++ b/src/Game/GameObjects/PlayerMobile.cs
@@ -1656,6 +1656,26 @@ namespace ClassicUO.Game.GameObjects
 
             Plugin.UpdatePlayerPosition(X, Y, Z);
             
+            TryOpenDoors();
+            
+            if (Engine.Profile.Current.AutoOpenCorpses && !TargetManager.IsTargeting)
+            {
+                foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && !OpenedCorpses.Contains(t.Serial) && t.Distance <= Engine.Profile.Current.AutoOpenCorpseRange))
+                {
+                    OpenedCorpses.Add(c.Serial);
+                    GameActions.DoubleClick(c.Serial);
+                }
+            }
+        }
+
+        protected override void OnDirectionChanged()
+        {
+            base.OnDirectionChanged();
+            TryOpenDoors();
+        }
+
+        private void TryOpenDoors()
+        {
             if (Engine.Profile.Current.AutoOpenDoors)
             {
                 int x = Position.X, y = Position.Y, z = Position.Z;
@@ -1665,15 +1685,6 @@ namespace ClassicUO.Game.GameObjects
                     s.Position.Z + 15 >= z))
                 {                    
                     GameActions.OpenDoor();
-                }
-            }
-            
-            if (Engine.Profile.Current.AutoOpenCorpses)
-            {
-                foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && !OpenedCorpses.Contains(t.Serial) && t.Distance <= Engine.Profile.Current.AutoOpenCorpseRange))
-                {
-                    OpenedCorpses.Add(c.Serial);
-                    GameActions.DoubleClick(c.Serial);
                 }
             }
         }


### PR DESCRIPTION
This adds OpenDoors to Direction Change not just movement, and also blocks attempting to open corpses with a target cursor up.

Thanks to Ace Mason for reporting both these issues.
