### PR TITLE
Clothing layerorder fix

### DIFF
--- a/src/Game/Data/LayerOrder.cs
+++ b/src/Game/Data/LayerOrder.cs
@@ -28,28 +28,28 @@ namespace ClassicUO.Game.Data
         public static Layer[,] UsedLayers { get; } = new Layer[8, Constants.USED_LAYER_COUNT]
         {
             {
-                Layer.Cloak, Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Helmet, Layer.TwoHanded
+                Layer.Cloak, Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             }
         };
     }

--- a/src/Game/Data/LayerOrder.cs
+++ b/src/Game/Data/LayerOrder.cs
@@ -28,28 +28,28 @@ namespace ClassicUO.Game.Data
         public static Layer[,] UsedLayers { get; } = new Layer[8, Constants.USED_LAYER_COUNT]
         {
             {
-                Layer.Cloak, Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Necklace, Layer.Hair, Layer.Robe, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Helmet, Layer.TwoHanded
+                Layer.Cloak, Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Necklace, Layer.Hair, Layer.Robe, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Necklace, Layer.Hair, Layer.Robe, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Necklace, Layer.Hair, Layer.Robe, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Necklace, Layer.Hair, Layer.Robe, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Necklace, Layer.Hair, Layer.Robe, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Necklace, Layer.Hair, Layer.Robe, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             },
             {
-                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs, Layer.Torso, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Necklace, Layer.Hair, Layer.Robe, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
+                Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Torso, Layer.Legs, Layer.Ring, Layer.Talisman, Layer.Bracelet, Layer.Face, Layer.Arms, Layer.Gloves, Layer.Skirt, Layer.Tunic, Layer.Robe, Layer.Necklace, Layer.Hair, Layer.Waist, Layer.Beard, Layer.Earrings, Layer.OneHanded, Layer.Cloak, Layer.Helmet, Layer.TwoHanded
             }
         };
     }

--- a/src/Game/GameObjects/Views/MobileView.cs
+++ b/src/Game/GameObjects/Views/MobileView.cs
@@ -532,8 +532,8 @@ namespace ClassicUO.Game.GameObjects
                         tunic = mobile.Equipment[(int) Layer.Tunic];
                         Item torso = mobile.Equipment[(int) Layer.Torso];
 
-                        if (tunic != null && tunic.Graphic != 0x1541 && tunic.Graphic != 0x1542)
-                            return true;
+                        //if (tunic != null && tunic.Graphic != 0x1541 && tunic.Graphic != 0x1542)
+                        //    return true;
 
                         if (torso != null && (torso.Graphic == 0x782A || torso.Graphic == 0x782B))
                             return true;

--- a/src/Game/UI/Controls/PaperDollInteractable.cs
+++ b/src/Game/UI/Controls/PaperDollInteractable.cs
@@ -34,7 +34,7 @@ namespace ClassicUO.Game.UI.Controls
         private static readonly Layer[] _layerOrder =
         {
             Layer.Cloak, Layer.Ring, Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs,
-            Layer.Torso, Layer.Arms, Layer.Bracelet, Layer.Face, Layer.Gloves, Layer.Tunic, Layer.Skirt, Layer.Necklace,
+            Layer.Arms, Layer.Torso, Layer.Bracelet, Layer.Face, Layer.Gloves, Layer.Tunic, Layer.Skirt, Layer.Necklace,
             Layer.Hair, Layer.Robe, Layer.Earrings, Layer.Beard, Layer.Helmet, Layer.Waist, Layer.OneHanded, Layer.TwoHanded, Layer.Talisman
         };
 

--- a/src/Game/UI/Controls/PaperDollInteractable.cs
+++ b/src/Game/UI/Controls/PaperDollInteractable.cs
@@ -34,7 +34,7 @@ namespace ClassicUO.Game.UI.Controls
         private static readonly Layer[] _layerOrder =
         {
             Layer.Cloak, Layer.Ring, Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs,
-            Layer.Arms, Layer.Torso, Layer.Bracelet, Layer.Face, Layer.Gloves, Layer.Tunic, Layer.Skirt, Layer.Necklace,
+            Layer.Torso, Layer.Arms, Layer.Bracelet, Layer.Face, Layer.Gloves, Layer.Tunic, Layer.Skirt, Layer.Necklace,
             Layer.Hair, Layer.Robe, Layer.Earrings, Layer.Beard, Layer.Helmet, Layer.Waist, Layer.OneHanded, Layer.TwoHanded, Layer.Talisman
         };
 


### PR DESCRIPTION
Hair and Necklace should draw above Robe
![image](https://user-images.githubusercontent.com/7057924/58753304-e572da80-84b4-11e9-9c1f-783dcc3ba86e.png)

Tunic "covers" Torso and prevents rendering of Torso (I have not found a tunic which does completely block torso rendering)
![image](https://user-images.githubusercontent.com/7057924/58753365-f96b0c00-84b5-11e9-85b9-d320326ed2e3.png)

There are also issues with paperdoll order, where arms are rendered above the torso, but in most cases this shouldn't be. Plate arms should render above torso but other arms below. Perhaps plate arms should be assigned a "fake" layer (Layers.PlateArms) but I'm not sure of the implications.