### PR TITLE
Added option hold shift for quantity

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -134,6 +134,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool HoldDownKeyTab { get; set; } = true;
         [JsonProperty] public bool HoldDownKeyAltToCloseAnchored { get; set; } = true;
         [JsonProperty] public bool HoldShiftForContext { get; set; } = false;
+        [JsonProperty] public bool HoldShiftForQuantity { get; set; } = false;
 
         // general
         [JsonProperty] public Point WindowClientBounds { get; set; } = new Point(600, 480);

--- a/src/Game/Scenes/GameSceneDragAndDropHandler.cs
+++ b/src/Game/Scenes/GameSceneDragAndDropHandler.cs
@@ -63,20 +63,23 @@ namespace ClassicUO.Game.Scenes
             if (World.Player.IsDead || item == null || item.IsDestroyed || item.IsMulti || item.OnGround && (item.IsLocked || item.Distance > Constants.DRAG_ITEMS_DISTANCE))
                 return false;
 
-            if (!_isShiftDown && !amount.HasValue && item.Amount > 1 && item.ItemData.IsStackable)
+            if (!amount.HasValue && item.Amount > 1 && item.ItemData.IsStackable)
             {
-                if (Engine.UI.GetGump<SplitMenuGump>(item) != null)
-                    return false;
-
-                SplitMenuGump gump = new SplitMenuGump(item, new Point(x, y))
+                if (Engine.Profile.Current.HoldShiftForQuantity == _isShiftDown)
                 {
-                    X = Mouse.Position.X - 80,
-                    Y = Mouse.Position.Y - 40
-                };
-                Engine.UI.Add(gump);
-                Engine.UI.AttemptDragControl(gump, Mouse.Position, true);
+                    if (Engine.UI.GetGump<SplitMenuGump>(item) != null)
+                        return false;
 
-                return true;
+                    SplitMenuGump gump = new SplitMenuGump(item, new Point(x, y))
+                    {
+                        X = Mouse.Position.X - 80,
+                        Y = Mouse.Position.Y - 40
+                    };
+                    Engine.UI.Add(gump);
+                    Engine.UI.AttemptDragControl(gump, Mouse.Position, true);
+
+                    return true;
+                }
             }
 
             return PickupItemDirectly(item, x, y, amount ?? item.Amount);

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -116,7 +116,7 @@ namespace ClassicUO.Game.UI.Gumps
         private ColorBox _poisonColorPickerBox, _paralyzedColorPickerBox, _invulnerableColorPickerBox;
         private TextBox _spellFormatBox;
         private Checkbox _useStandardSkillsGump, _showMobileNameIncoming, _showCorpseNameIncoming;
-        private Checkbox _holdShiftForContext, _reduceFPSWhenInactive, _sallosEasyGrab, _partyInviteGump;
+        private Checkbox _holdShiftForContext, _holdShiftForQuantity, _reduceFPSWhenInactive, _sallosEasyGrab, _partyInviteGump;
 
         //VendorGump Size Option
         private ArrowNumbersTextBox _vendorGumpSize;
@@ -261,6 +261,7 @@ namespace ClassicUO.Game.UI.Gumps
             _holdDownKeyTab = CreateCheckBox(rightArea, "Hold TAB key for combat", Engine.Profile.Current.HoldDownKeyTab, 0, 0);
             _holdDownKeyAlt = CreateCheckBox(rightArea, "Hold ALT key + right click to close Anchored gumps", Engine.Profile.Current.HoldDownKeyAltToCloseAnchored, 0, 0);
             _holdShiftForContext = CreateCheckBox(rightArea, "Hold Shift for Context Menus", Engine.Profile.Current.HoldShiftForContext, 0, 0);
+            _holdShiftForQuantity = CreateCheckBox(rightArea, "Hold Shift for item quantity", Engine.Profile.Current.HoldShiftForQuantity, 0, 0);
             _highlightByState = CreateCheckBox(rightArea, "Highlight by state (poisoned, yellow hits, paralyzed)", Engine.Profile.Current.HighlightMobilesByFlags, 0, 0);
             _poisonColorPickerBox = CreateClickableColorBox(rightArea, 20, 5, Engine.Profile.Current.PoisonHue, "Poisoned Color", 40, 5);
             _paralyzedColorPickerBox = CreateClickableColorBox(rightArea, 20, 0, Engine.Profile.Current.ParalyzedHue, "Paralyzed Color", 40, 0);
@@ -1307,6 +1308,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _holdDownKeyTab.IsChecked = true;
                     _holdDownKeyAlt.IsChecked = true;
                     _holdShiftForContext.IsChecked = false;
+                    _holdShiftForQuantity.IsChecked = false;
                     _enablePathfind.IsChecked = false;
                     _alwaysRun.IsChecked = false;
                     _showHpMobile.IsChecked = false;
@@ -1500,6 +1502,7 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.HoldDownKeyTab = _holdDownKeyTab.IsChecked;
             Engine.Profile.Current.HoldDownKeyAltToCloseAnchored = _holdDownKeyAlt.IsChecked;
             Engine.Profile.Current.HoldShiftForContext = _holdShiftForContext.IsChecked;
+            Engine.Profile.Current.HoldShiftForQuantity = _holdShiftForQuantity.IsChecked;
             Engine.Profile.Current.CloseHealthBarType = _healtbarType.SelectedIndex;
 
             if (Engine.Profile.Current.DrawRoofs == _drawRoofs.IsChecked)


### PR DESCRIPTION
This adds the option "Hold Shift for item quantity" under the "General" tab.
It basically inverts the Shift + Drag item behaviour, making it so that you don't have to hold down shift every time you want to move an entire stack of items.
As someone who plays modern games, this is a must have option.

![ClassicUO_2019-09-24_23-54-49](https://user-images.githubusercontent.com/1727541/65553354-fabdba00-df26-11e9-8f16-d2b657e3023a.png)

![2019-09-24_23-55-02](https://user-images.githubusercontent.com/1727541/65553427-2476e100-df27-11e9-8c6d-f89f08afecff.gif)

