### PR TITLE
Dragged item size uses ContainerScale

### DIFF
--- a/src/Game/GameCursor.cs
+++ b/src/Game/GameCursor.cs
@@ -357,19 +357,20 @@ namespace ClassicUO.Game
            
             if (_itemHold != null && _itemHold.Enabled && !_itemHold.Dropped)
             {
-                int x = Mouse.Position.X - _offset.X;
-                int y = Mouse.Position.Y - _offset.Y;
+                float scale = Engine.UI.ContainerScale;
+                int x = Mouse.Position.X - (int) (_offset.X * scale);
+                int y = Mouse.Position.Y - (int) (_offset.Y * scale);
 
                 Vector3 hue = Vector3.Zero;
                 ShaderHuesTraslator.GetHueVector(ref hue, _itemHold.Hue, _itemHold.IsPartialHue, _itemHold.HasAlpha ? .5f : 0);
 
-                sb.Draw2D(_draggedItemTexture, x, y, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
+                sb.Draw2D(_draggedItemTexture, x, y, _rect.Width * scale, _rect.Height * scale, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
 
                 if (_itemHold.Amount > 1 && _itemHold.DisplayedGraphic == _itemHold.Graphic && _itemHold.IsStackable)
                 {
                     x += 5;
                     y += 5;
-                    sb.Draw2D(_draggedItemTexture, x, y, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
+                    sb.Draw2D(_draggedItemTexture, x, y, _rect.Width * scale, _rect.Height * scale, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
                 }
             }
 

--- a/src/Game/GameCursor.cs
+++ b/src/Game/GameCursor.cs
@@ -357,7 +357,11 @@ namespace ClassicUO.Game
            
             if (_itemHold != null && _itemHold.Enabled && !_itemHold.Dropped)
             {
-                float scale = Engine.UI.ContainerScale;
+                float scale = 1;
+
+                if (Engine.Profile.Current != null && Engine.Profile.Current.ScaleItemsInsideContainers)
+                    scale = Engine.UI.ContainerScale;
+
                 int x = Mouse.Position.X - (int) (_offset.X * scale);
                 int y = Mouse.Position.Y - (int) (_offset.Y * scale);
 


### PR DESCRIPTION
Dragging items will now use `Engine.UI.ContainerScale`

Without this fix:
![2019-10-11_23-53-40](https://user-images.githubusercontent.com/1727541/66687565-4c827600-ec83-11e9-801e-fdb8990deb85.gif)

With this fix:
![2019-10-12_00-00-02](https://user-images.githubusercontent.com/1727541/66687567-4f7d6680-ec83-11e9-8a83-aec534d72062.gif)
