### PR TITLE
Auto loot no longer shows empty corpses

### DIFF
--- a/src/Game/GameCursor.cs
+++ b/src/Game/GameCursor.cs
@@ -357,19 +357,24 @@ namespace ClassicUO.Game
            
             if (_itemHold != null && _itemHold.Enabled && !_itemHold.Dropped)
             {
-                int x = Mouse.Position.X - _offset.X;
-                int y = Mouse.Position.Y - _offset.Y;
+                float scale = 1;
+
+                if (Engine.Profile.Current != null && Engine.Profile.Current.ScaleItemsInsideContainers)
+                    scale = Engine.UI.ContainerScale;
+
+                int x = Mouse.Position.X - (int) (_offset.X * scale);
+                int y = Mouse.Position.Y - (int) (_offset.Y * scale);
 
                 Vector3 hue = Vector3.Zero;
                 ShaderHuesTraslator.GetHueVector(ref hue, _itemHold.Hue, _itemHold.IsPartialHue, _itemHold.HasAlpha ? .5f : 0);
 
-                sb.Draw2D(_draggedItemTexture, x, y, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
+                sb.Draw2D(_draggedItemTexture, x, y, _rect.Width * scale, _rect.Height * scale, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
 
                 if (_itemHold.Amount > 1 && _itemHold.DisplayedGraphic == _itemHold.Graphic && _itemHold.IsStackable)
                 {
                     x += 5;
                     y += 5;
-                    sb.Draw2D(_draggedItemTexture, x, y, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
+                    sb.Draw2D(_draggedItemTexture, x, y, _rect.Width * scale, _rect.Height * scale, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
                 }
             }
 

--- a/src/Game/GameCursor.cs
+++ b/src/Game/GameCursor.cs
@@ -357,19 +357,20 @@ namespace ClassicUO.Game
            
             if (_itemHold != null && _itemHold.Enabled && !_itemHold.Dropped)
             {
-                int x = Mouse.Position.X - _offset.X;
-                int y = Mouse.Position.Y - _offset.Y;
+                float scale = Engine.UI.ContainerScale;
+                int x = Mouse.Position.X - (int) (_offset.X * scale);
+                int y = Mouse.Position.Y - (int) (_offset.Y * scale);
 
                 Vector3 hue = Vector3.Zero;
                 ShaderHuesTraslator.GetHueVector(ref hue, _itemHold.Hue, _itemHold.IsPartialHue, _itemHold.HasAlpha ? .5f : 0);
 
-                sb.Draw2D(_draggedItemTexture, x, y, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
+                sb.Draw2D(_draggedItemTexture, x, y, _rect.Width * scale, _rect.Height * scale, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
 
                 if (_itemHold.Amount > 1 && _itemHold.DisplayedGraphic == _itemHold.Graphic && _itemHold.IsStackable)
                 {
                     x += 5;
                     y += 5;
-                    sb.Draw2D(_draggedItemTexture, x, y, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
+                    sb.Draw2D(_draggedItemTexture, x, y, _rect.Width * scale, _rect.Height * scale, _rect.X, _rect.Y, _rect.Width, _rect.Height, ref hue);
                 }
             }
 

--- a/src/Game/GameCursor.cs
+++ b/src/Game/GameCursor.cs
@@ -357,7 +357,11 @@ namespace ClassicUO.Game
            
             if (_itemHold != null && _itemHold.Enabled && !_itemHold.Dropped)
             {
-                float scale = Engine.UI.ContainerScale;
+                float scale = 1;
+
+                if (Engine.Profile.Current != null && Engine.Profile.Current.ScaleItemsInsideContainers)
+                    scale = Engine.UI.ContainerScale;
+
                 int x = Mouse.Position.X - (int) (_offset.X * scale);
                 int y = Mouse.Position.Y - (int) (_offset.Y * scale);
 

--- a/src/Game/GameObjects/PlayerMobile.cs
+++ b/src/Game/GameObjects/PlayerMobile.cs
@@ -1271,9 +1271,9 @@ namespace ClassicUO.Game.GameObjects
                 if ((Engine.Profile.Current.CorpseOpenOptions == 2 || Engine.Profile.Current.CorpseOpenOptions == 3) && IsHidden)
                     return;
 
-                foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && !OpenedCorpses.Contains(t.Serial) && t.Distance <= Engine.Profile.Current.AutoOpenCorpseRange))
+                foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && !AutoOpenedCorpses.Contains(t.Serial) && t.Distance <= Engine.Profile.Current.AutoOpenCorpseRange))
                 {
-                    OpenedCorpses.Add(c.Serial);
+                    AutoOpenedCorpses.Add(c.Serial);
                     GameActions.DoubleClickQueued(c.Serial);
                 }
             }
@@ -1860,7 +1860,8 @@ namespace ClassicUO.Game.GameObjects
                    || type >= 0x9B3C && type <= 0x9B4B;
         }
 
-        private readonly HashSet<Serial> OpenedCorpses = new HashSet<Serial>();
+        private readonly HashSet<Serial> AutoOpenedCorpses = new HashSet<Serial>();
+        public readonly HashSet<Serial> ManualOpenedCorpses = new HashSet<Serial>();
 #if JAEDAN_MOVEMENT_PATCH
         public override void ForcePosition(ushort x, ushort y, sbyte z, Direction dir)
         {

--- a/src/Game/GameObjects/Views/MobileView.cs
+++ b/src/Game/GameObjects/Views/MobileView.cs
@@ -151,18 +151,16 @@ namespace ClassicUO.Game.GameObjects
             bool isUnderMouse = SelectedObject.LastObject == this && TargetManager.IsTargeting;
             //bool needHpLine = false;
 
-            if (this != World.Player && (isAttack || isUnderMouse || TargetManager.LastTarget == Serial))
+            if (this != World.Player)
             {
-                Hue targetColor = Notoriety.GetHue(NotorietyFlag);
+                if (isAttack || isUnderMouse)
+                    _viewHue = Notoriety.GetHue(NotorietyFlag);
 
-                if (isAttack || this == TargetManager.LastTarget)
+                if (this == TargetManager.LastTarget)
                 {
                     Engine.UI.SetTargetLineGump(this);
                     //needHpLine = true;
                 }
-
-                if (isAttack || isUnderMouse)
-                    _viewHue = targetColor;
             }
 
 

--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -633,16 +633,13 @@ namespace ClassicUO.Game.Managers
                 case MacroType.UseItemInHand:
                     Item itemInLeftHand = World.Player.Equipment[(int)Layer.OneHanded];
                     if (itemInLeftHand != null)
-                    {
                         GameActions.DoubleClick(itemInLeftHand.Serial);
-                    } else
+                    else
                     {
                         Item itemInRightHand = World.Player.Equipment[(int)Layer.TwoHanded];
                         if (itemInRightHand != null)
-                        {
                             GameActions.DoubleClick(itemInRightHand.Serial);
                         }
-                    }
 
                     break;
 
@@ -664,7 +661,8 @@ namespace ClassicUO.Game.Managers
                     }
                     else if (WaitForTargetTimer < Engine.Ticks)
                         WaitForTargetTimer = 0;
-                    else result = 1;
+                    else
+                        result = 1;
 
                     break;
 
@@ -932,26 +930,37 @@ namespace ClassicUO.Game.Managers
                 case MacroType.SelectNext:
                 case MacroType.SelectPrevious:
                 case MacroType.SelectNearest:
-                    // TODO:
-                    int scantype = macro.SubCode - MacroSubType.Hostile;
+                    // scanRange:
+                    // 0 - SelectNext
+                    // 1 - SelectPrevious
+                    // 2 - SelectNearest
                     int scanRange = macro.Code - MacroType.SelectNext;
 
+                    // scantype:
+                    // 0 - Hostile (only hostile mobiles: gray, criminal, enemy, murderer)
+                    // 1 - Party (only party members)
+                    // 2 - Follower (only your followers)
+                    // 3 - Object (???)
+                    // 4 - Mobile (any mobiles)
+                    int scantype = macro.SubCode - MacroSubType.Hostile;
 
                     switch (scanRange)
                     {
                         case 0:
-
+                            //GameActions.MessageOverhead($"SelectNext ({scantype})", World.Player);
+                            TargetManager.SelectNextMobile(scantype);
                             break;
 
                         case 1:
-
+                            //GameActions.MessageOverhead($"SelectPrevious ({scantype})", World.Player);
+                            TargetManager.SelectPreviousMobile(scantype);
                             break;
 
                         case 2:
-
+                            //GameActions.MessageOverhead($"SelectNearest ({scantype})", World.Player);
+                            TargetManager.SelectNearestMobile(scantype);
                             break;
                     }
-
 
                     break;
 

--- a/src/Game/Managers/TargetManager.cs
+++ b/src/Game/Managers/TargetManager.cs
@@ -284,8 +284,13 @@ namespace ClassicUO.Game.Managers
             ClearTargetingWithoutTargetCancelPacket();
         }
 
-        public static bool IsMobileSelectableAsTarget(Mobile mobile, int type)
+        public static bool IsMobileSelectableAsTarget(Serial serial, int type)
         {
+            Mobile mobile = World.Mobiles.Get(serial);
+
+            if (mobile == null)
+                return false;
+
             if (mobile == World.Player)
                 return false;
 
@@ -327,8 +332,13 @@ namespace ClassicUO.Game.Managers
             return true;
         }
 
-        public static void SetLastTarget(Mobile target)
+        public static void SetLastTarget(Serial serial)
         {
+            Mobile target = World.Mobiles.Get(serial);
+
+            if (target == null)
+                return;
+
             GameActions.MessageOverhead($"Target: {target.Name}", Notoriety.GetHue(target.NotorietyFlag), World.Player);
             Engine.UI.RemoveTargetLineGump(TargetManager.LastTarget);
             Engine.UI.RemoveTargetLineGump(TargetManager.LastAttack);
@@ -344,7 +354,10 @@ namespace ClassicUO.Game.Managers
 
             foreach (Mobile mobile in World.Mobiles)
             {
-                if (!IsMobileSelectableAsTarget(mobile, type))
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
                     continue;
 
                 if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
@@ -367,7 +380,7 @@ namespace ClassicUO.Game.Managers
                 target = firstMobile;
 
             if (target != null)
-                SetLastTarget(target);
+                SetLastTarget(target.Serial);
             else
                 GameActions.Print("No new target found");
         }
@@ -380,7 +393,10 @@ namespace ClassicUO.Game.Managers
 
             foreach (Mobile mobile in World.Mobiles)
             {
-                if (!IsMobileSelectableAsTarget(mobile, type))
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
                     continue;
 
                 if (!currentTargetFound && lastMobile != null)
@@ -399,7 +415,7 @@ namespace ClassicUO.Game.Managers
                 target = lastMobile;
 
             if (target != null)
-                SetLastTarget(target);
+                SetLastTarget(target.Serial);
             else
                 GameActions.Print("No new target found");
         }
@@ -415,7 +431,10 @@ namespace ClassicUO.Game.Managers
             // that we will use to rotate our nearest group of mobiles
             foreach (Mobile mobile in World.Mobiles)
             {
-                if (!IsMobileSelectableAsTarget(mobile, type))
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
                     continue;
 
                 if (mobile.Distance < closestDist)
@@ -424,7 +443,10 @@ namespace ClassicUO.Game.Managers
 
             foreach (Mobile mobile in World.Mobiles)
             {
-                if (!IsMobileSelectableAsTarget(mobile, type))
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
                     continue;
 
                 if (mobile.Distance > closestDist)
@@ -450,7 +472,7 @@ namespace ClassicUO.Game.Managers
                 target = firstMobile;
 
             if (target != null)
-                SetLastTarget(target);
+                SetLastTarget(target.Serial);
             else
                 GameActions.Print("No new target found");
         }

--- a/src/Game/Managers/TargetManager.cs
+++ b/src/Game/Managers/TargetManager.cs
@@ -283,5 +283,176 @@ namespace ClassicUO.Game.Managers
             MultiTargetInfo = null;
             ClearTargetingWithoutTargetCancelPacket();
         }
+
+        public static bool IsMobileSelectableAsTarget(Mobile mobile, int type)
+        {
+            if (mobile == World.Player)
+                return false;
+
+            if (Math.Abs(mobile.Z - World.Player.Z) >= 20)
+                return false;
+
+            if (mobile.Distance > 12)
+                return false;
+
+            if (type >= 0 && type != 4)
+            {
+                // 0 - Hostile (only hostile mobiles: gray, criminal, enemy, murderer)
+                if (
+                    type == 0 &&
+                    mobile.NotorietyFlag != NotorietyFlag.Gray &&
+                    mobile.NotorietyFlag != NotorietyFlag.Criminal &&
+                    mobile.NotorietyFlag != NotorietyFlag.Enemy &&
+                    mobile.NotorietyFlag != NotorietyFlag.Murderer
+                )
+                    return false;
+
+                // 1 - Party (only party members)
+                if (type == 1 && !World.Party.Contains(mobile))
+                    return false;
+
+                // 2 - Follower (only your followers)
+                // TODO: Find a better way to determine follower instead of checking if it is "renamable"
+                if (type == 2 && (mobile.NotorietyFlag != NotorietyFlag.Ally || !mobile.IsRenamable))
+                    return false;
+
+                // 3 - Object (no mobiles, only objects (items)?!)
+                if (type == 3)
+                    return false;
+
+                // 4 - Mobile (any mobiles)
+                // No need to check anything here
+            }
+
+            return true;
+        }
+
+        public static void SetLastTarget(Mobile target)
+        {
+            GameActions.MessageOverhead($"Target: {target.Name}", Notoriety.GetHue(target.NotorietyFlag), World.Player);
+            Engine.UI.RemoveTargetLineGump(TargetManager.LastTarget);
+            Engine.UI.RemoveTargetLineGump(TargetManager.LastAttack);
+            TargetManager.LastTarget = target.Serial;
+            Engine.UI.SetTargetLineGump(TargetManager.LastTarget);
+        }
+
+        public static void SelectNextMobile(int type = -1)
+        {
+            Mobile target = null;
+            Mobile firstMobile = null;
+            bool currentTargetFound = false;
+
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (!IsMobileSelectableAsTarget(mobile, type))
+                    continue;
+
+                if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
+                {
+                    currentTargetFound = true;
+                    continue;
+                }
+
+                if (firstMobile == null)
+                    firstMobile = mobile;
+
+                if (!currentTargetFound)
+                    continue;
+
+                target = mobile;
+                break;
+            }
+
+            if (target == null && firstMobile != null)
+                target = firstMobile;
+
+            if (target != null)
+                SetLastTarget(target);
+            else
+                GameActions.Print("No new target found");
+        }
+
+        public static void SelectPreviousMobile(int type = -1)
+        {
+            Mobile target = null;
+            Mobile lastMobile = null;
+            bool currentTargetFound = false;
+
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (!IsMobileSelectableAsTarget(mobile, type))
+                    continue;
+
+                if (!currentTargetFound && lastMobile != null)
+                    target = lastMobile;
+
+                if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
+                {
+                    currentTargetFound = true;
+                    continue;
+                }
+
+                lastMobile = mobile;
+            }
+
+            if (target == null && lastMobile != null)
+                target = lastMobile;
+
+            if (target != null)
+                SetLastTarget(target);
+            else
+                GameActions.Print("No new target found");
+        }
+
+        public static void SelectNearestMobile(int type = -1)
+        {
+            Mobile target = null;
+            int closestDist = ushort.MaxValue;
+            Mobile firstMobile = null;
+            bool currentTargetFound = false;
+
+            // NOTE: This first cycle is required to first determine closest distance
+            // that we will use to rotate our nearest group of mobiles
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (!IsMobileSelectableAsTarget(mobile, type))
+                    continue;
+
+                if (mobile.Distance < closestDist)
+                    closestDist = mobile.Distance;
+            }
+
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (!IsMobileSelectableAsTarget(mobile, type))
+                    continue;
+
+                if (mobile.Distance > closestDist)
+                    continue;
+
+                if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
+                {
+                    currentTargetFound = true;
+                    continue;
+                }
+
+                if (firstMobile == null)
+                    firstMobile = mobile;
+
+                if (!currentTargetFound)
+                    continue;
+
+                target = mobile;
+                break;
+            }
+
+            if (target == null && firstMobile != null)
+                target = firstMobile;
+
+            if (target != null)
+                SetLastTarget(target);
+            else
+                GameActions.Print("No new target found");
+        }
     }
 }

--- a/src/Game/Managers/TargetManager.cs
+++ b/src/Game/Managers/TargetManager.cs
@@ -283,5 +283,198 @@ namespace ClassicUO.Game.Managers
             MultiTargetInfo = null;
             ClearTargetingWithoutTargetCancelPacket();
         }
+
+        public static bool IsMobileSelectableAsTarget(Serial serial, int type)
+        {
+            Mobile mobile = World.Mobiles.Get(serial);
+
+            if (mobile == null)
+                return false;
+
+            if (mobile == World.Player)
+                return false;
+
+            if (Math.Abs(mobile.Z - World.Player.Z) >= 20)
+                return false;
+
+            if (mobile.Distance > 12)
+                return false;
+
+            if (type >= 0 && type != 4)
+            {
+                // 0 - Hostile (only hostile mobiles: gray, criminal, enemy, murderer)
+                if (
+                    type == 0 &&
+                    mobile.NotorietyFlag != NotorietyFlag.Gray &&
+                    mobile.NotorietyFlag != NotorietyFlag.Criminal &&
+                    mobile.NotorietyFlag != NotorietyFlag.Enemy &&
+                    mobile.NotorietyFlag != NotorietyFlag.Murderer
+                )
+                    return false;
+
+                // 1 - Party (only party members)
+                if (type == 1 && !World.Party.Contains(mobile))
+                    return false;
+
+                // 2 - Follower (only your followers)
+                // TODO: Find a better way to determine follower instead of checking if it is "renamable"
+                if (type == 2 && (mobile.NotorietyFlag != NotorietyFlag.Ally || !mobile.IsRenamable))
+                    return false;
+
+                // 3 - Object (no mobiles, only objects (items)?!)
+                if (type == 3)
+                    return false;
+
+                // 4 - Mobile (any mobiles)
+                // No need to check anything here
+            }
+
+            return true;
+        }
+
+        public static void SetLastTarget(Serial serial)
+        {
+            Mobile target = World.Mobiles.Get(serial);
+
+            if (target == null)
+                return;
+
+            GameActions.MessageOverhead($"Target: {target.Name}", Notoriety.GetHue(target.NotorietyFlag), World.Player);
+            Engine.UI.RemoveTargetLineGump(TargetManager.LastTarget);
+            Engine.UI.RemoveTargetLineGump(TargetManager.LastAttack);
+            TargetManager.LastTarget = target.Serial;
+            Engine.UI.SetTargetLineGump(TargetManager.LastTarget);
+        }
+
+        public static void SelectNextMobile(int type = -1)
+        {
+            Mobile target = null;
+            Mobile firstMobile = null;
+            bool currentTargetFound = false;
+
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
+                    continue;
+
+                if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
+                {
+                    currentTargetFound = true;
+                    continue;
+                }
+
+                if (firstMobile == null)
+                    firstMobile = mobile;
+
+                if (!currentTargetFound)
+                    continue;
+
+                target = mobile;
+                break;
+            }
+
+            if (target == null && firstMobile != null)
+                target = firstMobile;
+
+            if (target != null)
+                SetLastTarget(target.Serial);
+            else
+                GameActions.Print("No new target found");
+        }
+
+        public static void SelectPreviousMobile(int type = -1)
+        {
+            Mobile target = null;
+            Mobile lastMobile = null;
+            bool currentTargetFound = false;
+
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
+                    continue;
+
+                if (!currentTargetFound && lastMobile != null)
+                    target = lastMobile;
+
+                if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
+                {
+                    currentTargetFound = true;
+                    continue;
+                }
+
+                lastMobile = mobile;
+            }
+
+            if (target == null && lastMobile != null)
+                target = lastMobile;
+
+            if (target != null)
+                SetLastTarget(target.Serial);
+            else
+                GameActions.Print("No new target found");
+        }
+
+        public static void SelectNearestMobile(int type = -1)
+        {
+            Mobile target = null;
+            int closestDist = ushort.MaxValue;
+            Mobile firstMobile = null;
+            bool currentTargetFound = false;
+
+            // NOTE: This first cycle is required to first determine closest distance
+            // that we will use to rotate our nearest group of mobiles
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
+                    continue;
+
+                if (mobile.Distance < closestDist)
+                    closestDist = mobile.Distance;
+            }
+
+            foreach (Mobile mobile in World.Mobiles)
+            {
+                if (mobile == null)
+                    continue;
+
+                if (!IsMobileSelectableAsTarget(mobile.Serial, type))
+                    continue;
+
+                if (mobile.Distance > closestDist)
+                    continue;
+
+                if (TargetManager.LastTarget != null && TargetManager.LastTarget == mobile.Serial)
+                {
+                    currentTargetFound = true;
+                    continue;
+                }
+
+                if (firstMobile == null)
+                    firstMobile = mobile;
+
+                if (!currentTargetFound)
+                    continue;
+
+                target = mobile;
+                break;
+            }
+
+            if (target == null && firstMobile != null)
+                target = firstMobile;
+
+            if (target != null)
+                SetLastTarget(target.Serial);
+            else
+                GameActions.Print("No new target found");
+        }
     }
 }

--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -839,6 +839,10 @@ namespace ClassicUO.Game.Managers
 
         public void RemoveTargetLineGump(Serial serial)
         {
+            TargetLine?.Dispose();
+            Remove<TargetLineGump>();
+            TargetLine = null;
+
             //if (_targetLineGumps.TryGetValue(serial, out TargetLineGump gump))
             //{
             //    gump?.Dispose();

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -514,6 +514,10 @@ namespace ClassicUO.Game.Scenes
             {
                 case Item item:
                     result = true;
+
+                    if (item.IsCorpse)
+                        World.Player.ManualOpenedCorpses.Add(item.Serial);
+                    
                     GameActions.DoubleClick(item);
 
                     break;

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -43,6 +43,8 @@ namespace ClassicUO.Game.UI.Gumps
         private HitBox _iconizerArea;
         internal override HitBox IconizerArea => _iconizerArea;
         private long _corpseEyeTicks;
+        private bool _hadItems;
+        private bool _closeEmptyCorpse;
         private ContainerData _data;
         private int _eyeCorspeOffset;
         private GumpPic _eyeGumpPic;
@@ -52,7 +54,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
         }
 
-        public ContainerGump(Serial serial, Graphic gumpid) : this()
+        public ContainerGump(Serial serial, Graphic gumpid, bool closeEmptyCorpse = false) : this()
         {
             LocalSerial = serial;
             Item item = World.Items.Get(serial);
@@ -64,6 +66,8 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             Graphic = gumpid;
+            
+            _closeEmptyCorpse = closeEmptyCorpse;
 
             BuildGump();
 
@@ -195,14 +199,25 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (IsDisposed) return;
 
-            if (_isCorspeContainer && _corpseEyeTicks < totalMS)
+            if (item.Items.Count() > 0)
+                _hadItems = true;
+
+            if (_isCorspeContainer)
             {
-                _eyeCorspeOffset = _eyeCorspeOffset == 0 ? 1 : 0;
-                _corpseEyeTicks = (long) totalMS + 750;
-                _eyeGumpPic.Graphic = (Graphic) (0x0045 + _eyeCorspeOffset);
-                float scale = Engine.UI.ContainerScale;
-                _eyeGumpPic.Width = (int)(_eyeGumpPic.Texture.Width * scale);
-                _eyeGumpPic.Height = (int)(_eyeGumpPic.Texture.Height * scale);
+                if (_closeEmptyCorpse && !_hadItems && item.Items.Count() == 0){
+                    Dispose();
+                    return;
+                }
+
+                if (_corpseEyeTicks < totalMS)
+                {
+                    _eyeCorspeOffset = _eyeCorspeOffset == 0 ? 1 : 0;
+                    _corpseEyeTicks = (long) totalMS + 750;
+                    _eyeGumpPic.Graphic = (Graphic) (0x0045 + _eyeCorspeOffset);
+                    float scale = Engine.UI.ContainerScale;
+                    _eyeGumpPic.Width = (int)(_eyeGumpPic.Texture.Width * scale);
+                    _eyeGumpPic.Height = (int)(_eyeGumpPic.Texture.Height * scale);
+                }
             }
             if(Iconized != null) Iconized.Hue = item.Hue;
         }

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -43,6 +43,8 @@ namespace ClassicUO.Game.UI.Gumps
         private HitBox _iconizerArea;
         internal override HitBox IconizerArea => _iconizerArea;
         private long _corpseEyeTicks;
+        private bool _hadItems;
+        private bool _closeEmptyCorpse;
         private ContainerData _data;
         private int _eyeCorspeOffset;
         private GumpPic _eyeGumpPic;
@@ -52,7 +54,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
         }
 
-        public ContainerGump(Serial serial, Graphic gumpid) : this()
+        public ContainerGump(Serial serial, Graphic gumpid, bool closeEmpty = false) : this()
         {
             LocalSerial = serial;
             Item item = World.Items.Get(serial);
@@ -64,6 +66,8 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             Graphic = gumpid;
+            
+            _closeEmptyCorpse = closeEmpty;
 
             BuildGump();
 
@@ -195,14 +199,25 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (IsDisposed) return;
 
-            if (_isCorspeContainer && _corpseEyeTicks < totalMS)
+            if (item.Items.Count() > 0)
+                _hadItems = true;
+
+            if (_isCorspeContainer)
             {
-                _eyeCorspeOffset = _eyeCorspeOffset == 0 ? 1 : 0;
-                _corpseEyeTicks = (long) totalMS + 750;
-                _eyeGumpPic.Graphic = (Graphic) (0x0045 + _eyeCorspeOffset);
-                float scale = Engine.UI.ContainerScale;
-                _eyeGumpPic.Width = (int)(_eyeGumpPic.Texture.Width * scale);
-                _eyeGumpPic.Height = (int)(_eyeGumpPic.Texture.Height * scale);
+                if (_closeEmptyCorpse && !_hadItems && item.Items.Count() == 0){
+                    Dispose();
+                    return;
+                }
+
+                if (_corpseEyeTicks < totalMS)
+                {
+                    _eyeCorspeOffset = _eyeCorspeOffset == 0 ? 1 : 0;
+                    _corpseEyeTicks = (long) totalMS + 750;
+                    _eyeGumpPic.Graphic = (Graphic) (0x0045 + _eyeCorspeOffset);
+                    float scale = Engine.UI.ContainerScale;
+                    _eyeGumpPic.Width = (int)(_eyeGumpPic.Texture.Width * scale);
+                    _eyeGumpPic.Height = (int)(_eyeGumpPic.Texture.Height * scale);
+                }
             }
             if(Iconized != null) Iconized.Hue = item.Hue;
         }

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -54,7 +54,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
         }
 
-        public ContainerGump(Serial serial, Graphic gumpid, bool closeEmpty = false) : this()
+        public ContainerGump(Serial serial, Graphic gumpid, bool closeEmptyCorpse = false) : this()
         {
             LocalSerial = serial;
             Item item = World.Items.Get(serial);
@@ -67,7 +67,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             Graphic = gumpid;
             
-            _closeEmptyCorpse = closeEmpty;
+            _closeEmptyCorpse = closeEmptyCorpse;
 
             BuildGump();
 

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -154,9 +154,9 @@ namespace ClassicUO.Game.UI.Gumps
             Add(tc);
 
             Add(new NiceButton(10, 10, 140, 25, ButtonAction.SwitchPage, "General") {IsSelected = true, ButtonParameter = 1});
-            Add(new NiceButton(10, 10 + 30 * 1, 140, 25, ButtonAction.SwitchPage, "Sounds") {ButtonParameter = 2});
+            Add(new NiceButton(10, 10 + 30 * 1, 140, 25, ButtonAction.SwitchPage, "Sound") {ButtonParameter = 2});
             Add(new NiceButton(10, 10 + 30 * 2, 140, 25, ButtonAction.SwitchPage, "Video") {ButtonParameter = 3});
-            Add(new NiceButton(10, 10 + 30 * 3, 140, 25, ButtonAction.SwitchPage, "Macro") {ButtonParameter = 4});
+            Add(new NiceButton(10, 10 + 30 * 3, 140, 25, ButtonAction.SwitchPage, "Macros") {ButtonParameter = 4});
             //Add(new NiceButton(10, 10 + 30 * 4, 140, 25, ButtonAction.SwitchPage, "Tooltip") {ButtonParameter = 5});
             Add(new NiceButton(10, 10 + 30 * 4, 140, 25, ButtonAction.SwitchPage, "Fonts") {ButtonParameter = 6});
             Add(new NiceButton(10, 10 + 30 * 5, 140, 25, ButtonAction.SwitchPage, "Speech") {ButtonParameter = 7});
@@ -439,7 +439,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             _footStepsSound = CreateCheckBox(rightArea, "Play Footsteps", Engine.Profile.Current.EnableFootstepsSound, 0, 15);
             _combatMusic = CreateCheckBox(rightArea, "Combat music", Engine.Profile.Current.EnableCombatMusic, 0, 0);
-            _musicInBackground = CreateCheckBox(rightArea, "Reproduce music when ClassicUO is not focused", Engine.Profile.Current.ReproduceSoundsInBackground, 0, 0);
+            _musicInBackground = CreateCheckBox(rightArea, "Reproduce sounds and music when ClassicUO is not focused", Engine.Profile.Current.ReproduceSoundsInBackground, 0, 0);
 
 
             _loginMusicVolume.IsVisible = _loginMusic.IsChecked;

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1049,7 +1049,13 @@ namespace ClassicUO.Network
                     }
 
                     Engine.UI.GetGump<ContainerGump>(serial)?.Dispose();
-                    Engine.UI.Add(new ContainerGump(item, graphic));
+
+                    if (item.IsCorpse){
+                        Engine.UI.Add(new ContainerGump(item, graphic, !World.Player.ManualOpenedCorpses.Contains(serial)));
+                        World.Player.ManualOpenedCorpses.Remove(serial);
+                    }else{
+                        Engine.UI.Add(new ContainerGump(item, graphic, false));
+                    }
                 }
                 else 
                     Log.Message(LogTypes.Error, "[OpenContainer]: item not found");


### PR DESCRIPTION
This pull request makes auto loot no longer show empty corpse containers.
It does this by checking what corpses are manually double clicked and which are opened by auto loot.
If it's a manual corpse loot; empty containers are okay.
If it's an auto corpse loot; empty containers are disposed.
That means, unlike the Grid Loot gump, that you're still able to open empty corpses and put items into them, but you won't be spammed by auto loot showing empty containers.
This will only be applied to corpse containers, which means it should be fairly safe and not close any important gumps or containers.