### PR TITLE
Add Select{Next|Previous|Nearest} macros

### DIFF
--- a/src/Game/GameObjects/Views/MobileView.cs
+++ b/src/Game/GameObjects/Views/MobileView.cs
@@ -151,18 +151,16 @@ namespace ClassicUO.Game.GameObjects
             bool isUnderMouse = SelectedObject.LastObject == this && TargetManager.IsTargeting;
             //bool needHpLine = false;
 
-            if (this != World.Player && (isAttack || isUnderMouse || TargetManager.LastTarget == Serial))
+            if (this != World.Player)
             {
-                Hue targetColor = Notoriety.GetHue(NotorietyFlag);
+                if (isAttack || isUnderMouse)
+                    _viewHue = Notoriety.GetHue(NotorietyFlag);
 
-                if (isAttack || this == TargetManager.LastTarget)
+                if (this == TargetManager.LastTarget)
                 {
                     Engine.UI.SetTargetLineGump(this);
                     //needHpLine = true;
                 }
-
-                if (isAttack || isUnderMouse)
-                    _viewHue = targetColor;
             }
 
 

--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -633,16 +633,13 @@ namespace ClassicUO.Game.Managers
                 case MacroType.UseItemInHand:
                     Item itemInLeftHand = World.Player.Equipment[(int)Layer.OneHanded];
                     if (itemInLeftHand != null)
-                    {
                         GameActions.DoubleClick(itemInLeftHand.Serial);
-                    } else
+                    else
                     {
                         Item itemInRightHand = World.Player.Equipment[(int)Layer.TwoHanded];
                         if (itemInRightHand != null)
-                        {
                             GameActions.DoubleClick(itemInRightHand.Serial);
                         }
-                    }
 
                     break;
 
@@ -664,7 +661,8 @@ namespace ClassicUO.Game.Managers
                     }
                     else if (WaitForTargetTimer < Engine.Ticks)
                         WaitForTargetTimer = 0;
-                    else result = 1;
+                    else
+                        result = 1;
 
                     break;
 
@@ -932,26 +930,37 @@ namespace ClassicUO.Game.Managers
                 case MacroType.SelectNext:
                 case MacroType.SelectPrevious:
                 case MacroType.SelectNearest:
-                    // TODO:
-                    int scantype = macro.SubCode - MacroSubType.Hostile;
+                    // scanRange:
+                    // 0 - SelectNext
+                    // 1 - SelectPrevious
+                    // 2 - SelectNearest
                     int scanRange = macro.Code - MacroType.SelectNext;
 
+                    // scantype:
+                    // 0 - Hostile (only hostile mobiles: gray, criminal, enemy, murderer)
+                    // 1 - Party (only party members)
+                    // 2 - Follower (only your followers)
+                    // 3 - Object (???)
+                    // 4 - Mobile (any mobiles)
+                    int scantype = macro.SubCode - MacroSubType.Hostile;
 
                     switch (scanRange)
                     {
                         case 0:
-
+                            //GameActions.MessageOverhead($"SelectNext ({scantype})", World.Player);
+                            TargetManager.SelectNextMobile(scantype);
                             break;
 
                         case 1:
-
+                            //GameActions.MessageOverhead($"SelectPrevious ({scantype})", World.Player);
+                            TargetManager.SelectPreviousMobile(scantype);
                             break;
 
                         case 2:
-
+                            //GameActions.MessageOverhead($"SelectNearest ({scantype})", World.Player);
+                            TargetManager.SelectNearestMobile(scantype);
                             break;
                     }
-
 
                     break;
 

--- a/src/Game/Managers/TargetManager.cs
+++ b/src/Game/Managers/TargetManager.cs
@@ -284,8 +284,13 @@ namespace ClassicUO.Game.Managers
             ClearTargetingWithoutTargetCancelPacket();
         }
 
-        public static bool IsMobileSelectableAsTarget(Mobile mobile, int type)
+        public static bool IsMobileSelectableAsTarget(Serial serial, int type)
         {
+            Mobile mobile = World.Mobiles.Get(serial);
+
+            if (mobile == null)
+                return false;
+
             if (mobile == World.Player)
                 return false;
 
@@ -327,8 +332,13 @@ namespace ClassicUO.Game.Managers
             return true;
         }
 
-        public static void SetLastTarget(Mobile target)
+        public static void SetLastTarget(Serial serial)
         {
+            Mobile target = World.Mobiles.Get(serial);
+
+            if (target == null)
+                return;
+
             GameActions.MessageOverhead($"Target: {target.Name}", Notoriety.GetHue(target.NotorietyFlag), World.Player);
             Engine.UI.RemoveTargetLineGump(TargetManager.LastTarget);
             Engine.UI.RemoveTargetLineGump(TargetManager.LastAttack);
@@ -344,7 +354,10 @@ namespace ClassicUO.Game.Managers
 
             foreach (Mobile mobile in World.Mobiles)
             {
-                if (!IsMobileSelectableAsTarget(mobile, type))
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
                     continue;
 
                 if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
@@ -367,7 +380,7 @@ namespace ClassicUO.Game.Managers
                 target = firstMobile;
 
             if (target != null)
-                SetLastTarget(target);
+                SetLastTarget(target.Serial);
             else
                 GameActions.Print("No new target found");
         }
@@ -380,7 +393,10 @@ namespace ClassicUO.Game.Managers
 
             foreach (Mobile mobile in World.Mobiles)
             {
-                if (!IsMobileSelectableAsTarget(mobile, type))
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
                     continue;
 
                 if (!currentTargetFound && lastMobile != null)
@@ -399,7 +415,7 @@ namespace ClassicUO.Game.Managers
                 target = lastMobile;
 
             if (target != null)
-                SetLastTarget(target);
+                SetLastTarget(target.Serial);
             else
                 GameActions.Print("No new target found");
         }
@@ -415,7 +431,10 @@ namespace ClassicUO.Game.Managers
             // that we will use to rotate our nearest group of mobiles
             foreach (Mobile mobile in World.Mobiles)
             {
-                if (!IsMobileSelectableAsTarget(mobile, type))
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
                     continue;
 
                 if (mobile.Distance < closestDist)
@@ -424,7 +443,10 @@ namespace ClassicUO.Game.Managers
 
             foreach (Mobile mobile in World.Mobiles)
             {
-                if (!IsMobileSelectableAsTarget(mobile, type))
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
                     continue;
 
                 if (mobile.Distance > closestDist)
@@ -450,7 +472,7 @@ namespace ClassicUO.Game.Managers
                 target = firstMobile;
 
             if (target != null)
-                SetLastTarget(target);
+                SetLastTarget(target.Serial);
             else
                 GameActions.Print("No new target found");
         }

--- a/src/Game/Managers/TargetManager.cs
+++ b/src/Game/Managers/TargetManager.cs
@@ -283,5 +283,176 @@ namespace ClassicUO.Game.Managers
             MultiTargetInfo = null;
             ClearTargetingWithoutTargetCancelPacket();
         }
+
+        public static bool IsMobileSelectableAsTarget(Mobile mobile, int type)
+        {
+            if (mobile == World.Player)
+                return false;
+
+            if (Math.Abs(mobile.Z - World.Player.Z) >= 20)
+                return false;
+
+            if (mobile.Distance > 12)
+                return false;
+
+            if (type >= 0 && type != 4)
+            {
+                // 0 - Hostile (only hostile mobiles: gray, criminal, enemy, murderer)
+                if (
+                    type == 0 &&
+                    mobile.NotorietyFlag != NotorietyFlag.Gray &&
+                    mobile.NotorietyFlag != NotorietyFlag.Criminal &&
+                    mobile.NotorietyFlag != NotorietyFlag.Enemy &&
+                    mobile.NotorietyFlag != NotorietyFlag.Murderer
+                )
+                    return false;
+
+                // 1 - Party (only party members)
+                if (type == 1 && !World.Party.Contains(mobile))
+                    return false;
+
+                // 2 - Follower (only your followers)
+                // TODO: Find a better way to determine follower instead of checking if it is "renamable"
+                if (type == 2 && (mobile.NotorietyFlag != NotorietyFlag.Ally || !mobile.IsRenamable))
+                    return false;
+
+                // 3 - Object (no mobiles, only objects (items)?!)
+                if (type == 3)
+                    return false;
+
+                // 4 - Mobile (any mobiles)
+                // No need to check anything here
+            }
+
+            return true;
+        }
+
+        public static void SetLastTarget(Mobile target)
+        {
+            GameActions.MessageOverhead($"Target: {target.Name}", Notoriety.GetHue(target.NotorietyFlag), World.Player);
+            Engine.UI.RemoveTargetLineGump(TargetManager.LastTarget);
+            Engine.UI.RemoveTargetLineGump(TargetManager.LastAttack);
+            TargetManager.LastTarget = target.Serial;
+            Engine.UI.SetTargetLineGump(TargetManager.LastTarget);
+        }
+
+        public static void SelectNextMobile(int type = -1)
+        {
+            Mobile target = null;
+            Mobile firstMobile = null;
+            bool currentTargetFound = false;
+
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (!IsMobileSelectableAsTarget(mobile, type))
+                    continue;
+
+                if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
+                {
+                    currentTargetFound = true;
+                    continue;
+                }
+
+                if (firstMobile == null)
+                    firstMobile = mobile;
+
+                if (!currentTargetFound)
+                    continue;
+
+                target = mobile;
+                break;
+            }
+
+            if (target == null && firstMobile != null)
+                target = firstMobile;
+
+            if (target != null)
+                SetLastTarget(target);
+            else
+                GameActions.Print("No new target found");
+        }
+
+        public static void SelectPreviousMobile(int type = -1)
+        {
+            Mobile target = null;
+            Mobile lastMobile = null;
+            bool currentTargetFound = false;
+
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (!IsMobileSelectableAsTarget(mobile, type))
+                    continue;
+
+                if (!currentTargetFound && lastMobile != null)
+                    target = lastMobile;
+
+                if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
+                {
+                    currentTargetFound = true;
+                    continue;
+                }
+
+                lastMobile = mobile;
+            }
+
+            if (target == null && lastMobile != null)
+                target = lastMobile;
+
+            if (target != null)
+                SetLastTarget(target);
+            else
+                GameActions.Print("No new target found");
+        }
+
+        public static void SelectNearestMobile(int type = -1)
+        {
+            Mobile target = null;
+            int closestDist = ushort.MaxValue;
+            Mobile firstMobile = null;
+            bool currentTargetFound = false;
+
+            // NOTE: This first cycle is required to first determine closest distance
+            // that we will use to rotate our nearest group of mobiles
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (!IsMobileSelectableAsTarget(mobile, type))
+                    continue;
+
+                if (mobile.Distance < closestDist)
+                    closestDist = mobile.Distance;
+            }
+
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (!IsMobileSelectableAsTarget(mobile, type))
+                    continue;
+
+                if (mobile.Distance > closestDist)
+                    continue;
+
+                if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
+                {
+                    currentTargetFound = true;
+                    continue;
+                }
+
+                if (firstMobile == null)
+                    firstMobile = mobile;
+
+                if (!currentTargetFound)
+                    continue;
+
+                target = mobile;
+                break;
+            }
+
+            if (target == null && firstMobile != null)
+                target = firstMobile;
+
+            if (target != null)
+                SetLastTarget(target);
+            else
+                GameActions.Print("No new target found");
+        }
     }
 }

--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -839,6 +839,10 @@ namespace ClassicUO.Game.Managers
 
         public void RemoveTargetLineGump(Serial serial)
         {
+            TargetLine?.Dispose();
+            Remove<TargetLineGump>();
+            TargetLine = null;
+
             //if (_targetLineGumps.TryGetValue(serial, out TargetLineGump gump))
             //{
             //    gump?.Dispose();

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -154,9 +154,9 @@ namespace ClassicUO.Game.UI.Gumps
             Add(tc);
 
             Add(new NiceButton(10, 10, 140, 25, ButtonAction.SwitchPage, "General") {IsSelected = true, ButtonParameter = 1});
-            Add(new NiceButton(10, 10 + 30 * 1, 140, 25, ButtonAction.SwitchPage, "Sounds") {ButtonParameter = 2});
+            Add(new NiceButton(10, 10 + 30 * 1, 140, 25, ButtonAction.SwitchPage, "Sound") {ButtonParameter = 2});
             Add(new NiceButton(10, 10 + 30 * 2, 140, 25, ButtonAction.SwitchPage, "Video") {ButtonParameter = 3});
-            Add(new NiceButton(10, 10 + 30 * 3, 140, 25, ButtonAction.SwitchPage, "Macro") {ButtonParameter = 4});
+            Add(new NiceButton(10, 10 + 30 * 3, 140, 25, ButtonAction.SwitchPage, "Macros") {ButtonParameter = 4});
             //Add(new NiceButton(10, 10 + 30 * 4, 140, 25, ButtonAction.SwitchPage, "Tooltip") {ButtonParameter = 5});
             Add(new NiceButton(10, 10 + 30 * 4, 140, 25, ButtonAction.SwitchPage, "Fonts") {ButtonParameter = 6});
             Add(new NiceButton(10, 10 + 30 * 5, 140, 25, ButtonAction.SwitchPage, "Speech") {ButtonParameter = 7});
@@ -439,7 +439,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             _footStepsSound = CreateCheckBox(rightArea, "Play Footsteps", Engine.Profile.Current.EnableFootstepsSound, 0, 15);
             _combatMusic = CreateCheckBox(rightArea, "Combat music", Engine.Profile.Current.EnableCombatMusic, 0, 0);
-            _musicInBackground = CreateCheckBox(rightArea, "Reproduce music when ClassicUO is not focused", Engine.Profile.Current.ReproduceSoundsInBackground, 0, 0);
+            _musicInBackground = CreateCheckBox(rightArea, "Reproduce sounds and music when ClassicUO is not focused", Engine.Profile.Current.ReproduceSoundsInBackground, 0, 0);
 
 
             _loginMusicVolume.IsVisible = _loginMusic.IsChecked;


### PR DESCRIPTION
If you play without Razor on macOS or Linux, this is something that you probably miss a lot.

SelectNext: iterates through selected type of mobiles in a 12-tile radius (from top to bottom of the list);
SelectPrevious: iterates through selected type of mobiles in a 12-tile radius (from bottom to top of the list);
SelectNearest: iterates through selected type of mobiles in a 12-tile radius (from top to bottom of the list but only among the nearest mobiles);