### PR TITLE
Generic profile json

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -48,9 +48,9 @@ namespace ClassicUO.Configuration
             CharacterName = charactername;
         }
 
-        [JsonProperty] public string Username { get; }
-        [JsonProperty] public string ServerName { get; }
-        [JsonProperty] public string CharacterName { get; }
+        [JsonIgnore] public string Username { get; set; }
+        [JsonIgnore] public string ServerName { get; set;  }
+        [JsonIgnore] public string CharacterName { get; set;  }
 
         // sounds
         [JsonProperty] public bool EnableSound { get; set; } = true;

--- a/src/Configuration/ProfileManager.cs
+++ b/src/Configuration/ProfileManager.cs
@@ -46,7 +46,17 @@ namespace ClassicUO.Configuration
                                                               {
                                                                   TypeNameHandling = TypeNameHandling.All,
                                                                   MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead
-                                                              }) ?? new Profile(username, servername, charactername);
+                                                              });
+                if (Current == null)
+                {
+                    Current = new Profile(username, servername, charactername);
+                }
+                else
+                {
+                    Current.Username = username;
+                    Current.ServerName = servername;
+                    Current.CharacterName = charactername;
+                }
             }
         }
 


### PR DESCRIPTION
No more username/account name in the profile.

- Can be copied between characters with no editing
- Fixes the issue where if you log in as an incognito/disguised character (giving a blank profile instead of the real one), and then log out after the effect has expired, the real profile was overwritten by the new blank one. Now the blank profile is only written to the incognito character name folder.