### PR TITLE
Add Further options for corpse opening, None, Hiding, Targeting, Both.

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -160,6 +160,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool AutoOpenDoors { get; set; } = false;
         [JsonProperty] public bool AutoOpenCorpses { get; set; } = false;
         [JsonProperty] public int AutoOpenCorpseRange { get; set; } = 2;
+        [JsonProperty] public int CorpseOpenOptions { get; set; } = 3;
         [JsonProperty] public bool DisableDefaultHotkeys { get; set; } = false;
         [JsonProperty] public bool DisableArrowBtn { get; set; } = false;
         [JsonProperty] public bool DisableTabBtn { get; set; } = false;

--- a/src/Game/GameObjects/PlayerMobile.cs
+++ b/src/Game/GameObjects/PlayerMobile.cs
@@ -1657,8 +1657,12 @@ namespace ClassicUO.Game.GameObjects
             
             TryOpenDoors();
             
-            if (Engine.Profile.Current.AutoOpenCorpses && !TargetManager.IsTargeting)
+            if (Engine.Profile.Current.AutoOpenCorpses)
             {
+                if ((Engine.Profile.Current.CorpseOpenOptions == 1 ||  Engine.Profile.Current.CorpseOpenOptions == 3) && TargetManager.IsTargeting )
+                    return;
+                if ((Engine.Profile.Current.CorpseOpenOptions == 2 ||  Engine.Profile.Current.CorpseOpenOptions == 3) && IsHidden )
+                    return;
                 foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && !OpenedCorpses.Contains(t.Serial) && t.Distance <= Engine.Profile.Current.AutoOpenCorpseRange))
                 {
                     OpenedCorpses.Add(c.Serial);
@@ -1666,6 +1670,7 @@ namespace ClassicUO.Game.GameObjects
                 }
             }
         }
+        
 
         protected override void OnDirectionChanged()
         {

--- a/src/Game/GameObjects/PlayerMobile.cs
+++ b/src/Game/GameObjects/PlayerMobile.cs
@@ -1656,7 +1656,12 @@ namespace ClassicUO.Game.GameObjects
             Plugin.UpdatePlayerPosition(X, Y, Z);
             
             TryOpenDoors();
-            
+            TryOpenCorpses();
+          
+        }
+
+        public void TryOpenCorpses()
+        {
             if (Engine.Profile.Current.AutoOpenCorpses)
             {
                 if ((Engine.Profile.Current.CorpseOpenOptions == 1 ||  Engine.Profile.Current.CorpseOpenOptions == 3) && TargetManager.IsTargeting )
@@ -1668,7 +1673,7 @@ namespace ClassicUO.Game.GameObjects
                     OpenedCorpses.Add(c.Serial);
                     GameActions.DoubleClick(c.Serial);
                 }
-            }
+            } 
         }
         
 

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -58,6 +58,7 @@ namespace ClassicUO.Game.UI.Gumps
         //experimental
         private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn;
         private TextBox _autoOpenCorpseRange;
+        private Combobox _autoOpenCorpseOptions;
         private ScrollAreaItem _defaultHotkeysArea, _autoOpenCorpseArea;
 
         // sounds
@@ -949,6 +950,32 @@ namespace ClassicUO.Game.UI.Gumps
                 NumericOnly = true,
                 Text = Engine.Profile.Current.AutoOpenCorpseRange.ToString()
             }, "Corpse Open Range:");
+            
+            /* text = new Label("- Aura under feet:", true, HUE_FONT, 0, FONT)
+            {
+                Y = 10
+            };
+            item.Add(text);
+
+            _auraType = new Combobox(text.Width + 20, text.Y, 100, new[] {"None", "Warmode", "Ctrl+Shift", "Always"})
+            {
+                SelectedIndex = Engine.Profile.Current.AuraUnderFeetType
+            };*/
+            var text = new Label("Corpse Open Options:", true, HUE_FONT, 0, FONT)
+            {
+                Y = _autoOpenCorpseRange.Y + 30,
+                X = 10
+            };
+            _autoOpenCorpseArea.Add(text);
+            
+            _autoOpenCorpseOptions = new Combobox(text.Width + 20, text.Y, 150, new[]
+            {
+                "None", "Not Targeting", "Not Hiding", "Both"
+            })  
+            {
+                SelectedIndex = Engine.Profile.Current.CorpseOpenOptions
+            };
+            _autoOpenCorpseArea.Add(_autoOpenCorpseOptions);
 
             rightArea.Add(_autoOpenCorpseArea);
 
@@ -1529,7 +1556,7 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.AutoOpenDoors = _autoOpenDoors.IsChecked;
             Engine.Profile.Current.AutoOpenCorpses = _autoOpenCorpse.IsChecked;
             Engine.Profile.Current.AutoOpenCorpseRange = int.Parse(_autoOpenCorpseRange.Text);
-
+            Engine.Profile.Current.CorpseOpenOptions = _autoOpenCorpseOptions.SelectedIndex;
             
 
             // network

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -582,6 +582,11 @@ namespace ClassicUO.Network
             {
                 GameActions.SingleClick(item);
             }
+
+            if (graphic == 0x2006 && Engine.Profile.Current.AutoOpenCorpses)
+            {
+                World.Player.TryOpenCorpses();
+            }
         }
 
         private static void EnterWorld(Packet p)


### PR DESCRIPTION
Adds a drop down to the options menu allowing you to choose between None, Not Targeting, Not Hiding, or Both for dealing with corpse opening.

Also attempts to open corpses when a new corpse appears, not just on movement.

