### PR TITLE
Macro to toggle name overheads

### DIFF
--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -1027,6 +1027,11 @@ namespace ClassicUO.Game.Managers
                     TargetManager.SetTargeting(CursorTarget.SetGrabBag, Serial.INVALID, TargetType.Neutral);
 
                     break;
+
+                case MacroType.NamesOnOff:
+                    NameOverHeadManager.ToggleOverheads();
+
+                    break;
             }
 
 
@@ -1327,7 +1332,8 @@ namespace ClassicUO.Game.Managers
         Aura,
         AuraOnOff,
         Grab,
-        SetGrabBag
+        SetGrabBag,
+        NamesOnOff
     }
 
     internal enum MacroSubType

--- a/src/Game/Managers/NameOverHeadManager.cs
+++ b/src/Game/Managers/NameOverHeadManager.cs
@@ -43,6 +43,8 @@ namespace ClassicUO.Game.Managers
         private static NameOverHeadHandlerGump _gump;
         public static NameOverheadTypeAllowed TypeAllowed { get; set; }
 
+        public static bool IsToggled = false;
+
         public static bool IsAllowed(Entity serial)
         {
             if (serial == null)
@@ -79,6 +81,11 @@ namespace ClassicUO.Game.Managers
                 _gump.Dispose();
                 _gump = null;
             }
+        }
+
+        public static void ToggleOverheads()
+        {
+            IsToggled = !IsToggled;
         }
     }
 }

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -469,6 +469,12 @@ namespace ClassicUO.Game.Scenes
             _renderListCount = 0;
             _objectHandlesCount = 0;
 
+            _useObjectHandles = NameOverHeadManager.IsToggled || _useObjectHandles;
+
+            if (_useObjectHandles)
+                NameOverHeadManager.Open();
+            else
+                NameOverHeadManager.Close();
 
             _rectanglePlayer.X = (int) (World.Player.RealScreenPosition.X - World.Player.FrameInfo.X + 22 + World.Player.Offset.X);
             _rectanglePlayer.Y = (int) (World.Player.RealScreenPosition.Y - World.Player.FrameInfo.Y + 22 + (World.Player.Offset.Y - World.Player.Offset.Z));

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -580,11 +580,6 @@ namespace ClassicUO.Game.Scenes
 
             _useObjectHandles = isshift && isctrl;
 
-            if (_useObjectHandles)
-                NameOverHeadManager.Open();
-            else
-                NameOverHeadManager.Close();
-
             if (macro != null)
             {
                 Macros.SetMacroToExecute(macro.FirstNode);
@@ -672,9 +667,6 @@ namespace ClassicUO.Game.Scenes
             if ((e.keysym.mod & SDL.SDL_Keymod.KMOD_NUM) != SDL.SDL_Keymod.KMOD_NUM) _numPadKeyPressed = false;
 
             _useObjectHandles = isctrl && isshift;
-
-            if (!_useObjectHandles)
-                NameOverHeadManager.Close();
 
             if (e.keysym.sym == SDL.SDL_Keycode.SDLK_TAB /*&& !Engine.Profile.Current.DisableTabBtn*/)
             {

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -259,7 +259,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             base.Update(totalMS, frameMS);
 
-            if (Entity == null || Entity.IsDestroyed || !Entity.UseObjectHandles || Entity.ClosedObjectHandles || !Keyboard.Ctrl || !Keyboard.Shift) Dispose();
+            if (Entity == null || Entity.IsDestroyed || !Entity.UseObjectHandles || Entity.ClosedObjectHandles) Dispose();
 
             if (_isPressed)
             {


### PR DESCRIPTION
So that ctrl+shift is not the only option.

One thing, NameOverHeadGump was disposing itself if ctrl+shift is not pressed, but relying on !Entity.UseObjectHandles was already enough. And of course it stopped the toggle from working, so I removed it.