### PR TITLE
Don't close existing bars on drag select

### DIFF
--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -516,6 +516,10 @@ namespace ClassicUO.Game.Scenes
                         case Mobile mobile:
                             GameActions.RequestMobileStatus(mobile);
 
+                            if(Engine.UI.GetControl<HealthBarGump>(mobile)?.IsInitialized ?? false)
+                            {
+                                continue;
+                            }
                             Engine.UI.GetControl<HealthBarGump>(mobile)?.Dispose();
 
                             if (mobile == World.Player)


### PR DESCRIPTION
Prevents closing of health bars that are already opened when drag selecting bars.

