### PR TITLE
Disable default UO hotkeys + New Macro (aura, auraonoff, moveplayer)

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -51,9 +51,7 @@ namespace ClassicUO.Configuration
         }
 
         [JsonProperty] public string Username { get; }
-
         [JsonProperty] public string ServerName { get; }
-
         [JsonProperty] public string CharacterName { get; }
 
         // sounds
@@ -110,17 +108,13 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool NoColorObjectsOutOfRange { get; set; }
         [JsonProperty] public bool UseCircleOfTransparency { get; set; }
         [JsonProperty] public int CircleOfTransparencyRadius { get; set; } = 5;
-
         [JsonProperty] public int VendorGumpHeight { get; set; } = 60; //original vendor gump size
-
         [JsonProperty] public float ScaleZoom { get; set; } = 1.0f;
         [JsonProperty] public float RestoreScaleValue { get; set; } = 1.0f;
         [JsonProperty] public bool EnableScaleZoom { get; set; }
         [JsonProperty] public bool SaveScaleAfterClose { get; set; }
         [JsonProperty] public bool RestoreScaleAfterUnpressCtrl { get; set; }
-
         [JsonProperty] public bool BandageSelfOld { get; set; } = true;
-
         [JsonProperty] public bool EnableDeathScreen { get; set; } = true;
         [JsonProperty] public bool EnableBlackWhiteEffect { get; set; } = true;
 
@@ -149,7 +143,6 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool UseCustomLightLevel { get; set; }
         [JsonProperty] public byte LightLevel { get; set; }
         [JsonProperty] public int CloseHealthBarType { get; set; } // 0 = none, 1 == not exists, 2 == is dead
-
         [JsonProperty] public bool ActivateChatAfterEnter { get; set; }
         [JsonProperty] public bool ActivateChatStatus { get; set; } = true;
         [JsonProperty] public bool ActivateChatIgnoreHotkeys { get; set; } = true;
@@ -164,12 +157,13 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool DebugGumpIsMinimized { get; set; } = true;
         [JsonProperty] public bool RestoreLastGameSize { get; set; } = false;
         [JsonProperty] public bool CastSpellsByOneClick { get; set; } = false;
-        
         [JsonProperty] public bool AutoOpenDoors { get; set; } = false;
         [JsonProperty] public bool AutoOpenCorpses { get; set; } = false;
         [JsonProperty] public int AutoOpenCorpseRange { get; set; } = 2;
-
-        
+        [JsonProperty] public bool DisableDefaultHotkeys { get; set; } = false;
+        [JsonProperty] public bool DisableArrowBtn { get; set; } = false;
+        [JsonProperty] public bool DisableTabBtn { get; set; } = false;
+        [JsonProperty] public bool DisableCtrlQWBtn { get; set; } = false;
 
         [JsonProperty] public int MaxFPS { get; set; } = 60;
 

--- a/src/Game/Managers/AuraManager.cs
+++ b/src/Game/Managers/AuraManager.cs
@@ -56,8 +56,22 @@ namespace ClassicUO.Game.Managers
             }
         }
 
-        public Texture2D AuraTexture { get; private set; }
+        private int _saveAuraUnderFeetType;
 
+        public void ToggleVisibility()
+        {
+            if (!IsEnabled)
+            {
+                _saveAuraUnderFeetType = Engine.Profile.Current.AuraUnderFeetType;
+                Engine.Profile.Current.AuraUnderFeetType = 3;
+            }
+            else
+            {
+                Engine.Profile.Current.AuraUnderFeetType = _saveAuraUnderFeetType;
+            }
+        }
+
+        public Texture2D AuraTexture { get; private set; }
 
         public void CreateAuraTexture(int radius = 30)
         {

--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -66,8 +66,6 @@ namespace ClassicUO.Game.Managers
         private MacroObject _lastMacro;
         private long _nextTimer;
 
-        private WorldViewportGump viewport;
-
         public MacroManager(Macro[] macros)
         {
             if (macros != null)
@@ -926,6 +924,29 @@ namespace ClassicUO.Game.Managers
                 case MacroType.ToggleChatVisibility:
                     Engine.UI.SystemChat?.ToggleChatVisibility();
                     break;
+
+                case MacroType.MovePlayer:
+                    switch (macro.SubCode)
+                    {
+                        case MacroSubType.Top:
+                            break;
+                        case MacroSubType.Right:
+                            break;
+                        case MacroSubType.Down:
+                            break;
+                        case MacroSubType.Left:
+                            break;
+                    }
+                    break;
+
+                case MacroType.Aura:
+                    // hold to draw
+                    break;
+
+                case MacroType.AuraOnOff:
+                    Engine.AuraManager.ToggleVisibility();
+                    break;
+
             }
 
 
@@ -1020,42 +1041,46 @@ namespace ClassicUO.Game.Managers
                 case MacroType.Walk:
                     offset = (int) MacroSubType.NW;
                     count = (int) MacroSubType.Configuration - (int) MacroSubType.NW;
-
                     break;
+
                 case MacroType.Open:
                 case MacroType.Close:
                 case MacroType.Minimize:
                 case MacroType.Maximize:
                     offset = (int) MacroSubType.Configuration;
                     count = (int) MacroSubType.Anatomy - (int) MacroSubType.Configuration;
-
                     break;
+
                 case MacroType.UseSkill:
                     offset = (int) MacroSubType.Anatomy;
                     count = (int) MacroSubType.LeftHand - (int) MacroSubType.Anatomy;
-
                     break;
+
                 case MacroType.ArmDisarm:
                     offset = (int) MacroSubType.LeftHand;
                     count = (int) MacroSubType.Honor - (int) MacroSubType.LeftHand;
-
                     break;
+
                 case MacroType.InvokeVirtue:
                     offset = (int) MacroSubType.Honor;
                     count = (int) MacroSubType.Clumsy - (int) MacroSubType.Honor;
-
                     break;
+
                 case MacroType.CastSpell:
                     offset = (int) MacroSubType.Clumsy;
                     count = (int) MacroSubType.Hostile - (int) MacroSubType.Clumsy;
-
                     break;
+
                 case MacroType.SelectNext:
                 case MacroType.SelectPrevious:
                 case MacroType.SelectNearest:
                     offset = (int) MacroSubType.Hostile;
                     count = (int) MacroSubType.MscTotalCount - (int) MacroSubType.Hostile;
+                    break;
 
+                case MacroType.MovePlayer:
+                    offset = (int)MacroSubType.Top;
+                    count = 4;
                     break;
             }
         }
@@ -1084,6 +1109,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.SelectNext:
                 case MacroType.SelectPrevious:
                 case MacroType.SelectNearest:
+                case MacroType.MovePlayer:
 
                     if (sub == MacroSubType.MSC_NONE)
                     {
@@ -1205,7 +1231,10 @@ namespace ClassicUO.Game.Managers
         BandageTarget,
         ToggleGargoyleFly,
         DefaultScale,
-        ToggleChatVisibility
+        ToggleChatVisibility,
+        MovePlayer,
+        Aura,
+        AuraOnOff
     }
 
     internal enum MacroSubType
@@ -1421,6 +1450,10 @@ namespace ClassicUO.Game.Managers
         Follower,
         Object,
         Mobile,
-        MscTotalCount
+        MscTotalCount,
+        Top,
+        Right,
+        Down,
+        Left
     }
 }

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -577,10 +577,13 @@ namespace ClassicUO.Game.Scenes
 
             if (_rightMousePressed || _continueRunning)
                 MoveCharacterByMouseInput();
-            else if (_arrowKeyPressed)
-                MoveCharacterByKeyboardInput(false);
-            else if (_numPadKeyPressed)
-                MoveCharacterByKeyboardInput(true);
+            else if (!Engine.Profile.Current.DisableArrowBtn || _isMacroMoveDown)
+            {
+                if (_arrowKeyPressed)
+                    MoveCharacterByKeyboardInput(false);
+                else if (_numPadKeyPressed)
+                    MoveCharacterByKeyboardInput(true);
+            }
 
             if (_followingMode && _followingTarget.IsMobile && !Pathfinder.AutoWalking)
             {
@@ -615,7 +618,6 @@ namespace ClassicUO.Game.Scenes
 
             _useItemQueue.Update(totalMS, frameMS);
 
-
             if (!IsMouseOverViewport)
                 Game.SelectedObject.Object = Game.SelectedObject.LastObject = null;
             else
@@ -643,8 +645,6 @@ namespace ClassicUO.Game.Scenes
                     {
                         Engine.UI.Add(_deathScreenLabel = new Label("You are dead.", false, 999, 200, 3)
                         {
-                            //X = ((Engine.Profile.Current.GameWindowSize.X - Engine.Profile.Current.GameWindowPosition.X) >> 1) - 50,
-                            //Y = ((Engine.Profile.Current.GameWindowSize.Y - Engine.Profile.Current.GameWindowPosition.Y) >> 1) - 50,
                             X = (Engine.WindowWidth >> 1) - 50,
                             Y = (Engine.WindowHeight >> 1) - 50
                         });
@@ -659,8 +659,7 @@ namespace ClassicUO.Game.Scenes
             }
 
             DrawWorld(batcher);
-
-
+             
             Game.SelectedObject.LastObject = Game.SelectedObject.Object;
 
             return base.Draw(batcher);

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -56,8 +56,9 @@ namespace ClassicUO.Game.UI.Gumps
         private HSliderBar _cellSize;
 
         //experimental
-        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn;
         private TextBox _autoOpenCorpseRange;
+        private ScrollAreaItem _defaultHotkeysArea, _autoOpenCorpseArea;
 
         // sounds
         private Checkbox _enableSounds, _enableMusic, _footStepsSound, _combatMusic, _musicInBackground, _loginMusic;
@@ -917,10 +918,13 @@ namespace ClassicUO.Game.UI.Gumps
             _restoreLastGameSize = CreateCheckBox(rightArea, "Disable automatic maximize. Restore windows size after re-login", Engine.Profile.Current.RestoreLastGameSize, 0, 0);
 
             _autoOpenDoors = CreateCheckBox(rightArea, "Auto Open Doors", Engine.Profile.Current.AutoOpenDoors, 0, 0);
-            _autoOpenCorpse = CreateCheckBox(rightArea, "Auto Open Corpses", Engine.Profile.Current.AutoOpenCorpses, 0, 0);
-            var item = new ScrollAreaItem();
 
-            _autoOpenCorpseRange = CreateInputField(item,new TextBox(FONT, 2, 80, 80, true)
+            _autoOpenCorpseArea = new ScrollAreaItem();
+
+            _autoOpenCorpse = CreateCheckBox(rightArea, "Auto Open Corpses", Engine.Profile.Current.AutoOpenCorpses, 0, 0);
+            _autoOpenCorpse.ValueChanged += (sender, e) => { _autoOpenCorpseArea.IsVisible = _autoOpenCorpse.IsChecked; };
+
+            _autoOpenCorpseRange = CreateInputField(_autoOpenCorpseArea, new TextBox(FONT, 2, 80, 80, true)
             {
                 X = 20,
                 Y = _cellSize.Y + _cellSize.Height - 15,
@@ -929,9 +933,54 @@ namespace ClassicUO.Game.UI.Gumps
                 NumericOnly = true,
                 Text = Engine.Profile.Current.AutoOpenCorpseRange.ToString()
             }, "Corpse Open Range:");
-            rightArea.Add(item);
-            
+
+            rightArea.Add(_autoOpenCorpseArea);
+
+            // [BLOCK] disable hotkeys
+            {
+                _disableDefaultHotkeys = new Checkbox(0x00D2, 0x00D3, "Disable default UO hotkeys", FONT, HUE_FONT, true)
+                {
+                    Y = 0,
+                    IsChecked = Engine.Profile.Current.DisableDefaultHotkeys
+                };
+                _disableDefaultHotkeys.ValueChanged += (sender, e) => { _defaultHotkeysArea.IsVisible = _disableDefaultHotkeys.IsChecked; };
+
+                rightArea.Add(_disableDefaultHotkeys);
+
+                _defaultHotkeysArea = new ScrollAreaItem();
+
+                _disableArrowBtn = new Checkbox(0x00D2, 0x00D3, "Disable arrows & numlock arrows (player moving)", FONT, HUE_FONT, true)
+                {
+                    X = 20,
+                    Y = 15,
+                    IsChecked = Engine.Profile.Current.DisableArrowBtn
+                };
+                _defaultHotkeysArea.Add(_disableArrowBtn);
+
+                _disableTabBtn = new Checkbox(0x00D2, 0x00D3, "Disable TAB (toggle warmode)", FONT, HUE_FONT, true)
+                {
+                    X = 20,
+                    Y = 35,
+                    IsChecked = Engine.Profile.Current.DisableTabBtn
+                };
+                _defaultHotkeysArea.Add(_disableTabBtn);
+
+                _disableCtrlQWBtn = new Checkbox(0x00D2, 0x00D3, "Disable Ctrl + Q/W (messageHistory)", FONT, HUE_FONT, true)
+                {
+                    X = 20,
+                    Y = 55,
+                    IsChecked = Engine.Profile.Current.DisableCtrlQWBtn
+                };
+                _defaultHotkeysArea.Add(_disableCtrlQWBtn);
+
+                rightArea.Add(_defaultHotkeysArea);
+
+                _defaultHotkeysArea.IsVisible = _disableDefaultHotkeys.IsChecked;
+            }
+
             Add(rightArea, PAGE);
+
+            _autoOpenCorpseArea.IsVisible = _autoOpenCorpse.IsChecked;
         }
 
         private void BuildNetwork()
@@ -991,8 +1040,6 @@ namespace ClassicUO.Game.UI.Gumps
                     _enableTopbar.IsChecked = false;
                     _holdDownKeyTab.IsChecked = true;
                     _holdDownKeyAlt.IsChecked = true;
-
-                    //_smoothMovements.IsChecked = true;
                     _enablePathfind.IsChecked = false;
                     _alwaysRun.IsChecked = false;
                     _showHpMobile.IsChecked = false;
@@ -1009,8 +1056,8 @@ namespace ClassicUO.Game.UI.Gumps
                     _fieldsType.SelectedIndex = 0;
                     _vendorGumpSize.Text = "60";
                     _useStandardSkillsGump.IsChecked = true;
-
                     break;
+
                 case 2: // sounds
                     _enableSounds.IsChecked = true;
                     _enableMusic.IsChecked = true;
@@ -1023,8 +1070,8 @@ namespace ClassicUO.Game.UI.Gumps
                     _loginMusic.IsChecked = true;
                     _soundsVolume.IsVisible = _enableSounds.IsChecked;
                     _musicVolume.IsVisible = _enableMusic.IsChecked;
-
                     break;
+
                 case 3: // video
                     _debugControls.IsChecked = false;
                     _zoomCheckbox.IsChecked = false;
@@ -1051,18 +1098,18 @@ namespace ClassicUO.Game.UI.Gumps
 
                     _windowSizeArea.IsVisible = !_gameWindowFullsize.IsChecked;
                     _zoomSizeArea.IsVisible = _zoomCheckbox.IsChecked;
-
                     break;
+
                 case 4: // commands
-
                     break;
+
                 case 5: // tooltip
-
                     break;
+
                 case 6: // fonts
                     _fontSelectorChat.SetSelectedFont(0);
-
                     break;
+
                 case 7: // speech
                     _scaleSpeechDelay.IsChecked = true;
                     _sliderSpeechDelay.Value = 100;
@@ -1071,19 +1118,16 @@ namespace ClassicUO.Game.UI.Gumps
                     _partyMessageColorPickerBox.SetColor(0x0044, FileManager.Hues.GetPolygoneColor(12, 0x0044));
                     _guildMessageColorPickerBox.SetColor(0x0044, FileManager.Hues.GetPolygoneColor(12, 0x0044));
                     _allyMessageColorPickerBox.SetColor(0x0057, FileManager.Hues.GetPolygoneColor(12, 0x0057));
-
                     _chatAfterEnter.IsChecked = false;
-
                     Engine.UI.SystemChat.IsActive = !_chatAfterEnter.IsChecked;
-
                     _chatIgnodeHotkeysCheckbox.IsChecked = true;
                     _chatIgnodeHotkeysPluginsCheckbox.IsChecked = true;
                     _chatAdditionalButtonsCheckbox.IsChecked = true;
                     _chatShiftEnterCheckbox.IsChecked = true;
                     _activeChatArea.IsVisible = _chatAfterEnter.IsChecked;
                     _saveJournalCheckBox.IsChecked = false;
-
                     break;
+
                 case 8: // combat
                     _innocentColorPickerBox.SetColor(0x005A, FileManager.Hues.GetPolygoneColor(12, 0x005A));
                     _friendColorPickerBox.SetColor(0x0044, FileManager.Hues.GetPolygoneColor(12, 0x0044));
@@ -1093,7 +1137,6 @@ namespace ClassicUO.Game.UI.Gumps
                     _enemyColorPickerBox.SetColor(0x0031, FileManager.Hues.GetPolygoneColor(12, 0x0031));
                     _queryBeforAttackCheckbox.IsChecked = true;
                     _castSpellsByOneClick.IsChecked = false;
-
                     _beneficColorPickerBox.SetColor(0x0059, FileManager.Hues.GetPolygoneColor(12, 0x0059));
                     _harmfulColorPickerBox.SetColor(0x0020, FileManager.Hues.GetPolygoneColor(12, 0x0020));
                     _neutralColorPickerBox.SetColor(0x03B1, FileManager.Hues.GetPolygoneColor(12, 0x03B1));
@@ -1101,6 +1144,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _spellColoringCheckbox.IsChecked = false;
                     _spellFormatCheckbox.IsChecked = false;
                     break;
+
                 case 9:
                     _enableCounters.IsChecked = false;
                     _highlightOnUse.IsChecked = false;
@@ -1109,15 +1153,18 @@ namespace ClassicUO.Game.UI.Gumps
                     _cellSize.Value = 40;
                     _highlightOnAmount.IsChecked = false;
                     _highlightAmount.Text = "5";
-
                     break;
 
                 case 10:
                     _enableSelectionArea.IsChecked = false;
                     _debugGumpIsDisabled.IsChecked = false;
                     _restoreLastGameSize.IsChecked = false;
-
+                    _disableDefaultHotkeys.IsChecked = false;
+                    _disableArrowBtn.IsChecked = false;
+                    _disableTabBtn.IsChecked = false;
+                    _disableCtrlQWBtn.IsChecked = false;
                     break;
+
                 case 11:
                     _showNetStats.IsChecked = false;
                     break;
@@ -1411,6 +1458,22 @@ namespace ClassicUO.Game.UI.Gumps
             // experimental
             Engine.Profile.Current.EnableSelectionArea = _enableSelectionArea.IsChecked;
             Engine.Profile.Current.RestoreLastGameSize = _restoreLastGameSize.IsChecked;
+
+            Engine.Profile.Current.DisableArrowBtn = _disableArrowBtn.IsChecked;
+            Engine.Profile.Current.DisableTabBtn = _disableTabBtn.IsChecked;
+            Engine.Profile.Current.DisableCtrlQWBtn = _disableTabBtn.IsChecked;
+
+            if (Engine.Profile.Current.DisableDefaultHotkeys != _disableDefaultHotkeys.IsChecked)
+            {
+                if (!_debugGumpIsDisabled.IsChecked)
+                {
+                    Engine.Profile.Current.DisableArrowBtn = false;
+                    Engine.Profile.Current.DisableTabBtn = false;
+                    Engine.Profile.Current.DisableCtrlQWBtn = false;
+                }
+
+                Engine.Profile.Current.DisableDefaultHotkeys = _disableDefaultHotkeys.IsChecked;
+            }
 
             if (Engine.Profile.Current.DebugGumpIsDisabled != _debugGumpIsDisabled.IsChecked)
             {

--- a/src/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/Game/UI/Gumps/SystemChatControl.cs
@@ -362,7 +362,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             switch (key)
             {
-                case SDL.SDL_Keycode.SDLK_q when Input.Keyboard.IsModPressed(mod, SDL.SDL_Keymod.KMOD_CTRL) && _messageHistoryIndex > -1:
+                case SDL.SDL_Keycode.SDLK_q when Input.Keyboard.IsModPressed(mod, SDL.SDL_Keymod.KMOD_CTRL) && _messageHistoryIndex > -1 && !Engine.Profile.Current.DisableCtrlQWBtn:
 
                     if (!IsActive)
                         IsActive = true;
@@ -375,7 +375,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                     break;
 
-                case SDL.SDL_Keycode.SDLK_w when Input.Keyboard.IsModPressed(mod, SDL.SDL_Keymod.KMOD_CTRL):
+                case SDL.SDL_Keycode.SDLK_w when Input.Keyboard.IsModPressed(mod, SDL.SDL_Keymod.KMOD_CTRL) && !Engine.Profile.Current.DisableCtrlQWBtn:
 
                     if (!IsActive)
                         IsActive = true;


### PR DESCRIPTION
![41MbdE5](https://user-images.githubusercontent.com/1370602/58437387-6c4d3f00-80d2-11e9-9a4e-bf0277a142a8.jpg)
![3dd4f-clip-126kb](https://user-images.githubusercontent.com/1370602/58437389-6c4d3f00-80d2-11e9-881b-287368006d6c.jpg)

Disable default UO hotkeys
- Disable arrows & numlock arrows (player moving)
- Disable TAB (toggle warmode)
- Disable Ctrl + Q/W (messageHistory)

New Macro "MovePlayer": 
- Top, Right, Down, Left

New macro: 
- Aura - hold to draw aura, 
- AuraOnOff - toggle aura visibility

_Multiple button support (top+left etc) but works only 1 "MovePlayer" for one macro button._

#441 + I remember request for non-standard player movement buttons
I think we should develop it further to improve flexibility.
