### PR TITLE
More options for container opening location

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -170,7 +170,9 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool DisableCtrlQWBtn { get; set; }
         [JsonProperty] public bool EnableDragSelect { get; set; }
         [JsonProperty] public int DragSelectModifierKey { get; set; } // 0 = none, 1 = control, 2 = shift
-        [JsonProperty] public bool OpenContainersNearRealPosition { get; set; }
+        [JsonProperty] public bool OverrideContainerLocation { get; set; }
+        [JsonProperty] public int OverrideContainerLocationSetting { get; set; } // 0 = container position, 1 = top right of screen, 2 = last dragged position
+        [JsonProperty] public Point OverrideContainerLocationPosition { get; set; } = new Point(200, 200);
         [JsonProperty] public bool DragSelectHumanoidsOnly { get; set; }
 
         [JsonProperty] public int MaxFPS { get; set; } = 60;

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -100,46 +100,19 @@ namespace ClassicUO.Game.UI.Gumps
                     Location = location;
                 else
                 {
-                    if (Engine.Profile.Current.OpenContainersNearRealPosition)
+                    if (Engine.Profile.Current.OverrideContainerLocation)
                     {
-                        if (World.Player.Equipment[(int)Layer.Bank] != null && _item.Serial == World.Player.Equipment[(int) Layer.Bank])
+                        switch (Engine.Profile.Current.OverrideContainerLocationSetting)
                         {
-                            // open bank near player
-                            X = World.Player.RealScreenPosition.X + Engine.Profile.Current.GameWindowPosition.X + 40;
-                            Y = World.Player.RealScreenPosition.Y + Engine.Profile.Current.GameWindowPosition.Y - (Height >> 1);
-                        }
-                        else if (_item.OnGround)
-                        {
-                            // item is in world
-                            X = _item.RealScreenPosition.X + Engine.Profile.Current.GameWindowPosition.X + 40;
-                            Y = _item.RealScreenPosition.Y + Engine.Profile.Current.GameWindowPosition.Y - (Height >> 1);
-                        }
-                        else if (_item.Container.IsMobile)
-                        {
-                            // pack animal, snooped player, npc vendor
-                            Mobile mobile = World.Mobiles.Get(_item.Container);
-                            if (mobile != null)
-                            {
-                                X = mobile.RealScreenPosition.X + Engine.Profile.Current.GameWindowPosition.X + 40;
-                                Y = mobile.RealScreenPosition.Y + Engine.Profile.Current.GameWindowPosition.Y - (Height >> 1);
-                            }
-                        }
-                        else
-                        {
-                            // in a container, open near the container
-                            ContainerGump parentContainer = Engine.UI.Gumps.OfType<ContainerGump>().FirstOrDefault(s => s.LocalSerial == _item.Container);
-                            if (parentContainer != null)
-                            {
-                                X = parentContainer.X + (Width >> 1);
-                                Y = parentContainer.Y;
-                            }
-                            else
-                            {
-                                // I don't think we ever get here?
-                                ContainerManager.CalculateContainerPosition(g);
-                                X = ContainerManager.X;
-                                Y = ContainerManager.Y;
-                            }
+                            case 0:
+                                SetPositionNearGameObject(g);
+                                break;
+                            case 1:
+                                SetPositionTopRight();
+                                break;
+                            case 2:
+                                SetPositionByLastDragged();
+                                break;
                         }
 
                         if ((X + Width) > Engine.WindowWidth)
@@ -158,7 +131,6 @@ namespace ClassicUO.Game.UI.Gumps
                         X = ContainerManager.X;
                         Y = ContainerManager.Y;
                     }
-
                 }
             }
             else
@@ -305,6 +277,61 @@ namespace ClassicUO.Game.UI.Gumps
             if (x != item.X || y != item.Y) item.Position = new Position((ushort) x, (ushort) y);
         }
 
+        private void SetPositionNearGameObject(Graphic g)
+        {
+            if (World.Player.Equipment[(int)Layer.Bank] != null && _item.Serial == World.Player.Equipment[(int)Layer.Bank])
+            {
+                // open bank near player
+                X = World.Player.RealScreenPosition.X + Engine.Profile.Current.GameWindowPosition.X + 40;
+                Y = World.Player.RealScreenPosition.Y + Engine.Profile.Current.GameWindowPosition.Y - (Height >> 1);
+            }
+            else if (_item.OnGround)
+            {
+                // item is in world
+                X = _item.RealScreenPosition.X + Engine.Profile.Current.GameWindowPosition.X + 40;
+                Y = _item.RealScreenPosition.Y + Engine.Profile.Current.GameWindowPosition.Y - (Height >> 1);
+            }
+            else if (_item.Container.IsMobile)
+            {
+                // pack animal, snooped player, npc vendor
+                Mobile mobile = World.Mobiles.Get(_item.Container);
+                if (mobile != null)
+                {
+                    X = mobile.RealScreenPosition.X + Engine.Profile.Current.GameWindowPosition.X + 40;
+                    Y = mobile.RealScreenPosition.Y + Engine.Profile.Current.GameWindowPosition.Y - (Height >> 1);
+                }
+            }
+            else
+            {
+                // in a container, open near the container
+                ContainerGump parentContainer = Engine.UI.Gumps.OfType<ContainerGump>().FirstOrDefault(s => s.LocalSerial == _item.Container);
+                if (parentContainer != null)
+                {
+                    X = parentContainer.X + (Width >> 1);
+                    Y = parentContainer.Y;
+                }
+                else
+                {
+                    // I don't think we ever get here?
+                    ContainerManager.CalculateContainerPosition(g);
+                    X = ContainerManager.X;
+                    Y = ContainerManager.Y;
+                }
+            }
+        }
+
+        private void SetPositionTopRight()
+        {
+            X = Engine.WindowWidth - Width;
+            Y = 0;
+        }
+
+        private void SetPositionByLastDragged()
+        {
+            X = Engine.Profile.Current.OverrideContainerLocationPosition.X - (Width >> 1);
+            Y = Engine.Profile.Current.OverrideContainerLocationPosition.Y - (Height >> 1);
+        }
+
         public override void Dispose()
         {
             TextContainer.Clear();
@@ -327,6 +354,17 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             base.Dispose();
+        }
+
+        protected override void OnDragEnd(int x, int y)
+        {
+            if (Engine.Profile.Current.OverrideContainerLocation && Engine.Profile.Current.OverrideContainerLocationSetting == 2)
+            {
+                Point gumpCenter = new Point(X + (Width >> 1), Y + (Height >> 1));
+                Engine.Profile.Current.OverrideContainerLocationPosition = gumpCenter;
+            }
+
+            base.OnDragEnd(x, y);
         }
     }
 }

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -62,7 +62,8 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _enableDragSelect, _dragSelectHumanoidsOnly;
 
         //experimental
-        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _openContainersNearRealPosition;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation;
+        private Combobox _overrideContainerLocationSetting;
 
         // sounds
         private Checkbox _enableSounds, _enableMusic, _footStepsSound, _combatMusic, _musicInBackground, _loginMusic;
@@ -1096,7 +1097,21 @@ namespace ClassicUO.Game.UI.Gumps
 
             rightArea.Add(_dragSelectArea);
 
-            _openContainersNearRealPosition = CreateCheckBox(rightArea, "Containers open near their point of origin", Engine.Profile.Current.OpenContainersNearRealPosition, 0, 0);
+
+            ScrollAreaItem _containerGumpLocation = new ScrollAreaItem();
+
+            _overrideContainerLocation = new Checkbox(0x00D2, 0x00D3, "Override container gump location", FONT, HUE_FONT, true)
+            {
+                IsChecked = Engine.Profile.Current.OverrideContainerLocation,
+            };
+
+            _overrideContainerLocationSetting = new Combobox(_overrideContainerLocation.Width + 20, 0, 200, new[] { "Near container position", "Top right", "Last dragged position" }, Engine.Profile.Current.OverrideContainerLocationSetting);
+
+            _containerGumpLocation.Add(_overrideContainerLocation);
+            _containerGumpLocation.Add(_overrideContainerLocationSetting);
+
+            rightArea.Add(_containerGumpLocation);
+
 
             Add(rightArea, PAGE);
 
@@ -1309,7 +1324,8 @@ namespace ClassicUO.Game.UI.Gumps
                     _disableTabBtn.IsChecked = false;
                     _disableCtrlQWBtn.IsChecked = false;
                     _enableDragSelect.IsChecked = false;
-                    _openContainersNearRealPosition.IsChecked = false;
+                    _overrideContainerLocation.IsChecked = false;
+                    _overrideContainerLocationSetting.SelectedIndex = 0;
                     _dragSelectHumanoidsOnly.IsChecked = false;
 
                     break;
@@ -1683,7 +1699,8 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.DragSelectModifierKey = _dragSelectModifierKey.SelectedIndex;
             Engine.Profile.Current.DragSelectHumanoidsOnly = _dragSelectHumanoidsOnly.IsChecked;
 
-            Engine.Profile.Current.OpenContainersNearRealPosition = _openContainersNearRealPosition.IsChecked;
+            Engine.Profile.Current.OverrideContainerLocation = _overrideContainerLocation.IsChecked;
+            Engine.Profile.Current.OverrideContainerLocationSetting = _overrideContainerLocationSetting.SelectedIndex;
 
             // network
             Engine.Profile.Current.ShowNetworkStats = _showNetStats.IsChecked;


### PR DESCRIPTION
Due to comments on Outlands discord.

Changed from
![image](https://user-images.githubusercontent.com/7057924/61151875-d719d480-a4de-11e9-81c6-72cb57e8d593.png)
to
![image](https://user-images.githubusercontent.com/7057924/61151832-bea9ba00-a4de-11e9-863f-aca777a53594.png)

The options are:

- **Near container position**: same function as the previous option
- **Top right**: opens in the very top/right of the screen, emulating the standard client behaviour when container position offsetting is disabled
- **Last dragged position**: When you drag a container, it will remember where you put it and open new containers in the same position