### PR TITLE
fix distance not affecting sound volume if 'play music in bg' option unticked

### DIFF
--- a/src/Game/Managers/AudioManager.cs
+++ b/src/Game/Managers/AudioManager.cs
@@ -57,11 +57,7 @@ namespace ClassicUO.Game.Managers
             if (Engine.Profile == null || Engine.Profile.Current == null || !Engine.Profile.Current.EnableSound || !Engine.Instance.IsActive && !Engine.Profile.Current.ReproduceSoundsInBackground)
                 return;
 
-            if (Engine.Instance.IsActive)
-            {
-                if (!Engine.Profile.Current.ReproduceSoundsInBackground) volume = Engine.Profile.Current.SoundVolume / Constants.SOUND_DELTA;
-            }
-            else if (!Engine.Profile.Current.ReproduceSoundsInBackground) volume = 0;
+            if (!Engine.Instance.IsActive && !Engine.Profile.Current.ReproduceSoundsInBackground) volume = 0;
 
             if (volume < -1 || volume > 1f)
                 return;


### PR DESCRIPTION
If "play music in background" (ReproduceSoundsInBackground) is false, distance was ignored for sound volume.

I don't think this code was supposed to be in PlaySoundByDistance, but correct me if I'm wrong.