### PR TITLE
Prevent spell cast when dragging spell icon with "Cast spells by one click"

### DIFF
--- a/src/Game/UI/Gumps/UseSpellButtonGump.cs
+++ b/src/Game/UI/Gumps/UseSpellButtonGump.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System;
 using System.IO;
 
 using ClassicUO.Game.Data;
@@ -64,7 +65,10 @@ namespace ClassicUO.Game.UI.Gumps
         protected override void OnMouseClick(int x, int y, MouseButton button)
         {
             if (Engine.Profile.Current.CastSpellsByOneClick && button == MouseButton.Left)
-                GameActions.CastSpell(_spell.ID);
+            {
+                if (Math.Max(Math.Abs(Mouse.LDroppedOffset.X), Math.Abs(Mouse.LDroppedOffset.Y)) <= 1)
+                    GameActions.CastSpell(_spell.ID);
+            }
         }
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)


### PR DESCRIPTION
Made it so there must be an offset of 1px or less to count as a click. Not sure if it's the right way - the buttons to use skills (SkillButtonGump) has a hidden feature where you must hold Alt to prevent a "click". Could copy that here instead but would anyone know to use it?