### PR TITLE
Clickable buttons to run macros

### DIFF
--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Game\UI\Controls\TextureControl.cs" />
     <Compile Include="Game\UI\Gumps\GridLootGump.cs" />
     <Compile Include="Game\UI\Gumps\InfoBarGump.cs" />
+    <Compile Include="Game\UI\Gumps\MacroButtonGump.cs" />
     <Compile Include="Game\UI\Gumps\NameOverHeadHandlerGump.cs" />
     <Compile Include="Game\UI\Gumps\PartyInviteGump.cs" />
     <Compile Include="Game\UI\Gumps\ResizableGump.cs" />

--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -155,6 +155,21 @@ namespace ClassicUO.Game.Managers
             return obj;
         }
 
+        public Macro FindMacro(string name)
+        {
+            Macro obj = _firstNode;
+
+            while (obj != null)
+            {
+                if (obj.Name == name)
+                    break;
+
+                obj = obj.Right;
+            }
+
+            return obj;
+        }
+
         public void SetMacroToExecute(MacroObject macro)
         {
             _lastMacro = macro;
@@ -210,6 +225,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.Emote:
                 case MacroType.Whisper:
                 case MacroType.Yell:
+                case MacroType.RazorMacro:
 
                     MacroObjectString mos = (MacroObjectString) macro;
 
@@ -217,6 +233,7 @@ namespace ClassicUO.Game.Managers
                     {
                         MessageType type = MessageType.Regular;
                         ushort hue = Engine.Profile.Current.SpeechHue;
+                        string prefix = null;
 
                         switch (macro.Code)
                         {
@@ -236,9 +253,14 @@ namespace ClassicUO.Game.Managers
                                 type = MessageType.Yell;
 
                                 break;
+
+                            case MacroType.RazorMacro:
+                                prefix = ">macro ";
+
+                                break;
                         }
 
-                        GameActions.Say(mos.Text, hue, type);
+                        GameActions.Say(prefix + mos.Text, hue, type);
                     }
 
                     break;
@@ -1118,7 +1140,7 @@ namespace ClassicUO.Game.Managers
             if (other == null)
                 return false;
 
-            return Key == other.Key && Alt == other.Alt && Ctrl == other.Ctrl && Shift == other.Shift;
+            return Key == other.Key && Alt == other.Alt && Ctrl == other.Ctrl && Shift == other.Shift && Name == other.Name;
         }
 
         [JsonIgnore] public Macro Left { get; set; }
@@ -1137,6 +1159,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.Delay:
                 case MacroType.SetUpdateRange:
                 case MacroType.ModifyUpdateRange:
+                case MacroType.RazorMacro:
                     obj = new MacroObjectString(code, MacroSubType.MSC_NONE);
 
                     break;
@@ -1282,6 +1305,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.Delay:
                 case MacroType.SetUpdateRange:
                 case MacroType.ModifyUpdateRange:
+                case MacroType.RazorMacro:
                     HasSubMenu = 2;
 
                     break;
@@ -1395,6 +1419,7 @@ namespace ClassicUO.Game.Managers
         UseItemInHand,
         UsePotion,
         CloseAllHealthBars,
+        RazorMacro,
 
     }
 

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -736,7 +736,7 @@ namespace ClassicUO.Game.Scenes
 
             _useObjectHandles = isshift && isctrl;
 
-            if (macro != null)
+            if (macro != null && e.keysym.sym != SDL.SDL_Keycode.SDLK_UNKNOWN)
             {
                 Macros.SetMacroToExecute(macro.FirstNode);
                 Macros.WaitForTargetTimer = 0;

--- a/src/Game/UI/Controls/MacroControl.cs
+++ b/src/Game/UI/Controls/MacroControl.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Input;
 using ClassicUO.Renderer;
 
 using SDL2;
@@ -53,10 +54,12 @@ namespace ClassicUO.Game.UI.Controls
             Add(new NiceButton(0, box.Height + 3, 50, 25, ButtonAction.Activate, "Add") {IsSelectable = false});
             Add(new NiceButton(52, box.Height + 3, 50, 25, ButtonAction.Activate, "Remove") {ButtonParameter = 1, IsSelectable = false});
 
+            Add(new NiceButton(0, box.Height + 30, 170, 25, ButtonAction.Activate, "+ Create macro button", 0, IO.Resources.TEXT_ALIGN_TYPE.TS_LEFT) { ButtonParameter = 2, IsSelectable = false });
+
 
             Add(_collection = new MacroCollectionControl(name, 280, 280)
             {
-                Y = box.Height + 25 + 10
+                Y = box.Height + 50 + 10
             });
 
             if (_collection.Macro.Key != SDL.SDL_Keycode.SDLK_UNKNOWN)
@@ -85,7 +88,7 @@ namespace ClassicUO.Game.UI.Controls
             bool alt = (b.Mod & SDL.SDL_Keymod.KMOD_ALT) != SDL.SDL_Keymod.KMOD_NONE;
             bool ctrl = (b.Mod & SDL.SDL_Keymod.KMOD_CTRL) != SDL.SDL_Keymod.KMOD_NONE;
 
-            if (Engine.SceneManager.GetScene<GameScene>().Macros.FindMacro(b.Key, alt, ctrl, shift) != null)
+            if (b.Key != SDL.SDL_Keycode.SDLK_UNKNOWN && Engine.SceneManager.GetScene<GameScene>().Macros.FindMacro(b.Key, alt, ctrl, shift) != null)
             {
                 MessageBoxGump gump = new MessageBoxGump(250, 250, "This key combination\nalready exists.", s => { b.SetKey(SDL.SDL_Keycode.SDLK_UNKNOWN, SDL.SDL_Keymod.KMOD_NONE); });
                 Engine.UI.Add(gump);
@@ -113,6 +116,13 @@ namespace ClassicUO.Game.UI.Controls
                 _collection.AddEmpty();
             else if (buttonID == 1) // remove
                 _collection.RemoveLast();
+            else if (buttonID == 2) // add macro button
+            {
+                Engine.UI.Gumps.OfType<MacroButtonGump>().FirstOrDefault(s => s._macro == _collection.Macro)?.Dispose();
+
+                MacroButtonGump macroButtonGump = new MacroButtonGump(_collection.Macro, Mouse.Position.X, Mouse.Position.Y);
+                Engine.UI.Add(macroButtonGump);
+            }
         }
     }
 

--- a/src/Game/UI/Gumps/MacroButtonGump.cs
+++ b/src/Game/UI/Gumps/MacroButtonGump.cs
@@ -1,0 +1,179 @@
+﻿#region license
+
+//  Copyright (C) 2019 ClassicUO Development Community on Github
+//
+//	This project is an alternative client for the game Ultima Online.
+//	The goal of this is to develop a lightweight client considering 
+//	new technologies.  
+//      
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Input;
+using ClassicUO.IO.Resources;
+using ClassicUO.Renderer;
+using ClassicUO.Utility;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using SDL2;
+
+namespace ClassicUO.Game.UI.Gumps
+{
+    internal class MacroButtonGump : AnchorableGump
+    {
+        public Macro _macro;
+        private Texture2D backgroundTexture;
+        private Label label;
+
+        public MacroButtonGump(Macro macro, int x, int y) : this()
+        {
+            X = x;
+            Y = y;
+            _macro = macro;
+
+            BuildGump();
+        }
+
+        public MacroButtonGump() : base(0, 0)
+        {
+            CanMove = true;
+            AcceptMouseInput = true;
+            CanCloseWithRightClick = true;
+            CanBeSaved = true;
+            WantUpdateSize = false;
+            AnchorGroupName = "spell";
+            WidthMultiplier = 2;
+            HeightMultiplier = 1;
+            GroupMatrixWidth = 44;
+            GroupMatrixHeight = 44;
+        }
+
+        private void BuildGump()
+        {
+            Width = 88;
+            Height = 44;
+
+            label = new Label(_macro.Name, true, 1001, Width, 255, FontStyle.BlackBorder, TEXT_ALIGN_TYPE.TS_CENTER)
+            {
+                X = 0,
+                Width = Width - 10,
+            };
+            label.Y = (Height >> 1) - (label.Height >> 1);
+            Add(label);
+
+            backgroundTexture = Textures.GetTexture(new Color(30, 30, 30));
+        }
+
+        protected override void OnMouseEnter(int x, int y)
+        {
+            label.Hue = 53;
+            backgroundTexture = Textures.GetTexture(Color.DimGray);
+            base.OnMouseEnter(x, y);
+        }
+
+        protected override void OnMouseExit(int x, int y)
+        {
+            label.Hue = 1001;
+            backgroundTexture = Textures.GetTexture(new Color(30, 30, 30));
+            base.OnMouseExit(x, y);
+        }
+
+
+        protected override void OnMouseUp(int x, int y, MouseButton button)
+        {
+            Point offset = Mouse.LDroppedOffset;
+
+            if (Engine.Profile.Current.CastSpellsByOneClick && button == MouseButton.Left && !Keyboard.Alt && Math.Abs(offset.X) < 5 && Math.Abs(offset.Y) < 5)
+            {
+                RunMacro();
+            }
+        }
+
+        protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)
+        {
+            if (Engine.Profile.Current.CastSpellsByOneClick || button != MouseButton.Left)
+                return false;
+
+            RunMacro();
+            
+            return true;
+        }
+
+        private void RunMacro()
+        {
+            if (_macro != null)
+            {
+                GameScene gs = Engine.SceneManager.GetScene<GameScene>();
+                gs.Macros.SetMacroToExecute(_macro.FirstNode);
+                gs.Macros.WaitForTargetTimer = 0;
+                gs.Macros.Update();
+            }
+        }
+
+        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        {
+            ResetHueVector();
+            _hueVector.Z = 0.1f;
+
+            batcher.Draw2D(backgroundTexture, x, y, Width, Height, ref _hueVector);
+
+            _hueVector.Z = 0;
+            batcher.DrawRectangle(Textures.GetTexture(Color.Gray), x, y, Width, Height, ref _hueVector);
+
+            base.Draw(batcher, x, y);
+            return true;
+        }
+
+        public override void Save(BinaryWriter writer)
+        {
+            if(_macro != null)
+            {
+                int macroid = Engine.SceneManager.GetScene<GameScene>().Macros.GetAllMacros().IndexOf(_macro);
+
+                LocalSerial = (uint) macroid + 1000;
+
+                base.Save(writer);
+                writer.Write((byte) 0); //version
+                writer.Write(_macro.Name);
+                writer.Write(LocalSerial);
+            }
+        }
+
+        public override void Restore(BinaryReader reader)
+        {
+            base.Restore(reader);
+
+            byte version = reader.ReadByte();
+            string name = reader.ReadString();
+            LocalSerial = reader.ReadUInt32();
+
+            Macro macro = Engine.SceneManager.GetScene<GameScene>().Macros.FindMacro(name);
+
+            if (macro != null)
+            {
+                _macro = macro;
+                BuildGump();
+            }
+
+        }
+    }
+}

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -687,6 +687,25 @@ namespace ClassicUO.Game.UI.Gumps
 
                     Add(_macroControl, PAGE);
 
+                    nb.DragBegin += (sss, eee) =>
+                    {
+                        if (Engine.UI.IsDragging
+                            || nb.ScreenCoordinateX > Mouse.LDropPosition.X || nb.ScreenCoordinateX < Mouse.LDropPosition.X - nb.Width
+                            || nb.ScreenCoordinateY > Mouse.LDropPosition.Y || nb.ScreenCoordinateY + nb.Height < Mouse.LDropPosition.Y)
+                            return;
+
+                        MacroCollectionControl control = _macroControl.FindControls<MacroCollectionControl>().SingleOrDefault();
+
+                        if (control == null)
+                            return;
+
+                        Engine.UI.Gumps.OfType<MacroButtonGump>().FirstOrDefault(s => s._macro == control.Macro)?.Dispose();
+
+                        MacroButtonGump macroButtonGump = new MacroButtonGump(control.Macro, Mouse.Position.X, Mouse.Position.Y);
+                        Engine.UI.Add(macroButtonGump);
+                        Engine.UI.AttemptDragControl(macroButtonGump, new Point(Mouse.Position.X + (macroButtonGump.Width >> 1), Mouse.Position.Y + (macroButtonGump.Height >> 1)), true);
+                    };
+
                     nb.MouseUp += (sss, eee) =>
                     {
                         _macroControl?.Dispose();
@@ -731,6 +750,7 @@ namespace ClassicUO.Game.UI.Gumps
                             if (control == null)
                                 return;
 
+                            Engine.UI.Gumps.OfType<MacroButtonGump>().FirstOrDefault(s => s._macro == control.Macro)?.Dispose();
                             Engine.SceneManager.GetScene<GameScene>().Macros.RemoveMacro(control.Macro);
                         }
 
@@ -755,6 +775,20 @@ namespace ClassicUO.Game.UI.Gumps
                 });
 
                 nb.IsSelected = true;
+
+                nb.DragBegin += (sss, eee) =>
+                {
+                    if (Engine.UI.IsDragging
+                        || nb.ScreenCoordinateX > Mouse.LDropPosition.X || nb.ScreenCoordinateX < Mouse.LDropPosition.X - nb.Width
+                        || nb.ScreenCoordinateY > Mouse.LDropPosition.Y || nb.ScreenCoordinateY + nb.Height < Mouse.LDropPosition.Y)
+                            return;
+
+                    Engine.UI.Gumps.OfType<MacroButtonGump>().FirstOrDefault(s => s._macro == macro)?.Dispose();
+
+                    MacroButtonGump macroButtonGump = new MacroButtonGump(macro, Mouse.Position.X, Mouse.Position.Y);
+                    Engine.UI.Add(macroButtonGump);
+                    Engine.UI.AttemptDragControl(macroButtonGump, new Point(Mouse.Position.X + (macroButtonGump.Width >> 1), Mouse.Position.Y + (macroButtonGump.Height >> 1)), true);
+                };
 
                 nb.MouseUp += (sss, eee) =>
                 {


### PR DESCRIPTION
![macrobutton](https://user-images.githubusercontent.com/7057924/66949304-2cb9cc00-f04e-11e9-92b6-c9cef5da3573.gif)

![razormacro](https://user-images.githubusercontent.com/7057924/66949381-53780280-f04e-11e9-90f5-3a423dc83a71.gif)

Some notes regarding changes made to support this

- Added a new macro type RazorMacro, which is really just a shortcut for: say >macro (macroname). It's not actually necessary, it just educates people that the buttons (or any macro) can trigger Razor macros
- Allowed creation of multiple unassigned macros
- LocalSerial for the gumps is generated at the time of saving, based on their position in the Macros list. I don't love it but they need a unique LocalSerial so that the anchor group can save and restore. The other option is to give each macro an id and manage those ids when creating/deleting macros.