### PR TITLE
✨ Add -hue command for quick inspection of in-game items

### DIFF
--- a/src/Game/Graphic.cs
+++ b/src/Game/Graphic.cs
@@ -87,7 +87,7 @@ namespace ClassicUO.Game
 
         public override string ToString()
         {
-            return $"0x{Value:X4}";
+            return $"{Value} (0x{Value:X4})";
         }
 
         public override int GetHashCode()

--- a/src/Game/Hue.cs
+++ b/src/Game/Hue.cs
@@ -89,7 +89,7 @@ namespace ClassicUO.Game
 
         public override string ToString()
         {
-            return $"0x{_value:X4}";
+            return $"{_value} (0x{_value:X4})";
         }
 
         public override int GetHashCode()

--- a/src/Game/Managers/CommandManager.cs
+++ b/src/Game/Managers/CommandManager.cs
@@ -24,6 +24,8 @@
 using System;
 using System.Collections.Generic;
 
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Input;
 using ClassicUO.Utility.Logging;
 
 namespace ClassicUO.Game.Managers

--- a/src/Game/Managers/CommandManager.cs
+++ b/src/Game/Managers/CommandManager.cs
@@ -38,7 +38,7 @@ namespace ClassicUO.Game.Managers
             Register("info", s =>
             {
                 if (!TargetManager.IsTargeting)
-                    TargetManager.SetTargeting(CursorTarget.SetTargetClientSide, 6983686, 0);
+                    TargetManager.SetTargeting(CursorTarget.SetTargetClientSide, CursorType.Target, TargetType.Neutral);
                 else
                     TargetManager.CancelTarget();
             });
@@ -51,6 +51,13 @@ namespace ClassicUO.Game.Managers
                     GameActions.Print($"Current DateTime.Now is {DateTime.Now}");
                     GameActions.Print($"Current CurrDateTime is {Engine.CurrDateTime}");
                 }
+            });
+            Register("hue", s =>
+            {
+                if (!TargetManager.IsTargeting)
+                    TargetManager.SetTargeting(CursorTarget.HueCommandTarget, CursorType.Target, TargetType.Neutral);
+                else
+                    TargetManager.CancelTarget();
             });
         }
 
@@ -86,6 +93,13 @@ namespace ClassicUO.Game.Managers
                 action.Invoke(args);
             else
                 Log.Message(LogTypes.Warning, $"Commad: '{name}' not exists");
+        }
+
+        public static void OnHueTarget(Entity entity)
+        {
+            TargetManager.TargetGameObject(entity);
+            Mouse.LastLeftButtonClickTime = 0;
+            GameActions.Print($"Item ID: {entity.Graphic}\nHue: {entity.Hue}");
         }
     }
 }

--- a/src/Game/Managers/TargetManager.cs
+++ b/src/Game/Managers/TargetManager.cs
@@ -41,7 +41,14 @@ namespace ClassicUO.Game.Managers
         MultiPlacement = 2,
         SetTargetClientSide = 3,
         Grab,
-        SetGrabBag
+        SetGrabBag,
+        HueCommandTarget
+    }
+
+    public enum CursorType
+    {
+        Invalid = -1,
+        Target = 6983686
     }
 
     public enum TargetType

--- a/src/Game/Managers/TargetManager.cs
+++ b/src/Game/Managers/TargetManager.cs
@@ -45,10 +45,9 @@ namespace ClassicUO.Game.Managers
         HueCommandTarget
     }
 
-    public enum CursorType
+    internal class CursorType
     {
-        Invalid = -1,
-        Target = 6983686
+        public static readonly Serial Target = new Serial(6983686);
     }
 
     public enum TargetType

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -357,6 +357,15 @@ namespace ClassicUO.Game.Scenes
 
                         break;
 
+                    case CursorTarget.HueCommandTarget:
+
+                        if (SelectedObject.Object is Entity selectedEntity)
+                        {
+                            CommandManager.OnHueTarget(selectedEntity);
+                        }
+
+                        break;
+
                     default:
                         Log.Message(LogTypes.Warning, "Not implemented.");
 

--- a/src/Game/UI/Controls/ItemGump.cs
+++ b/src/Game/UI/Controls/ItemGump.cs
@@ -225,6 +225,17 @@ namespace ClassicUO.Game.UI.Controls
                             }
 
                             break;
+
+                        case CursorTarget.HueCommandTarget:
+                            SelectedObject.Object = Item;
+
+                            if (Item != null)
+                            {
+                                CommandManager.OnHueTarget(Item);
+                            }
+
+                            break;
+
                     }
                 }
                 else

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -259,6 +259,12 @@ namespace ClassicUO.Game.UI.Gumps
                             Engine.UI.Add(new InfoGump(Entity));
 
                             break;
+
+                        case CursorTarget.HueCommandTarget:
+                            CommandManager.OnHueTarget(Entity);
+
+                            break;
+
                     }
                 }
                 else


### PR DESCRIPTION
This command is available in the UO:Renaissance client, but was not available in ClassicUO. It is a pared down version of the information available in the "-info" command gump, intended for rapid inspection of the most common "hidden" properties: item ID and hue.

Personally, I use this for organizing NPC cloth I take from brigands, escorts, evil mages, and the vendors in Buc's Den.

![Screen Shot 2019-07-16 at 13 42 52](https://user-images.githubusercontent.com/4053794/61328439-dda29780-a7cf-11e9-88ee-71376af4dab1.png)

![Screen Shot 2019-07-16 at 13 43 05](https://user-images.githubusercontent.com/4053794/61328441-dda29780-a7cf-11e9-9e12-995267c07f6c.png)
