### PR TITLE
Fix chat focus events and other chat improvements

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -151,7 +151,6 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool UseDarkNights { get; set; }
         [JsonProperty] public int CloseHealthBarType { get; set; } // 0 = none, 1 == not exists, 2 == is dead
         [JsonProperty] public bool ActivateChatAfterEnter { get; set; }
-        [JsonProperty] public bool ActivateChatStatus { get; set; } = true;
         [JsonProperty] public bool ActivateChatIgnoreHotkeys { get; set; } = true;
         [JsonProperty] public bool ActivateChatIgnoreHotkeysPlugins { get; set; } = true;
         [JsonProperty] public bool ActivateChatAdditionalButtons { get; set; } = true;

--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -151,8 +151,6 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool UseDarkNights { get; set; }
         [JsonProperty] public int CloseHealthBarType { get; set; } // 0 = none, 1 == not exists, 2 == is dead
         [JsonProperty] public bool ActivateChatAfterEnter { get; set; }
-        [JsonProperty] public bool ActivateChatIgnoreHotkeys { get; set; } = true;
-        [JsonProperty] public bool ActivateChatIgnoreHotkeysPlugins { get; set; } = true;
         [JsonProperty] public bool ActivateChatAdditionalButtons { get; set; } = true;
         [JsonProperty] public bool ActivateChatShiftEnterSupport { get; set; } = true;
 

--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+using ClassicUO.Game;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
@@ -262,7 +263,11 @@ namespace ClassicUO.Game.Managers
                         {
                             _keyboardFocusControl = c.GetFirstControlAcceptKeyboardInput();
 
-                            if (_keyboardFocusControl != null) break;
+                            if (_keyboardFocusControl != null)
+                            {
+                                _keyboardFocusControl.OnFocusEnter();
+                                break;
+                            }
                         }
                     }
                 }
@@ -277,6 +282,36 @@ namespace ClassicUO.Game.Managers
                     _keyboardFocusControl = value;
                     value.OnFocusEnter();
                 }
+            }
+        }
+
+        public bool IsKeyboardFocusAllowHotkeys
+        {
+            get
+            {
+                // TODO: `ActivateChatIgnoreHotkeysPlugins` should be refactored into something like `[Smart]IgnoreHotkeysOnTextInput`
+                //   that will not depend on `ActivateChatAfterEnter`
+
+                // We are not at the game scene or no player character present
+                if (World.Player == null || !(Engine.SceneManager.CurrentScene is GameScene gs))
+                    return false;
+
+                // System Chat is NOT focused (items stack amount field or macros text fields is probably focused),
+                // it means that some other text input is focused and we're going to enter some text there
+                // thus we don't expect to execute any game macro or trigger any plugin hotkeys
+                if (Engine.UI.SystemChat?.IsFocused == false)
+                    return false;
+
+                // "Press 'Enter' to activate chat" is enabled and System Chat is active,
+                // it means that we want to enter some text into the chat,
+                // thus we don't expect to execute any game macro or trigger any plugin hotkeys
+                if (Engine.Profile.Current.ActivateChatAfterEnter &&
+                    Engine.Profile.Current.ActivateChatIgnoreHotkeys && // NOTE: Let's keep this for now, but refactor later
+                    Engine.UI.SystemChat?.IsActive == true)
+                    return false;
+
+                // In all other cases hotkeys for macros and plugins are allowed
+                return true;
             }
         }
 

--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -289,9 +289,6 @@ namespace ClassicUO.Game.Managers
         {
             get
             {
-                // TODO: `ActivateChatIgnoreHotkeysPlugins` should be refactored into something like `[Smart]IgnoreHotkeysOnTextInput`
-                //   that will not depend on `ActivateChatAfterEnter`
-
                 // We are not at the game scene or no player character present
                 if (World.Player == null || !(Engine.SceneManager.CurrentScene is GameScene gs))
                     return false;
@@ -306,7 +303,6 @@ namespace ClassicUO.Game.Managers
                 // it means that we want to enter some text into the chat,
                 // thus we don't expect to execute any game macro or trigger any plugin hotkeys
                 if (Engine.Profile.Current.ActivateChatAfterEnter &&
-                    Engine.Profile.Current.ActivateChatIgnoreHotkeys && // NOTE: Let's keep this for now, but refactor later
                     Engine.UI.SystemChat?.IsActive == true)
                     return false;
 

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -692,7 +692,7 @@ namespace ClassicUO.Game.Scenes
 
             if (_isUpDown || _isDownDown || _isLeftDown || _isRightDown)
             {
-                if (!Engine.Profile.Current.ActivateChatStatus || Engine.UI.SystemChat?.textBox.Text.Length == 0)
+                if (Engine.UI.SystemChat?.IsActive == false || Engine.UI.SystemChat?.textBox.Text.Length == 0)
                     _arrowKeyPressed = true;
             }
 
@@ -702,11 +702,8 @@ namespace ClassicUO.Game.Scenes
             if (TargetManager.IsTargeting && e.keysym.sym == SDL.SDL_Keycode.SDLK_ESCAPE && Keyboard.IsModPressed(e.keysym.mod, SDL.SDL_Keymod.KMOD_NONE))
                 TargetManager.CancelTarget();
 
-            if (Engine.Profile.Current.ActivateChatAfterEnter)
-            {
-                if (Engine.Profile.Current.ActivateChatIgnoreHotkeys && Engine.Profile.Current.ActivateChatStatus)
-                    return;
-            }
+            if (!Engine.UI.IsKeyboardFocusAllowHotkeys)
+                return;
 
             if (e.keysym.sym == SDL.SDL_Keycode.SDLK_TAB /*&& !Engine.Profile.Current.DisableTabBtn*/)
             {

--- a/src/Game/UI/Controls/Control.cs
+++ b/src/Game/UI/Controls/Control.cs
@@ -774,6 +774,7 @@ namespace ClassicUO.Game.UI.Controls
 
         internal virtual void OnFocusEnter()
         {
+            Parent?.OnFocusEnter();
         }
 
         internal virtual void OnFocusLeft()

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -84,7 +84,7 @@ namespace ClassicUO.Game.UI.Gumps
         // GameWindowSize
         private TextBox _gameWindowWidth;
         private Combobox _gridLoot;
-        private Checkbox _highlightObjects, /*_smoothMovements,*/ _enablePathfind, _alwaysRun, _showHpMobile, _highlightByState, _drawRoofs, _treeToStumps, _hideVegetation, _noColorOutOfRangeObjects, _useCircleOfTransparency, _enableTopbar, _holdDownKeyTab, _holdDownKeyAlt, _chatAfterEnter, _chatIgnodeHotkeysCheckbox, _chatIgnodeHotkeysPluginsCheckbox, _chatAdditionalButtonsCheckbox, _chatShiftEnterCheckbox, _enableCaveBorder;
+        private Checkbox _highlightObjects, /*_smoothMovements,*/ _enablePathfind, _alwaysRun, _showHpMobile, _highlightByState, _drawRoofs, _treeToStumps, _hideVegetation, _noColorOutOfRangeObjects, _useCircleOfTransparency, _enableTopbar, _holdDownKeyTab, _holdDownKeyAlt, _chatAfterEnter, _chatAdditionalButtonsCheckbox, _chatShiftEnterCheckbox, _enableCaveBorder;
         private Combobox _hpComboBox, _healtbarType, _fieldsType, _hpComboBoxShowWhen;
 
         // combat & spells
@@ -886,18 +886,17 @@ namespace ClassicUO.Game.UI.Gumps
 
             // [BLOCK] activate chat
             {
-                _chatAfterEnter = new Checkbox(0x00D2, 0x00D3, "Activate chat after `Enter` pressing", FONT, HUE_FONT)
+                _chatAfterEnter = new Checkbox(0x00D2, 0x00D3, "Press `Enter` to activate chat", FONT, HUE_FONT)
                 {
                     Y = 0,
                     IsChecked = Engine.Profile.Current.ActivateChatAfterEnter
                 };
                 _chatAfterEnter.ValueChanged += (sender, e) => { _activeChatArea.IsVisible = _chatAfterEnter.IsChecked; };
-
                 rightArea.Add(_chatAfterEnter);
 
                 _activeChatArea = new ScrollAreaItem();
 
-                _chatAdditionalButtonsCheckbox = new Checkbox(0x00D2, 0x00D3, "Additional buttons activate chat: ! ; : / \\ , . [ | -", FONT, HUE_FONT)
+                _chatAdditionalButtonsCheckbox = new Checkbox(0x00D2, 0x00D3, "Use additional buttons to activate chat: ! ; : / \\ , . [ | -", FONT, HUE_FONT)
                 {
                     X = 20,
                     Y = 15,
@@ -905,7 +904,7 @@ namespace ClassicUO.Game.UI.Gumps
                 };
                 _activeChatArea.Add(_chatAdditionalButtonsCheckbox);
 
-                _chatShiftEnterCheckbox = new Checkbox(0x00D2, 0x00D3, "Shift+Enter send message without closing chat", FONT, HUE_FONT)
+                _chatShiftEnterCheckbox = new Checkbox(0x00D2, 0x00D3, "Use `Shift+Enter` to send message without closing chat", FONT, HUE_FONT)
                 {
                     X = 20,
                     Y = 35,
@@ -913,33 +912,9 @@ namespace ClassicUO.Game.UI.Gumps
                 };
                 _activeChatArea.Add(_chatShiftEnterCheckbox);
 
-                var text = new Label("If chat active - ignores hotkeys from:", true, HUE_FONT)
-                {
-                    X = 20,
-                    Y = 60
-                };
-
-                _activeChatArea.Add(text);
-
-                _chatIgnodeHotkeysCheckbox = new Checkbox(0x00D2, 0x00D3, "Client (macro system)", FONT, HUE_FONT)
-                {
-                    X = 40,
-                    Y = 85,
-                    IsChecked = Engine.Profile.Current.ActivateChatIgnoreHotkeys
-                };
-                _activeChatArea.Add(_chatIgnodeHotkeysCheckbox);
-
-                _chatIgnodeHotkeysPluginsCheckbox = new Checkbox(0x00D2, 0x00D3, "Plugins (Razor)", FONT, HUE_FONT)
-                {
-                    X = 40,
-                    Y = 105,
-                    IsChecked = Engine.Profile.Current.ActivateChatIgnoreHotkeysPlugins
-                };
-                _activeChatArea.Add(_chatIgnodeHotkeysPluginsCheckbox);
-
-                rightArea.Add(_activeChatArea);
-
                 _activeChatArea.IsVisible = _chatAfterEnter.IsChecked;
+                
+                rightArea.Add(_activeChatArea);
             }
 
             _speechColorPickerBox = CreateClickableColorBox(rightArea, 0, 20, Engine.Profile.Current.SpeechHue, "Speech Color", 20, 20);
@@ -1395,8 +1370,6 @@ namespace ClassicUO.Game.UI.Gumps
                     _allyMessageColorPickerBox.SetColor(0x0057, FileManager.Hues.GetPolygoneColor(12, 0x0057));
                     _chatAfterEnter.IsChecked = false;
                     Engine.UI.SystemChat.IsActive = !_chatAfterEnter.IsChecked;
-                    _chatIgnodeHotkeysCheckbox.IsChecked = true;
-                    _chatIgnodeHotkeysPluginsCheckbox.IsChecked = true;
                     _chatAdditionalButtonsCheckbox.IsChecked = true;
                     _chatShiftEnterCheckbox.IsChecked = true;
                     _activeChatArea.IsVisible = _chatAfterEnter.IsChecked;
@@ -1579,8 +1552,6 @@ namespace ClassicUO.Game.UI.Gumps
                 Engine.Profile.Current.ActivateChatAfterEnter = _chatAfterEnter.IsChecked;
             }
 
-            Engine.Profile.Current.ActivateChatIgnoreHotkeys = _chatIgnodeHotkeysCheckbox.IsChecked;
-            Engine.Profile.Current.ActivateChatIgnoreHotkeysPlugins = _chatIgnodeHotkeysPluginsCheckbox.IsChecked;
             Engine.Profile.Current.ActivateChatAdditionalButtons = _chatAdditionalButtonsCheckbox.IsChecked;
             Engine.Profile.Current.ActivateChatShiftEnterSupport = _chatShiftEnterCheckbox.IsChecked;
             Engine.Profile.Current.SaveJournalToFile = _saveJournalCheckBox.IsChecked;

--- a/src/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/Game/UI/Gumps/SystemChatControl.cs
@@ -66,6 +66,7 @@ namespace ClassicUO.Game.UI.Gumps
         public readonly TextBox textBox;
 
         private bool _isActive;
+        private bool _isFocused = false;
         private int _messageHistoryIndex = -1;
         private ChatMode _mode = ChatMode.Default;
 
@@ -126,7 +127,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (_isActive)
                 {
-                    Engine.Profile.Current.ActivateChatStatus = _trans.IsVisible = true;
+                    _trans.IsVisible = true;
                     _trans.Y = textBox.Y;
                     textBox.Width = _trans.Width;
                     textBox.SetText(string.Empty);
@@ -135,11 +136,15 @@ namespace ClassicUO.Game.UI.Gumps
                 else
                 {
                     int height = FileManager.Fonts.GetHeightUnicode(Engine.Profile.Current.ChatFont, "123ABC", Width, 0, (ushort) (FontStyle.BlackBorder | FontStyle.Fixed));
-                    Engine.Profile.Current.ActivateChatStatus = false;
                     textBox.Width = 1;
                     _trans.Y = textBox.Y + height + 3;
                 }
             }
+        }
+
+        public bool IsFocused
+        {
+            get => _isFocused;
         }
 
         private ChatMode Mode
@@ -215,6 +220,16 @@ namespace ClassicUO.Game.UI.Gumps
             textBox.IsEditable = true;
             textBox.SetKeyboardFocus();
             textBox.IsEditable = _isActive;
+        }
+
+        internal override void OnFocusEnter()
+        {
+            _isFocused = true;
+        }
+
+        internal override void OnFocusLeft()
+        {
+            _isFocused = false;
         }
 
         public void ToggleChatVisibility()

--- a/src/Network/Plugin.cs
+++ b/src/Network/Plugin.cs
@@ -360,13 +360,7 @@ namespace ClassicUO.Network
         {
             bool result = true;
 
-            // Activate chat after `Enter` pressing, 
-            // If chat active - ignores hotkeys from Razor (Plugins)
-            if (World.Player != null &&
-                Engine.Profile.Current.ActivateChatAfterEnter &&
-                Engine.Profile.Current.ActivateChatIgnoreHotkeysPlugins &&
-                Engine.Profile.Current.ActivateChatStatus &&
-                Engine.SceneManager.CurrentScene is GameScene gs)
+            if (!Engine.UI.IsKeyboardFocusAllowHotkeys)
                 return true;
 
             foreach (Plugin plugin in _plugins)


### PR DESCRIPTION
This commit addresses two issues:
1. When keyboard focus was switched from active/inactive chat input field to any other input field and then switched back to chat, the SystemChatControl didn't get proper event about it getting focus back. This invalid behavior was fixed and now when game returns keyboard focus back to system chat, its `OnFocusEnter` event will be properly fired;
2. When other than system chat input fields were focused for keyboard input, game still executed macros and passed hotkey events to plugins. This is now also fixed and if any other text input field but system chat is focused, any input from the keyboard will ignore macros' and plugins' hotkeys.