### PR TITLE
Drag-select to get health bars

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -165,6 +165,8 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool DisableArrowBtn { get; set; } = false;
         [JsonProperty] public bool DisableTabBtn { get; set; } = false;
         [JsonProperty] public bool DisableCtrlQWBtn { get; set; } = false;
+        [JsonProperty] public bool EnableDragSelect { get; set; } = false;
+        [JsonProperty] public int DragSelectModifierKey { get; set; } = 0; // 0 = none, 1 = control, 2 = shift
 
         [JsonProperty] public int MaxFPS { get; set; } = 60;
 

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -796,11 +796,14 @@ namespace ClassicUO.Game.Scenes
             // batcher.SetBlendState(null);
             // workaround to set overheads clickable
             //_mousePicker.UpdateOverObjects(_mouseOverList, _mouseOverList.MousePosition);
+        }
 
+        public void DrawSelection(UltimaBatcher2D batcher, int x, int y)
+        {
             if (_isSelection)
             {
                 Vector3 selhue = Vector3.Zero;
-                batcher.DrawRectangle(Textures.GetTexture(Color.Aqua), _selectionStart.Item1 + x, _selectionStart.Item2 + y, Mouse.Position.X - (_selectionStart.Item1 + x), Mouse.Position.Y - (_selectionStart.Item2 + y), ref selhue);
+                batcher.DrawRectangle(Textures.GetTexture(Color.Aqua), _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref selhue);
             }
         }
 

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -806,7 +806,7 @@ namespace ClassicUO.Game.Scenes
                 sellines.Z = 0.3f;
                 Vector3 selhue = new Vector3();
                 selhue.Z = 0.7f;
-                batcher.Draw2D(CheckerTrans.TransparentTexture, _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref selhue);
+                batcher.Draw2D(Textures.GetTexture(Color.Black), _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref selhue);
                 batcher.DrawRectangle(Textures.GetTexture(Color.DeepSkyBlue), _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref sellines);
             }
         }

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -800,13 +800,14 @@ namespace ClassicUO.Game.Scenes
 
         public void DrawSelection(UltimaBatcher2D batcher, int x, int y)
         {
-            if (_isSelection)
+            if (_isSelectionActive)
             {
-                Vector3 zero = Vector3.Zero;
+                Vector3 sellines = Vector3.Zero;
+                sellines.Z = 0.3f;
                 Vector3 selhue = new Vector3();
                 selhue.Z = 0.7f;
                 batcher.Draw2D(CheckerTrans.TransparentTexture, _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref selhue);
-                batcher.DrawRectangle(Textures.GetTexture(Color.DeepSkyBlue), _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref zero);
+                batcher.DrawRectangle(Textures.GetTexture(Color.DeepSkyBlue), _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref sellines);
             }
         }
 

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -802,7 +802,7 @@ namespace ClassicUO.Game.Scenes
                 Vector3 selhue = Vector3.Zero;
                 ShaderHuesTraslator.GetHueVector(ref selhue, 222, false, 0.5f);
 
-                batcher.Draw2D(CheckerTrans.TransparentTexture, _selectionArea.Item1 + x, _selectionArea.Item2 + y, Mouse.Position.X - (_selectionArea.Item1 + x), Mouse.Position.Y - (_selectionArea.Item2 + y), ref selhue);
+                batcher.Draw2D(CheckerTrans.TransparentTexture, _selectionStart.Item1 + x, _selectionStart.Item2 + y, Mouse.Position.X - (_selectionStart.Item1 + x), Mouse.Position.Y - (_selectionStart.Item2 + y), ref selhue);
             }
         }
 

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -796,6 +796,14 @@ namespace ClassicUO.Game.Scenes
             // batcher.SetBlendState(null);
             // workaround to set overheads clickable
             //_mousePicker.UpdateOverObjects(_mouseOverList, _mouseOverList.MousePosition);
+
+            if (_isSelection)
+            {
+                Vector3 selhue = Vector3.Zero;
+                ShaderHuesTraslator.GetHueVector(ref selhue, 222, false, 0.5f);
+
+                batcher.Draw2D(CheckerTrans.TransparentTexture, _selectionArea.Item1 + x, _selectionArea.Item2 + y, Mouse.Position.X - (_selectionArea.Item1 + x), Mouse.Position.Y - (_selectionArea.Item2 + y), ref selhue);
+            }
         }
 
 

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -802,8 +802,11 @@ namespace ClassicUO.Game.Scenes
         {
             if (_isSelection)
             {
-                Vector3 selhue = Vector3.Zero;
-                batcher.DrawRectangle(Textures.GetTexture(Color.Aqua), _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref selhue);
+                Vector3 zero = Vector3.Zero;
+                Vector3 selhue = new Vector3();
+                selhue.Z = 0.7f;
+                batcher.Draw2D(CheckerTrans.TransparentTexture, _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref selhue);
+                batcher.DrawRectangle(Textures.GetTexture(Color.DeepSkyBlue), _selectionStart.Item1, _selectionStart.Item2, Mouse.Position.X - (_selectionStart.Item1), Mouse.Position.Y - (_selectionStart.Item2), ref zero);
             }
         }
 

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -800,9 +800,7 @@ namespace ClassicUO.Game.Scenes
             if (_isSelection)
             {
                 Vector3 selhue = Vector3.Zero;
-                ShaderHuesTraslator.GetHueVector(ref selhue, 222, false, 0.5f);
-
-                batcher.Draw2D(CheckerTrans.TransparentTexture, _selectionStart.Item1 + x, _selectionStart.Item2 + y, Mouse.Position.X - (_selectionStart.Item1 + x), Mouse.Position.Y - (_selectionStart.Item2 + y), ref selhue);
+                batcher.DrawRectangle(Textures.GetTexture(Color.Aqua), _selectionStart.Item1 + x, _selectionStart.Item2 + y, Mouse.Position.X - (_selectionStart.Item1 + x), Mouse.Position.Y - (_selectionStart.Item2 + y), ref selhue);
             }
         }
 

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -188,7 +188,14 @@ namespace ClassicUO.Game.Scenes
                             {
                                 Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
                                 GameActions.RequestMobileStatus(mobile);
-                                Engine.UI.Add(new HealthBarGump(mobile) { X = x - (rect.Width >> 1), Y = y - (rect.Height >> 1) - 100 });
+                                HealthBarGump hbg = new HealthBarGump(mobile);
+                                // Need to initialize before setting X Y otherwise AnchorableGump.OnMove() is not called
+                                // if OnMove() is not called, _prevX _prevY are not set, anchoring is unpredictable
+                                // maybe should be fixed elsewhere
+                                hbg.Initialize();
+                                hbg.X = x - (rect.Width >> 1);
+                                hbg.Y = y - (rect.Height >> 1) - 100;
+                                Engine.UI.Add(hbg);
                             }
                         }
                     }

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -122,7 +122,7 @@ namespace ClassicUO.Game.Scenes
             _dragginObject = Game.SelectedObject.Object as GameObject;
             _dragOffset = Mouse.LDropPosition;
 
-            if (_dragginObject is Static || _dragginObject is Land)
+            if (_dragginObject is Static || _dragginObject is Land || _dragginObject is Multi || (_dragginObject is Item tmpitem && tmpitem.IsLocked))
             {
                 _selectionStart = (Mouse.Position.X, Mouse.Position.Y);
                 _isSelection = true;
@@ -151,7 +151,52 @@ namespace ClassicUO.Game.Scenes
 
             //Chat.HandleMessage(null, "AAA", World.Player.Name, 123, MessageType.Party, (MessageFont)i, true);
 
-            if (TargetManager.IsTargeting)
+            if (_isSelection)
+            {
+                if (_selectionStart.Item1 != Mouse.Position.X && _selectionStart.Item2 != Mouse.Position.Y)
+                {
+                    if (_selectionStart.Item1 > Mouse.Position.X)
+                    {
+                        _selectionEnd.Item1 = _selectionStart.Item1;
+                        _selectionStart.Item1 = Mouse.Position.X;
+                    }
+                    else
+                    {
+                        _selectionEnd.Item1 = Mouse.Position.X;
+                    }
+
+                    if (_selectionStart.Item2 > Mouse.Position.Y)
+                    {
+                        _selectionEnd.Item2 = _selectionStart.Item2;
+                        _selectionStart.Item2 = Mouse.Position.Y;
+                    }
+                    else
+                    {
+                        _selectionEnd.Item2 = Mouse.Position.Y;
+                    }
+
+                    foreach (Mobile mobile in World.Mobiles)
+                    {
+                        int x = Engine.Profile.Current.GameWindowPosition.X + mobile.RealScreenPosition.X + (int) mobile.Offset.X + 22 + 5;
+                        int y = Engine.Profile.Current.GameWindowPosition.Y + (mobile.RealScreenPosition.Y - (int) mobile.Offset.Z) + 22 + 5;
+
+                        if (x > _selectionStart.Item1 && x < _selectionEnd.Item1 && y > _selectionStart.Item2 && y < _selectionEnd.Item2)
+                        {
+                            Engine.UI.GetControl<HealthBarGump>(mobile)?.Dispose();
+
+                            if (mobile != World.Player)
+                            {
+                                Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
+                                GameActions.RequestMobileStatus(mobile);
+                                Engine.UI.Add(new HealthBarGump(mobile) { X = x - (rect.Width >> 1), Y = y - (rect.Height >> 1) - 100 });
+                            }
+                        }
+                    }
+                }
+                _isSelection = false;
+                _selectionStart = (0, 0);
+            }
+            else if (TargetManager.IsTargeting)
             {
                 switch (TargetManager.TargetingState)
                 {
@@ -237,51 +282,6 @@ namespace ClassicUO.Game.Scenes
                 }
                 else
                     Engine.SceneManager.CurrentScene.Audio.PlaySound(0x0051);
-            }
-            else if (_isSelection)
-            {
-                if (_selectionStart.Item1 != Mouse.Position.X && _selectionStart.Item2 != Mouse.Position.Y)
-                {
-                    if (_selectionStart.Item1 > Mouse.Position.X)
-                    {
-                        _selectionEnd.Item1 = _selectionStart.Item1;
-                        _selectionStart.Item1 = Mouse.Position.X;
-                    }
-                    else
-                    {
-                        _selectionEnd.Item1 = Mouse.Position.X;
-                    }
-
-                    if (_selectionStart.Item2 > Mouse.Position.Y)
-                    {
-                        _selectionEnd.Item2 = _selectionStart.Item2;
-                        _selectionStart.Item2 = Mouse.Position.Y;
-                    }
-                    else
-                    {
-                        _selectionEnd.Item2 = Mouse.Position.Y;
-                    }
-
-                    foreach (Mobile mobile in World.Mobiles)
-                    {
-                        if (mobile.RealScreenPosition.X > _selectionStart.Item1
-                            && mobile.RealScreenPosition.X < _selectionEnd.Item1
-                            && mobile.RealScreenPosition.Y > _selectionStart.Item2
-                            && mobile.RealScreenPosition.Y < _selectionEnd.Item2)
-                        {
-                            Engine.UI.GetControl<HealthBarGump>(mobile)?.Dispose();
-
-                            if (mobile != World.Player)
-                            {
-                                Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
-                                GameActions.RequestMobileStatus(mobile);
-                                Engine.UI.Add(new HealthBarGump(mobile) { X = mobile.RealScreenPosition.X - (rect.Width >> 1) + 30, Y = mobile.RealScreenPosition.Y - (rect.Height >> 1) - 30 });
-                            }
-                        }
-                    }
-                }
-                _isSelection = false;
-                _selectionStart = (0, 0);
             }
             else
             {

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -122,12 +122,20 @@ namespace ClassicUO.Game.Scenes
             _dragginObject = Game.SelectedObject.Object as GameObject;
             _dragOffset = Mouse.LDropPosition;
 
-            if (_dragginObject is Static || _dragginObject is Land || _dragginObject is Multi || (_dragginObject is Item tmpitem && tmpitem.IsLocked))
+            if (Engine.Profile.Current.EnableDragSelect)
             {
-                _selectionStart = (Mouse.Position.X, Mouse.Position.Y);
-                _isSelectionActive = true;
+                if (Engine.Profile.Current.DragSelectModifierKey == 0 ||
+                    (Engine.Profile.Current.DragSelectModifierKey == 1 && _isCtrlDown) ||
+                    (Engine.Profile.Current.DragSelectModifierKey == 2 && _isShiftDown))
+                {
+                    if (_dragginObject is Static || _dragginObject is Land || _dragginObject is Multi || (_dragginObject is Item tmpitem && tmpitem.IsLocked))
+                    {
+                        _selectionStart = (Mouse.Position.X, Mouse.Position.Y);
+                        _isSelectionActive = true;
+                    }
+                }
             }
-            
+
         }
 
         private void OnLeftMouseUp(object sender, EventArgs e)

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -296,18 +296,18 @@ namespace ClassicUO.Game.Scenes
                                 if (item.Graphic == HeldItem.Graphic && HeldItem.IsStackable)
                                     MergeHeldItem(item);
                                 else
-                                    DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte)(obj.Position.Z + item.ItemData.Height));
+                                    DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte) (obj.Position.Z + item.ItemData.Height));
                             }
 
                             break;
 
                         case Multi multi:
-                            DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte)(obj.Position.Z + multi.ItemData.Height));
+                            DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte) (obj.Position.Z + multi.ItemData.Height));
 
                             break;
 
                         case Static st:
-                            DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte)(obj.Position.Z + st.ItemData.Height));
+                            DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte) (obj.Position.Z + st.ItemData.Height));
 
                             break;
 

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -115,7 +115,7 @@ namespace ClassicUO.Game.Scenes
 
         private bool CanDragSelectOnObject(GameObject obj)
         {
-            return (obj is Static || obj is Land || obj is Multi || (obj is Item tmpitem && tmpitem.IsLocked));
+            return (obj is null || obj is Static || obj is Land || obj is Multi || (obj is Item tmpitem && tmpitem.IsLocked));
         }
         
         private void SetDragSelectionStartEnd(ref (int, int) start, ref (int, int) end)

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -240,41 +240,36 @@ namespace ClassicUO.Game.Scenes
 
             if (TargetManager.IsTargeting)
             {
-                switch (TargetManager.TargetingState)
+                case CursorTarget.Grab:
+                case CursorTarget.SetGrabBag:
+                case CursorTarget.Position:
+                case CursorTarget.Object:
+                case CursorTarget.MultiPlacement:
+                    var obj = Game.SelectedObject.Object;
+
+                if (obj != null)
                 {
-                    switch (TargetManager.TargetingState)
-                    {
-                        case CursorTarget.Grab:
-                        case CursorTarget.SetGrabBag:
-                        case CursorTarget.Position:
-                        case CursorTarget.Object:
-                        case CursorTarget.MultiPlacement:
-                            var obj = Game.SelectedObject.Object;
-
-                        if (obj != null)
-                        {
-                            TargetManager.TargetGameObject(obj);
-                            Mouse.LastLeftButtonClickTime = 0;
-                        }
-
-                        break;
-
-                    case CursorTarget.SetTargetClientSide:
-
-                        if (Game.SelectedObject.Object is GameObject obj2)
-                        {
-                            TargetManager.TargetGameObject(obj2);
-                            Mouse.LastLeftButtonClickTime = 0;
-                            Engine.UI.Add(new InfoGump(obj2));
-                        }
-
-                        break;
-
-                    default:
-                        Log.Message(LogTypes.Warning, "Not implemented.");
-
-                        break;
+                    TargetManager.TargetGameObject(obj);
+                    Mouse.LastLeftButtonClickTime = 0;
                 }
+
+                break;
+
+            case CursorTarget.SetTargetClientSide:
+
+                if (Game.SelectedObject.Object is GameObject obj2)
+                {
+                    TargetManager.TargetGameObject(obj2);
+                    Mouse.LastLeftButtonClickTime = 0;
+                    Engine.UI.Add(new InfoGump(obj2));
+                }
+
+                break;
+
+            default:
+                Log.Message(LogTypes.Warning, "Not implemented.");
+
+                break;
             }
             else if (IsHoldingItem)
             {

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -77,7 +77,7 @@ namespace ClassicUO.Game.Scenes
         private bool _rightMousePressed, _continueRunning, _useObjectHandles, _arrowKeyPressed, _numPadKeyPressed;
         public Direction _numPadDirection;
         private (int, int) _selectionStart, _selectionEnd;
-        private bool _isSelection;
+        private bool _isSelectionActive;
 
         public bool IsMouseOverUI => Engine.UI.IsMouseOverAControl && !(Engine.UI.MouseOverControl is WorldViewport);
         public bool IsMouseOverViewport => Engine.UI.MouseOverControl is WorldViewport;
@@ -125,14 +125,14 @@ namespace ClassicUO.Game.Scenes
             if (_dragginObject is Static || _dragginObject is Land || _dragginObject is Multi || (_dragginObject is Item tmpitem && tmpitem.IsLocked))
             {
                 _selectionStart = (Mouse.Position.X, Mouse.Position.Y);
-                _isSelection = true;
+                _isSelectionActive = true;
             }
             
         }
 
         private void OnLeftMouseUp(object sender, EventArgs e)
         {
-            if (!IsMouseOverViewport && !_isSelection)
+            if (!IsMouseOverViewport && !_isSelectionActive)
                 return;
 
             if (_rightMousePressed)
@@ -151,7 +151,7 @@ namespace ClassicUO.Game.Scenes
 
             //Chat.HandleMessage(null, "AAA", World.Player.Name, 123, MessageType.Party, (MessageFont)i, true);
 
-            if (_isSelection)
+            if (_isSelectionActive)
             {
                 if (_selectionStart.Item1 != Mouse.Position.X && _selectionStart.Item2 != Mouse.Position.Y)
                 {
@@ -182,11 +182,11 @@ namespace ClassicUO.Game.Scenes
 
                         if (x > _selectionStart.Item1 && x < _selectionEnd.Item1 && y > _selectionStart.Item2 && y < _selectionEnd.Item2)
                         {
-                            Engine.UI.GetControl<HealthBarGump>(mobile)?.Dispose();
+                            Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
 
                             if (mobile != World.Player)
                             {
-                                Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
+                                Engine.UI.GetControl<HealthBarGump>(mobile)?.Dispose();
                                 GameActions.RequestMobileStatus(mobile);
                                 HealthBarGump hbg = new HealthBarGump(mobile);
                                 // Need to initialize before setting X Y otherwise AnchorableGump.OnMove() is not called
@@ -200,7 +200,7 @@ namespace ClassicUO.Game.Scenes
                         }
                     }
                 }
-                _isSelection = false;
+                _isSelectionActive = false;
                 _selectionStart = (0, 0);
             }
             else if (TargetManager.IsTargeting)

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -124,7 +124,7 @@ namespace ClassicUO.Game.Scenes
 
             if (_dragginObject is Static || _dragginObject is Land)
             {
-                _selectionStart = (Mouse.LDropPosition.X, Mouse.LDropPosition.Y);
+                _selectionStart = (Mouse.Position.X, Mouse.Position.Y);
                 _isSelection = true;
             }
             
@@ -274,12 +274,8 @@ namespace ClassicUO.Game.Scenes
                             if (mobile != World.Player)
                             {
                                 Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
-                                HealthBarGump currentHealthBarGump;
-                                //Engine.UI.Add(currentHealthBarGump = new HealthBarGump(mobile));
-                                //currentHealthBarGump.X = mobile.RealScreenPosition.X - (rect.Width >> 1) + 30;
-                                //currentHealthBarGump.Y = mobile.RealScreenPosition.Y - (rect.Width >> 1) - 30;
-                                Engine.UI.Add(currentHealthBarGump = new HealthBarGump(mobile) { X = mobile.RealScreenPosition.X - (rect.Width >> 1) + 30, Y = mobile.RealScreenPosition.Y - (rect.Height >> 1) - 30 });
-                                //Engine.UI.AttemptDragControl(currentHealthBarGump, mobile.RealScreenPosition, true);
+                                GameActions.RequestMobileStatus(mobile);
+                                Engine.UI.Add(new HealthBarGump(mobile) { X = mobile.RealScreenPosition.X - (rect.Width >> 1) + 30, Y = mobile.RealScreenPosition.Y - (rect.Height >> 1) - 30 });
                             }
                         }
                     }

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -240,36 +240,39 @@ namespace ClassicUO.Game.Scenes
 
             if (TargetManager.IsTargeting)
             {
-                case CursorTarget.Grab:
-                case CursorTarget.SetGrabBag:
-                case CursorTarget.Position:
-                case CursorTarget.Object:
-                case CursorTarget.MultiPlacement:
-                    var obj = Game.SelectedObject.Object;
-
-                if (obj != null)
+                switch (TargetManager.TargetingState)
                 {
-                    TargetManager.TargetGameObject(obj);
-                    Mouse.LastLeftButtonClickTime = 0;
+                    case CursorTarget.Grab:
+                    case CursorTarget.SetGrabBag:
+                    case CursorTarget.Position:
+                    case CursorTarget.Object:
+                    case CursorTarget.MultiPlacement:
+                        var obj = Game.SelectedObject.Object;
+
+                        if (obj != null)
+                        {
+                            TargetManager.TargetGameObject(obj);
+                            Mouse.LastLeftButtonClickTime = 0;
+                        }
+
+                        break;
+
+                    case CursorTarget.SetTargetClientSide:
+
+                        if (Game.SelectedObject.Object is GameObject obj2)
+                        {
+                            TargetManager.TargetGameObject(obj2);
+                            Mouse.LastLeftButtonClickTime = 0;
+                            Engine.UI.Add(new InfoGump(obj2));
+                        }
+
+                        break;
+
+                    default:
+                        Log.Message(LogTypes.Warning, "Not implemented.");
+
+                        break;
                 }
-
-                break;
-
-            case CursorTarget.SetTargetClientSide:
-
-                if (Game.SelectedObject.Object is GameObject obj2)
-                {
-                    TargetManager.TargetGameObject(obj2);
-                    Mouse.LastLeftButtonClickTime = 0;
-                    Engine.UI.Add(new InfoGump(obj2));
-                }
-
-                break;
-
-            default:
-                Log.Message(LogTypes.Warning, "Not implemented.");
-
-                break;
             }
             else if (IsHoldingItem)
             {
@@ -293,18 +296,18 @@ namespace ClassicUO.Game.Scenes
                                 if (item.Graphic == HeldItem.Graphic && HeldItem.IsStackable)
                                     MergeHeldItem(item);
                                 else
-                                    DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte) (obj.Position.Z + item.ItemData.Height));
+                                    DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte)(obj.Position.Z + item.ItemData.Height));
                             }
 
                             break;
 
                         case Multi multi:
-                            DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte) (obj.Position.Z + multi.ItemData.Height));
+                            DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte)(obj.Position.Z + multi.ItemData.Height));
 
                             break;
 
                         case Static st:
-                            DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte) (obj.Position.Z + st.ItemData.Height));
+                            DropHeldItemToWorld(obj.Position.X, obj.Position.Y, (sbyte)(obj.Position.Z + st.ItemData.Height));
 
                             break;
 

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -175,8 +175,12 @@ namespace ClassicUO.Game.Scenes
 
         private void OnLeftMouseUp(object sender, EventArgs e)
         {
-            // should allow selection to end on mouseup outside of viewport
-            if (_isSelectionActive && _selectionStart.Item1 != Mouse.Position.X && _selectionStart.Item2 != Mouse.Position.Y)
+            //  drag-select code comes first to allow selection finish on mouseup outside of viewport
+            if (_selectionStart.Item1 == Mouse.Position.X && _selectionStart.Item2 == Mouse.Position.Y)
+            {
+                _isSelectionActive = false;
+            }
+            if (_isSelectionActive)
             {
                 SetDragSelectionStartEnd(ref _selectionStart, ref _selectionEnd);
 

--- a/src/Game/UI/Controls/WorldViewport.cs
+++ b/src/Game/UI/Controls/WorldViewport.cs
@@ -99,6 +99,7 @@ namespace ClassicUO.Game.UI.Controls
             }
 
             // draw overheads
+            _scene.DrawSelection(batcher, x, y);
             _scene.DrawOverheads(batcher, x, y);
 
             return base.Draw(batcher, x, y);

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -1032,12 +1032,12 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 60
             };
             item.Add(text);
-
-            _dragSelectModifierKey = new Combobox(text.Width + 100, text.Y, 100, new[] { "None", "Ctrl", "Shift" })
+            _dragSelectModifierKey = new Combobox(text.Width + 80, text.Y, 100, new[] { "None", "Ctrl", "Shift" })
             {
                 SelectedIndex = Engine.Profile.Current.DragSelectModifierKey
             };
             item.Add(_dragSelectModifierKey);
+            _enableDragSelect.ValueChanged += (sender, e) => { item.IsVisible = _enableDragSelect.IsChecked; };
             rightArea.Add(item);
             Add(rightArea, PAGE);
 

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -1027,7 +1027,7 @@ namespace ClassicUO.Game.UI.Gumps
             _enableDragSelect = CreateCheckBox(rightArea, "Enable drag-select to open health bars", Engine.Profile.Current.EnableDragSelect, 0, 0);
 
             ScrollAreaItem item = new ScrollAreaItem();
-            Label text = new Label("Drag-select modifier key", true, HUE_FONT, 0, FONT)
+            text = new Label("Drag-select modifier key", true, HUE_FONT, 0, FONT)
             {
                 X = 60
             };

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -60,6 +60,8 @@ namespace ClassicUO.Game.UI.Gumps
         private TextBox _autoOpenCorpseRange;
         private Combobox _autoOpenCorpseOptions;
         private ScrollAreaItem _defaultHotkeysArea, _autoOpenCorpseArea;
+        private Checkbox _enableDragSelect;
+        private Combobox _dragSelectModifierKey;
 
         // sounds
         private Checkbox _enableSounds, _enableMusic, _footStepsSound, _combatMusic, _musicInBackground, _loginMusic;
@@ -930,7 +932,8 @@ namespace ClassicUO.Game.UI.Gumps
             const int PAGE = 10;
             ScrollArea rightArea = new ScrollArea(190, 20, WIDTH - 210, 420, true);
 
-            _enableSelectionArea = CreateCheckBox(rightArea, "Enable Selection Area", Engine.Profile.Current.EnableSelectionArea, 0, 0);
+            _enableSelectionArea = CreateCheckBox(rightArea, "Enable Text Selection Area", Engine.Profile.Current.EnableSelectionArea, 0, 0);
+            
             _debugGumpIsDisabled = CreateCheckBox(rightArea, "Disable Debug Gump", Engine.Profile.Current.DebugGumpIsDisabled, 0, 0);
             _restoreLastGameSize = CreateCheckBox(rightArea, "Disable automatic maximize. Restore windows size after re-login", Engine.Profile.Current.RestoreLastGameSize, 0, 0);
 
@@ -1021,6 +1024,21 @@ namespace ClassicUO.Game.UI.Gumps
                 _defaultHotkeysArea.IsVisible = _disableDefaultHotkeys.IsChecked;
             }
 
+            _enableDragSelect = CreateCheckBox(rightArea, "Enable drag-select to open health bars", Engine.Profile.Current.EnableDragSelect, 0, 0);
+
+            ScrollAreaItem item = new ScrollAreaItem();
+            Label text = new Label("Drag-select modifier key", true, HUE_FONT, 0, FONT)
+            {
+                X = 60
+            };
+            item.Add(text);
+
+            _dragSelectModifierKey = new Combobox(text.Width + 100, text.Y, 100, new[] { "None", "Ctrl", "Shift" })
+            {
+                SelectedIndex = Engine.Profile.Current.DragSelectModifierKey
+            };
+            item.Add(_dragSelectModifierKey);
+            rightArea.Add(item);
             Add(rightArea, PAGE);
 
             _autoOpenCorpseArea.IsVisible = _autoOpenCorpse.IsChecked;
@@ -1557,7 +1575,10 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.AutoOpenCorpses = _autoOpenCorpse.IsChecked;
             Engine.Profile.Current.AutoOpenCorpseRange = int.Parse(_autoOpenCorpseRange.Text);
             Engine.Profile.Current.CorpseOpenOptions = _autoOpenCorpseOptions.SelectedIndex;
-            
+
+            Engine.Profile.Current.EnableDragSelect = _enableDragSelect.IsChecked;
+            Engine.Profile.Current.DragSelectModifierKey = _dragSelectModifierKey.SelectedIndex;           
+
 
             // network
             Engine.Profile.Current.ShowNetworkStats = _showNetStats.IsChecked;


### PR DESCRIPTION
For your consideration...

![dragselect_a](https://user-images.githubusercontent.com/7057924/59232894-2b7b1d00-8bde-11e9-97ae-a28f66f7034e.gif)
![dragselect_b](https://user-images.githubusercontent.com/7057924/59232899-3170fe00-8bde-11e9-8b47-ddbd760f0921.gif)

Pulling health bars while I'm moving, or while the opponent is moving, has always been a huge annoyance to me. I saw the "selection area" in experimental features and wondered, what the hell is that? Disappointingly, I found that it's for selecting text. But that's when my idea was formed.

This will

- Allow click and drag either just using left mouse down, or optionally requiring a modifier key (ctrl or shift)
- Allow click and drag only from whitelisted types (e.g. can drag if you start on a static, a multi, an item as long as it's locked...)

I haven't found any remaining bugs for it. Anyway whatever happens with it, I had fun making it!