### PR TITLE
Add change party color name hue to match notoriety

### DIFF
--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -417,7 +417,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (CanBeSaved)
                 {
-                    Add(_textBox = new TextBox(3, width: 120, isunicode: false, style: FontStyle.Fixed, hue: 0x0386)
+                    Add(_textBox = new TextBox(3, width: 120, isunicode: false, style: FontStyle.Fixed, hue: Notoriety.GetHue(World.Player.NotorietyFlag))
                     {
                         X = 0,
                         Y = -2,


### PR DESCRIPTION
This darkgray is hard to read and makes no sense being gray.
https://gyazo.com/06c5f4738864d494004f820c21a5276f

made it match notoriety
https://gyazo.com/9fd4911f637449839ca7a946603421f0