### PR TITLE
Open containers near origin

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -166,6 +166,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool DisableCtrlQWBtn { get; set; }
         [JsonProperty] public bool EnableDragSelect { get; set; }
         [JsonProperty] public int DragSelectModifierKey { get; set; } // 0 = none, 1 = control, 2 = shift
+        [JsonProperty] public bool OpenContainersNearRealPosition { get; set; }
 
         [JsonProperty] public int MaxFPS { get; set; } = 60;
 

--- a/src/Game/Data/ContainerManager.cs
+++ b/src/Game/Data/ContainerManager.cs
@@ -216,7 +216,7 @@ namespace ClassicUO.Game.Data
             if (X == DefaultX || Y == DefaultY)
 
                 X = X;
-            Y = Y;
+                Y = Y;
         }
     }
 

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -100,9 +100,55 @@ namespace ClassicUO.Game.UI.Gumps
                     Location = location;
                 else
                 {
-                    ContainerManager.CalculateContainerPosition(g);
-                    X = ContainerManager.X;
-                    Y = ContainerManager.Y;
+                    if (Engine.Profile.Current.OpenContainersNearRealPosition)
+                    {
+                        if (World.Player.Equipment[(int)Layer.Bank] != null && _item.Serial == World.Player.Equipment[(int) Layer.Bank])
+                        {
+                            // open bank near player
+                            X = World.Player.RealScreenPosition.X;
+                            Y = World.Player.RealScreenPosition.Y;
+                        }
+                        else if (_item.OnGround)
+                        {
+                            // item is in world
+                            X = _item.RealScreenPosition.X;
+                            Y = _item.RealScreenPosition.Y;
+                        }
+                        else
+                        {
+                            // in a container, open near the container
+                            ContainerGump parentContainer = Engine.UI.Gumps.OfType<ContainerGump>().FirstOrDefault(s => s.LocalSerial == _item.Container);
+                            if (parentContainer != null)
+                            {
+                                X = parentContainer.X + 20;
+                                Y = parentContainer.Y + 20;
+                            }
+                            else
+                            {
+                                // I don't think we ever get here?
+                                ContainerManager.CalculateContainerPosition(g);
+                                X = ContainerManager.X;
+                                Y = ContainerManager.Y;
+                            }
+                        }
+
+                        if ((X + Width) > Engine.WindowWidth)
+                        {
+                            X -= Width;
+                        }
+
+                        if ((Y + Height) > Engine.WindowHeight)
+                        {
+                            Y -= Height;
+                        }
+                    }
+                    else
+                    {
+                        ContainerManager.CalculateContainerPosition(g);
+                        X = ContainerManager.X;
+                        Y = ContainerManager.Y;
+                    }
+
                 }
             }
             else

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -62,7 +62,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _enableDragSelect;
 
         //experimental
-        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _openContainersNearRealPosition;
 
         // sounds
         private Checkbox _enableSounds, _enableMusic, _footStepsSound, _combatMusic, _musicInBackground, _loginMusic;
@@ -1051,6 +1051,8 @@ namespace ClassicUO.Game.UI.Gumps
             _enableDragSelect.ValueChanged += (sender, e) => { _dragSelectArea.IsVisible = _enableDragSelect.IsChecked; };
             rightArea.Add(_dragSelectArea);
 
+            _openContainersNearRealPosition = CreateCheckBox(rightArea, "Containers open near their point of origin", Engine.Profile.Current.OpenContainersNearRealPosition, 0, 0);
+
             Add(rightArea, PAGE);
 
             _autoOpenCorpseArea.IsVisible = _autoOpenCorpse.IsChecked;
@@ -1253,6 +1255,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _disableTabBtn.IsChecked = false;
                     _disableCtrlQWBtn.IsChecked = false;
                     _enableDragSelect.IsChecked = false;
+                    _openContainersNearRealPosition.IsChecked = false;
 
                     break;
 
@@ -1615,6 +1618,7 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.EnableDragSelect = _enableDragSelect.IsChecked;
             Engine.Profile.Current.DragSelectModifierKey = _dragSelectModifierKey.SelectedIndex;
 
+            Engine.Profile.Current.OpenContainersNearRealPosition = _openContainersNearRealPosition.IsChecked;
 
             // network
             Engine.Profile.Current.ShowNetworkStats = _showNetStats.IsChecked;


### PR DESCRIPTION
An option to make container gumps appear in more predictable screen locations.

If a cached location is not found:
- Bank box opens near player
- Containers from items on the ground (including corpses) open near their world position
- Containers within containers open near the parent container gump (did not find a way to get the actual ItemGump position with data available from ContainerGump, and didn't want to use mouse click position as it seems lazy)