### PR TITLE
missing double click mouse button checks

### DIFF
--- a/src/Game/UI/Controls/ItemGump.cs
+++ b/src/Game/UI/Controls/ItemGump.cs
@@ -302,6 +302,9 @@ namespace ClassicUO.Game.UI.Controls
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)
         {
+            if (button != MouseButton.Left)
+                return false;
+
             GameActions.DoubleClick(Item);
             _sendClickIfNotDClick = false;
             _lastClickPosition = Point.Zero;

--- a/src/Game/UI/Gumps/BulletinBoardGump.cs
+++ b/src/Game/UI/Gumps/BulletinBoardGump.cs
@@ -356,6 +356,9 @@ namespace ClassicUO.Game.UI.Gumps
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)
         {
+            if (button != MouseButton.Left)
+                return false;
+
             NetClient.Socket.Send(new PBulletinBoardRequestMessage(LocalSerial, Item));
 
             return true;

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -575,15 +575,19 @@ namespace ClassicUO.Game.UI.Gumps
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)
         {
+            if (button != MouseButton.Left)
+                return false;
+
             var entity = World.Get(LocalSerial);
 
             if (entity != null)
             {
                 if (entity != World.Player)
                 {
-                    if (World.Player.InWarMode && World.Player != entity)
+                    if (World.Player.InWarMode)
                         GameActions.Attack(entity);
-                    else if (button == MouseButton.Left) GameActions.DoubleClick(entity);
+                    else
+                        GameActions.DoubleClick(entity);
                 }
                 else
                 {


### PR DESCRIPTION
If closing multiple containers quickly with right mouse button, it can count as a double click on items in the container below.

I wonder if OnMouseDoubleClick should only be raised for left mouse, at least for UI elements, since now everything has an individual check for left mouse being used.