### PR TITLE
Settings system update (#2)

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -317,14 +317,14 @@ namespace ClassicUO.Configuration
 
             Log.Message(LogTypes.Trace, $"Saving path:\t\t{path}");
 
-            // save settings.json
+            // Save profile settings
             ConfigurationResolver.Save(this, Path.Combine(path, "profile.json"), new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.All,
                 MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead
             });
 
-            // save gumps.bin
+            // Save opened gumps
             SaveGumps(path, gumps);
 
             Log.Message(LogTypes.Trace, "Saving done!");

--- a/src/Configuration/ProfileManager.cs
+++ b/src/Configuration/ProfileManager.cs
@@ -41,7 +41,7 @@ namespace ClassicUO.Configuration
 
 
 
-            // this is a temporary patch to change the profile settings name safety
+            // FIXME: this is a temporary patch to change the profile settings name safety
             string fileToLoad = Path.Combine(path, "settings.json");
             string newPath = Path.Combine(path, "profile.json");
 
@@ -53,7 +53,7 @@ namespace ClassicUO.Configuration
                     {
                         File.Delete(fileToLoad);
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
                         Log.Message(LogTypes.Warning, $"Failed to delete file: '{fileToLoad}'");
                     }

--- a/src/Configuration/Settings.cs
+++ b/src/Configuration/Settings.cs
@@ -101,6 +101,20 @@ namespace ClassicUO.Configuration
 
 
         public const string SETTINGS_FILENAME = "settings.json";
+        public static string CustomSettingsFilepath = null;
+
+        public static string GetSettingsFilepath()
+        {
+            if (CustomSettingsFilepath != null)
+            {
+                if (Path.IsPathRooted(CustomSettingsFilepath))
+                    return CustomSettingsFilepath;
+                else
+                    return Path.Combine(Engine.ExePath, CustomSettingsFilepath);
+            }
+
+            return Path.Combine(Engine.ExePath, SETTINGS_FILENAME);
+        }
 
         public void Save()
         {
@@ -117,7 +131,7 @@ namespace ClassicUO.Configuration
 
             // NOTE: We can do any other settings clean-ups here before we save them
 
-            ConfigurationResolver.Save(settingsToSave, Path.Combine(Engine.ExePath, SETTINGS_FILENAME));
+            ConfigurationResolver.Save(settingsToSave, GetSettingsFilepath());
         }
 
         public bool IsValid()

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -26,7 +26,7 @@ namespace ClassicUO
             if (updater.Check())
                 return;
 #endif
-            ParseAdditionalArgs(args);
+            ParseMainArgs(args);
 
             if (!SkipUpdate)
                 if (CheckUpdate(args))
@@ -39,21 +39,40 @@ namespace ClassicUO
         public static bool StartInLittleWindow { get; set; }
         public static bool SkipUpdate { get; set; }
 
-        private static void ParseAdditionalArgs(string[] args)
+        private static void ParseMainArgs(string[] args)
         {
-            int count = args.Length - 1;
-
-            for (int i = 0; i <= count; i++)
+            for (int i = 0; i <= args.Length - 1; i++)
             {
-                switch (args[i])
+                string cmd = args[i].ToLower();
+
+                // NOTE: Command-line option name should start with "-" character
+                if (cmd.Length == 0 || cmd[0] != '-')
+                    continue;
+
+                cmd = cmd.Remove(0, 1);
+                string value = (i < args.Length - 1) ? args[i + 1] : null;
+
+                Log.Message(LogTypes.Trace, $"ARG: {cmd}, VALUE: {value}");
+
+                switch (cmd)
                 {
-                    case "-minimized":
+                    // Here we have it! Using `-settings` option we can now set the filepath that will be used 
+                    // to load and save ClassicUO main settings instead of default `./settings.json`
+                    // NOTE: All individual settings like `username`, `password`, etc passed in command-line options
+                    // will override and overwrite those in the settings file because they have higher priority
+                    case "settings":
+                        Settings.CustomSettingsFilepath = value;
+                        break;
+
+                    case "minimized":
                         StartMinimized = true;
                         break;
-                    case "-littlewindow":
+
+                    case "littlewindow":
                         StartInLittleWindow = true;
                         break;
-                    case "-skipupdate":
+
+                    case "skipupdate":
                         SkipUpdate = true;
                         break;
                 }
@@ -78,8 +97,11 @@ namespace ClassicUO
                     pid = int.Parse(args[i + 1]);
             }
 
-            Console.WriteLine("CURRENT PATH: {0}", currentPath);
-            Console.WriteLine("Args: \tpath={0}\taction={1}\tpid={2}", path, action, pid);
+            if (action != string.Empty)
+            {
+                Console.WriteLine("[CheckUpdate] CURRENT PATH: {0}", currentPath);
+                Console.WriteLine("[CheckUpdate] Args: \tpath={0}\taction={1}\tpid={2}", path, action, pid);
+            }
 
             if (action == "update")
             {
@@ -141,11 +163,11 @@ namespace ClassicUO
                 {
                     Directory.Delete(path, true);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                 }
 
-                Log.Message(LogTypes.Trace, "ClassicUO updated successful!", ConsoleColor.Green);
+                Log.Message(LogTypes.Trace, "ClassicUO updated successfully!", ConsoleColor.Green);
             }
 
             return false;


### PR DESCRIPTION
This update brings an ability to use different `settings.json` files when starting ClassicUO.exe with the `-settings <filepath>` option.

This change is necessary in preparation for ClassicUO Launcher that will allow to create different profiles (settings files) for different shards and start ClassicUO with selected profile.

For those who want to utilize this new change without the launcher: you can just start ClassicUO with the settings option and filepath of your settings file, for example:

`ClassicUO.exe -settings "C:\Users\username\path\to\settings_1.json"`

Or if you're running it via mono on macOS or Linux:

`./ClassicUO-mono.sh -settings "/Users/username/path/to/settings_1.json"`