### PR TITLE
Added option Double click to loot items inside containers

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -298,6 +298,8 @@ namespace ClassicUO.Configuration
 
         [JsonProperty] public bool ScaleItemsInsideContainers { get; set; }
 
+        [JsonProperty] public bool DoubleClickToLootInsideContainers { get; set; }
+
 
         internal static string ProfilePath { get; } = Path.Combine(Engine.ExePath, "Data", "Profiles");
         internal static string DataPath { get; } = Path.Combine(Engine.ExePath, "Data");

--- a/src/Game/UI/Controls/ItemGump.cs
+++ b/src/Game/UI/Controls/ItemGump.cs
@@ -320,12 +320,11 @@ namespace ClassicUO.Game.UI.Controls
             if (
                 Engine.Profile.Current.DoubleClickToLootInsideContainers &&
                 (item = World.Items.Get(LocalSerial)) != null &&
+                item.ItemData.IsContainer == false &&
                 (container = World.Items.Get(item.RootContainer)) != null &&
                 container.IsCorpse
             ){
                 GameActions.GrabItem(item, item.Amount);
-                if (container.Items.Count == 1)
-                    Engine.UI.GetGump(container).Dispose();
             } else
                 GameActions.DoubleClick(LocalSerial);
  

--- a/src/Game/UI/Controls/ItemGump.cs
+++ b/src/Game/UI/Controls/ItemGump.cs
@@ -320,7 +320,7 @@ namespace ClassicUO.Game.UI.Controls
             if (
                 Engine.Profile.Current.DoubleClickToLootInsideContainers &&
                 (item = World.Items.Get(LocalSerial)) != null &&
-                item.ItemData.IsContainer == false &&
+                !item.ItemData.IsContainer && item.Items.Count == 0 &&
                 (container = World.Items.Get(item.RootContainer)) != null &&
                 container.IsCorpse
             ){

--- a/src/Game/UI/Controls/ItemGump.cs
+++ b/src/Game/UI/Controls/ItemGump.cs
@@ -314,11 +314,24 @@ namespace ClassicUO.Game.UI.Controls
         {
             if (button != MouseButton.Left)
                 return false;
-
-            GameActions.DoubleClick(LocalSerial);
+ 
+            Item item, container;
+ 
+            if (
+                Engine.Profile.Current.DoubleClickToLootInsideContainers &&
+                (item = World.Items.Get(LocalSerial)) != null &&
+                (container = World.Items.Get(item.RootContainer)) != null &&
+                container.IsCorpse
+            ){
+                GameActions.GrabItem(item, item.Amount);
+                if (container.Items.Count == 1)
+                    Engine.UI.GetGump(container).Dispose();
+            } else
+                GameActions.DoubleClick(LocalSerial);
+ 
             _sendClickIfNotDClick = false;
             _lastClickPosition = Point.Zero;
-
+ 
             return true;
         }
 

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -127,7 +127,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         // containers
         private HSliderBar _containersScale;
-        private Checkbox _containerScaleItems;
+        private Checkbox _containerScaleItems, _containerDoubleClickToLoot;
 
         public OptionsGump() : base(0, 0)
         {
@@ -1251,7 +1251,8 @@ namespace ClassicUO.Game.UI.Gumps
             rightArea.Add(item);
 
             _containerScaleItems = CreateCheckBox(rightArea, "Scale items inside containers", Engine.Profile.Current.ScaleItemsInsideContainers, 0, 20);
-
+            _containerDoubleClickToLoot = CreateCheckBox(rightArea, "Double click to loot items inside containers", Engine.Profile.Current.DoubleClickToLootInsideContainers, 0, 0);
+            
             Add(rightArea, PAGE);
         }
 
@@ -1476,6 +1477,7 @@ namespace ClassicUO.Game.UI.Gumps
                 case 13:
                     _containersScale.Value = 100;
                     _containerScaleItems.IsChecked = false;
+                    _containerDoubleClickToLoot.IsChecked = false;
                     break;
             }
         }
@@ -1917,6 +1919,8 @@ namespace ClassicUO.Game.UI.Gumps
                     resizableGump.ForceUpdate();
                 }
             }
+
+            Engine.Profile.Current.DoubleClickToLootInsideContainers = _containerDoubleClickToLoot.IsChecked;
 
             Engine.Profile.Current?.Save(Engine.UI.Gumps.OfType<Gump>().Where(s => s.CanBeSaved).Reverse().ToList());
         }


### PR DESCRIPTION
This adds the option "Double click to loot items inside containers".
It will only work for corpse containers.
Containers inside the corpse will be opened, not looted.

Example (auto close has been removed):
![2019-10-13_03-25-27](https://user-images.githubusercontent.com/1727541/66709661-3222c800-ed69-11e9-87d8-871530d5b1e1.gif)
