### PR TITLE
"Infobar" customisable slim status gump

### DIFF
--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Game\Managers\CorpseManager.cs" />
     <Compile Include="Game\Managers\HealthLinesManager.cs" />
     <Compile Include="Game\Managers\HotkeysManager.cs" />
+    <Compile Include="Game\Managers\InfoBarManager.cs" />
     <Compile Include="Game\Managers\MacroManager.cs" />
     <Compile Include="Game\Managers\AudioManager.cs" />
     <Compile Include="Game\Managers\NameOverHeadManager.cs" />
@@ -152,6 +153,8 @@
     <Compile Include="Game\UI\Controls\AbstractTextBox.cs" />
     <Compile Include="Game\UI\Controls\AlphaBlendControl.cs" />
     <Compile Include="Game\UI\Controls\ArrowNumbersTextBox.cs" />
+    <Compile Include="Game\UI\Controls\ClickableColorBox.cs" />
+    <Compile Include="Game\UI\Controls\InfoBarBuilderControl.cs" />
     <Compile Include="Game\UI\Controls\ColorBox.cs" />
     <Compile Include="Game\UI\Controls\EditableLabel.cs" />
     <Compile Include="Game\UI\Controls\GumpPicWithWidth.cs" />
@@ -164,6 +167,7 @@
     <Compile Include="Game\UI\Controls\NiceButton.cs" />
     <Compile Include="Game\UI\Controls\TextureControl.cs" />
     <Compile Include="Game\UI\Gumps\GridLootGump.cs" />
+    <Compile Include="Game\UI\Gumps\InfoBarGump.cs" />
     <Compile Include="Game\UI\Gumps\NameOverHeadHandlerGump.cs" />
     <Compile Include="Game\UI\Gumps\StandardSkillsGump.cs" />
     <Compile Include="Game\UI\Gumps\TipNoticeGump.cs" />

--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -176,6 +176,17 @@ namespace ClassicUO.Configuration
         [JsonProperty] public Point OverrideContainerLocationPosition { get; set; } = new Point(200, 200);
         [JsonProperty] public bool DragSelectHumanoidsOnly { get; set; }
 
+        [JsonProperty] public bool ShowInfoBar { get; set; }
+        [JsonProperty] public int InfoBarHighlightType { get; set; } // 0 = text colour changes, 1 = underline
+        [JsonProperty]
+        public InfoBarItem[] InfoBarItems { get; set; } =
+        {
+            new InfoBarItem("Hits", InfoBarVars.HP, 0x1B6),
+            new InfoBarItem("Mana", InfoBarVars.Mana, 0x1ED),
+            new InfoBarItem("Stam", InfoBarVars.Stamina, 0x22E),
+            new InfoBarItem("Weight", InfoBarVars.Weight, 0x3D2),
+        };
+
         [JsonProperty] public int MaxFPS { get; set; } = 60;
 
         [JsonProperty]

--- a/src/Game/Managers/InfoBarManager.cs
+++ b/src/Game/Managers/InfoBarManager.cs
@@ -1,0 +1,108 @@
+﻿#region license
+
+//  Copyright (C) 2019 ClassicUO Development Community on Github
+//
+//	This project is an alternative client for the game Ultima Online.
+//	The goal of this is to develop a lightweight client considering 
+//	new technologies.  
+//      
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace ClassicUO.Game.Managers
+{
+    internal class InfoBarManager
+    {
+        private List<InfoBarItem> infoBarItems;
+
+        public InfoBarManager()
+        {
+            infoBarItems = new List<InfoBarItem>();
+
+            if (Engine.Profile.Current.InfoBarItems != null)
+            {
+                infoBarItems = Engine.Profile.Current.InfoBarItems?.ToList<InfoBarItem>();
+            }
+        }
+
+        public List<InfoBarItem> GetInfoBars()
+        {
+            return infoBarItems;
+        }
+
+        public void AddItem(InfoBarItem ibi)
+        {
+            infoBarItems.Add(ibi);
+        }
+
+        public void RemoveItem(InfoBarItem item)
+        {
+            infoBarItems.Remove(item);
+        }
+
+        public void Clear()
+        {
+            infoBarItems.Clear();
+        }
+
+    }
+
+    internal enum InfoBarVars
+    {
+        HP = 0,
+        Mana,
+        Stamina,
+        Weight,
+        Followers,
+        Gold,
+        Damage,
+        Armor,
+        Luck,
+        FireResist,
+        ColdResist,
+        PoisonResist,
+        EnergyResist,
+        LowerReagentCost,
+        SpellDamageInc,
+        FasterCasting,
+        FasterCastRecovery,
+        HitChanceInc,
+        DefenseChanceInc,
+        LowerManaCost,
+        DamageChanceInc,
+        SwingSpeedInc,
+        StatsCap,
+    }
+
+    [JsonObject]
+    internal class InfoBarItem
+    {
+        [JsonProperty] public string label;
+        [JsonProperty] public InfoBarVars var;
+        [JsonProperty] public ushort hue;
+
+        [JsonConstructor]
+        public InfoBarItem(string _label, InfoBarVars _var, Hue _labelColor)
+        {
+            label = _label;
+            var = _var;
+            hue = _labelColor;
+        }
+    }
+}

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -90,6 +90,8 @@ namespace ClassicUO.Game.Scenes
 
         public MacroManager Macros { get; private set; }
 
+        public InfoBarManager InfoBars { get; private set; }
+
         public Texture2D ViewportTexture => _renderTarget;
 
         public Texture2D Darkness => _darkness;
@@ -130,6 +132,7 @@ namespace ClassicUO.Game.Scenes
             HeldItem = new ItemHold();
             Hotkeys = new HotkeysManager();
             Macros = new MacroManager(Engine.Profile.Current.Macros);
+            InfoBars = new InfoBarManager();
             _healthLinesManager = new HealthLinesManager();
 
             WorldViewportGump viewport = new WorldViewportGump(this);

--- a/src/Game/UI/Controls/ClickableColorBox.cs
+++ b/src/Game/UI/Controls/ClickableColorBox.cs
@@ -1,0 +1,71 @@
+﻿#region license
+
+//  Copyright (C) 2019 ClassicUO Development Community on Github
+//
+//	This project is an alternative client for the game Ultima Online.
+//	The goal of this is to develop a lightweight client considering 
+//	new technologies.  
+//      
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Input;
+using ClassicUO.IO;
+using ClassicUO.Renderer;
+
+namespace ClassicUO.Game.UI.Controls
+{
+    internal class ClickableColorBox : ColorBox
+    {
+        private const int CELL = 12;
+
+        private readonly SpriteTexture _background;
+
+        public ClickableColorBox(int x, int y, int w, int h, ushort hue, uint color) : base(w, h, hue, color)
+        {
+            X = x + 3;
+            Y = y + 3;
+            WantUpdateSize = false;
+
+            _background = FileManager.Gumps.GetTexture(0x00D4);
+        }
+
+        public override void Update(double totalMS, double frameMS)
+        {
+            _background.Ticks = (long) totalMS;
+
+            base.Update(totalMS, frameMS);
+        }
+
+        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        {
+            ResetHueVector();
+            batcher.Draw2D(_background, x - 3, y - 3, ref _hueVector);
+
+            return base.Draw(batcher, x, y);
+        }
+
+        protected override void OnMouseUp(int x, int y, MouseButton button)
+        {
+            if (button == MouseButton.Left)
+            {
+                ColorPickerGump pickerGump = new ColorPickerGump(0, 0, 100, 100, s => SetColor(s, FileManager.Hues.GetPolygoneColor(CELL, s)));
+                Engine.UI.Add(pickerGump);
+            }
+        }
+    }
+}

--- a/src/Game/UI/Controls/InfoBarBuilderControl.cs
+++ b/src/Game/UI/Controls/InfoBarBuilderControl.cs
@@ -1,0 +1,68 @@
+﻿#region license
+
+//  Copyright (C) 2019 ClassicUO Development Community on Github
+//
+//	This project is an alternative client for the game Ultima Online.
+//	The goal of this is to develop a lightweight client considering 
+//	new technologies.  
+//      
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System;
+using ClassicUO.Game.Managers;
+using ClassicUO.IO;
+
+namespace ClassicUO.Game.UI.Controls
+{
+    internal class InfoBarBuilderControl : Control
+    {
+        public string LabelText { get { return infoLabel.Text; } }
+        public InfoBarVars Var { get { return (InfoBarVars) varStat.SelectedIndex; } }
+        public Hue Hue { get { return labelColor.Hue; } }
+
+        private TextBox infoLabel;
+        private Combobox varStat;
+        private ClickableColorBox labelColor;
+
+        public InfoBarBuilderControl(InfoBarItem item)
+        {
+            infoLabel = new TextBox(0xFF, 10, 80, 80) { X = 5, Y = 0, Width = 130, Height = 30, Text = item.label };
+
+            varStat = new Combobox(200, 0, 170, Enum.GetNames(typeof(InfoBarVars)), (int) item.var);
+
+            uint color = 0xFF7F7F7F;
+
+            if (item.hue != 0xFFFF)
+                color = FileManager.Hues.GetPolygoneColor(12, item.hue);
+
+            labelColor = new ClickableColorBox(150, 0, 13, 14, item.hue, color);
+
+            NiceButton deleteButton = new NiceButton(390, 0, 60, 25, ButtonAction.Activate, "Delete") { ButtonParameter = 999 };
+            deleteButton.MouseUp += (sender, e) =>
+            {
+                Dispose();
+            };
+
+            Add(new ResizePic(0x0BB8) { X = infoLabel.X - 5, Y = 0, Width = infoLabel.Width + 10, Height = infoLabel.Height - 6 });
+            Add(infoLabel);
+            Add(varStat);
+            Add(labelColor);
+            Add(deleteButton);
+        }
+
+    }
+
+}

--- a/src/Game/UI/Gumps/InfoBarGump.cs
+++ b/src/Game/UI/Gumps/InfoBarGump.cs
@@ -1,0 +1,284 @@
+﻿#region license
+
+//  Copyright (C) 2019 ClassicUO Development Community on Github
+//
+//	This project is an alternative client for the game Ultima Online.
+//	The goal of this is to develop a lightweight client considering 
+//	new technologies.  
+//      
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Renderer;
+using Microsoft.Xna.Framework;
+
+namespace ClassicUO.Game.UI.Gumps
+{
+    internal class InfoBarGump : Gump
+    {
+
+        private AlphaBlendControl _background;
+        private long _refreshTime;
+        private Label _name;
+
+        public InfoBarGump() : base(0, 0)
+        {
+            CanMove = true;
+            AcceptMouseInput = true;
+            AcceptKeyboardInput = false;
+            CanCloseWithRightClick = false;
+            CanBeSaved = true;
+            Height = 20;
+
+            Add(_background = new AlphaBlendControl(0.3f) { Width = Width, Height = Height });
+
+            _name = new Label(World.Player.Name, true, 999) { X = 5, Hue = World.Player.Hue };
+            Add(_name);
+
+            ResetItems();
+        }
+
+        public void ResetItems()
+        {
+            foreach (Control c in Children.OfType<InfoBarControl>())
+            {
+                c.Dispose();
+            }
+
+            List<InfoBarItem> infoBarItems = Engine.SceneManager.GetScene<GameScene>().InfoBars.GetInfoBars();
+
+            for (int i = 0; i < infoBarItems.Count; i++)
+            {
+                Add(new InfoBarControl(infoBarItems[i].label, infoBarItems[i].var, infoBarItems[i].hue));
+            }
+        }
+
+        public override void Update(double totalMS, double frameMS)
+        {
+            if (IsDisposed)
+                return;
+
+            if (_refreshTime < totalMS)
+            {
+                _refreshTime = (long) totalMS + 125;
+
+                _name.Text = World.Player.Name;
+                _name.Hue = Notoriety.GetHue(World.Player.NotorietyFlag);
+
+                int x = _name.Bounds.Right + 5;
+
+                foreach (Control c in Children.OfType<InfoBarControl>())
+                {
+                    c.X = x;
+                    x += c.Width + 5;
+                }
+            }
+
+            base.Update(totalMS, frameMS);
+
+            Control last = Children.LastOrDefault();
+
+            if (last != null)
+            {
+                Width = last.Bounds.Right;
+            }
+
+            _background.Width = Width;
+        }
+
+
+    }
+
+
+    class InfoBarControl : Control
+    {
+        private Label _label;
+        private Label _data;
+        private InfoBarVars _var;
+        private Hue _warningLinesHue;
+        protected long _refreshTime;
+
+        public InfoBarControl(string label, InfoBarVars var, ushort hue)
+        {
+            AcceptMouseInput = false;
+            WantUpdateSize = true;
+            CanMove = false;
+
+            _label = new Label(label, true, 999) { Height = 20, Hue = hue };
+            _var = var;
+
+            _data = new Label("", true, 999) { Height = 20, X = _label.Width, Hue = 0xFFFF };
+            Add(_label);
+            Add(_data);
+        }
+
+        public override void Update(double totalMS, double frameMS)
+        {
+            if (IsDisposed)
+                return;
+
+            if (_refreshTime < totalMS)
+            {
+                _refreshTime = (long) totalMS + 125;
+
+                _data.Text = GetVarData(_var);
+                
+                if (Engine.Profile.Current.InfoBarHighlightType == 0)
+                {
+                    _data.Hue = GetVarHue(_var);
+                }
+                else
+                {
+                    _data.Hue = 0xFFFF;
+                    _warningLinesHue = GetVarHue(_var);
+                }
+                
+                _data.WantUpdateSize = true;
+            }
+
+            WantUpdateSize = true;
+
+            base.Update(totalMS, frameMS);
+        }
+
+        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        {
+            base.Draw(batcher, x, y);
+
+            Vector3 dataHue = Vector3.Zero;
+
+            if (Engine.Profile.Current.InfoBarHighlightType == 1)
+            {
+                ShaderHuesTraslator.GetHueVector(ref dataHue, _warningLinesHue);
+                batcher.Draw2D(Textures.GetTexture(Color.White), _data.ScreenCoordinateX, _data.ScreenCoordinateY, _data.Width, 2, ref dataHue);
+                batcher.Draw2D(Textures.GetTexture(Color.White), _data.ScreenCoordinateX, _data.ScreenCoordinateY + Parent.Height - 2, _data.Width, 2, ref dataHue);
+            }
+
+            return true;
+        }
+
+        private string GetVarData(InfoBarVars var)
+        {
+            switch (var)
+            {
+                case InfoBarVars.HP:
+                    return World.Player.Hits + "/" + World.Player.HitsMax;
+                case InfoBarVars.Mana:
+                    return World.Player.Mana + "/" + World.Player.ManaMax;
+                case InfoBarVars.Stamina:
+                    return World.Player.Stamina + "/" + World.Player.StaminaMax;
+                case InfoBarVars.Weight:
+                    return World.Player.Weight + "/" + World.Player.WeightMax;
+                case InfoBarVars.Followers:
+                    return World.Player.Followers + "/" + World.Player.FollowersMax;
+                case InfoBarVars.Gold:
+                    return World.Player.Gold.ToString();
+                case InfoBarVars.Damage:
+                    return World.Player.DamageMin + "-" + World.Player.DamageMax;
+                case InfoBarVars.Armor:
+                    return World.Player.PhysicalResistence.ToString();
+                case InfoBarVars.Luck:
+                    return World.Player.Luck.ToString();
+                case InfoBarVars.FireResist:
+                    return World.Player.FireResistance.ToString();
+                case InfoBarVars.ColdResist:
+                    return World.Player.ColdResistance.ToString();
+                case InfoBarVars.PoisonResist:
+                    return World.Player.PoisonResistance.ToString();
+                case InfoBarVars.EnergyResist:
+                    return World.Player.EnergyResistance.ToString();
+                case InfoBarVars.LowerReagentCost:
+                    return World.Player.LowerReagentCost.ToString();
+                case InfoBarVars.SpellDamageInc:
+                    return World.Player.SpellDamageIncrease.ToString();
+                case InfoBarVars.FasterCasting:
+                    return World.Player.FasterCasting.ToString();
+                case InfoBarVars.FasterCastRecovery:
+                    return World.Player.FasterCastRecovery.ToString();
+                case InfoBarVars.HitChanceInc:
+                    return World.Player.HitChanceIncrease.ToString();
+                case InfoBarVars.DefenseChanceInc:
+                    return World.Player.DefenseChanceIncrease.ToString();
+                case InfoBarVars.LowerManaCost:
+                    return World.Player.LowerManaCost.ToString();
+                case InfoBarVars.DamageChanceInc:
+                    return World.Player.DamageIncrease.ToString();
+                case InfoBarVars.SwingSpeedInc:
+                    return World.Player.SwingSpeedIncrease.ToString();
+                case InfoBarVars.StatsCap:
+                    return World.Player.StatsCap.ToString();
+                default:
+                    return "";
+            }
+        }
+
+        private ushort GetVarHue(InfoBarVars var)
+        {
+            float percent;
+            switch (var)
+            {
+                case InfoBarVars.HP:
+                    percent = (float) World.Player.Hits / (float) World.Player.HitsMax;
+                    if (percent <= 0.25)
+                        return 0x0021;
+                    else if (percent <= 0.5)
+                        return 0x0030;
+                    else if (percent <= 0.75)
+                        return 0x0035;
+                    else
+                        return 0xFFFF;
+                case InfoBarVars.Mana:
+                    percent = (float) World.Player.Mana / (float) World.Player.ManaMax;
+                    if (percent <= 0.25)
+                        return 0x0021;
+                    else if (percent <= 0.5)
+                        return 0x0030;
+                    else if (percent <= 0.75)
+                        return 0x0035;
+                    else
+                        return 0xFFFF;
+                case InfoBarVars.Stamina:
+                    percent = (float) World.Player.Stamina / (float) World.Player.StaminaMax;
+                    if (percent <= 0.25)
+                        return 0x0021;
+                    else if (percent <= 0.5)
+                        return 0x0030;
+                    else if (percent <= 0.75)
+                        return 0x0035;
+                    else
+                        return 0xFFFF;
+                case InfoBarVars.Weight:
+                    percent = (float) World.Player.Weight / (float) World.Player.WeightMax;
+                    if (percent >= 1)
+                        return 0x0021;
+                    else if (percent >= 0.75)
+                        return 0x0030;
+                    else if (percent >= 0.5)
+                        return 0x0035;
+                    else
+                        return 0xFFFF;
+                default:
+                    return 0xFFFF;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7057924/61717120-63868b80-ad58-11e9-895f-f0a37a049c6d.png)

- Satisfies the request for a smaller status gump, while keeping it shard agnostic
- Adds some assistant titlebar functionality we're missing (coloured name for notoriety, coloured stats based on %)
- Because of the large game window size allowed by ClassicUO, the large status gump and titlebar are usually far from the game window centre. This gump allows the info to be anywhere on screen for easier reading, without getting in the way

Supported stats:
![image](https://user-images.githubusercontent.com/7057924/61720423-a77c8f00-ad5e-11e9-98c3-9ce23cec3099.png)
(for Outlands users, ColdResist = criminal timer, EnergyResist = bandage timer, PosionResist = pvp cooldown, Luck = food satisfaction or something, StatsCap = Murder Count, FireResist = Count Decay


Since I'm using ClickableColorBox outside of OptionsGump, I moved it into its own file.