### PR TITLE
Allow smaller circle of transparency

### DIFF
--- a/src/Game/Constants.cs
+++ b/src/Game/Constants.cs
@@ -99,7 +99,7 @@ namespace ClassicUO.Game
         public const ushort FIELD_REPLACE_GRAPHIC = 0x1826;
         public const ushort TREE_REPLACE_GRAPHIC = 0x0E59;
 
-        public const int MIN_CIRCLE_OF_TRANSPARENCY_RADIUS = 2;
+        public const int MIN_CIRCLE_OF_TRANSPARENCY_RADIUS = 1;
         public const int MAX_CIRCLE_OF_TRANSPARENCY_RADIUS = 8;
 
         public const int MAX_ABILITIES_COUNT = 32;


### PR DESCRIPTION
Someone asked to set 1 instead of 2, why not?

![image](https://user-images.githubusercontent.com/7057924/62579535-f288bd00-b89b-11e9-9c1f-3acd4dbca29f.png)
