### PR TITLE
predictable container position - also work for mobiles

### DIFF
--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -114,6 +114,16 @@ namespace ClassicUO.Game.UI.Gumps
                             X = _item.RealScreenPosition.X + Engine.Profile.Current.GameWindowPosition.X + 40;
                             Y = _item.RealScreenPosition.Y + Engine.Profile.Current.GameWindowPosition.Y - (Height >> 1);
                         }
+                        else if (_item.Container.IsMobile)
+                        {
+                            // pack animal, snooped player, npc vendor
+                            Mobile mobile = World.Mobiles.Get(_item.Container);
+                            if (mobile != null)
+                            {
+                                X = mobile.RealScreenPosition.X + Engine.Profile.Current.GameWindowPosition.X + 40;
+                                Y = mobile.RealScreenPosition.Y + Engine.Profile.Current.GameWindowPosition.Y - (Height >> 1);
+                            }
+                        }
                         else
                         {
                             // in a container, open near the container


### PR DESCRIPTION
For "Containers open near their point of origin" option, Containers from mobiles e.g. pack animals, player vendors, snooped bags, will also appear near the mobile