### PR TITLE
NamesOnOff macro shouldn't rely on keyboard input

### DIFF
--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -59,6 +59,7 @@ namespace ClassicUO.Game.Scenes
         private Rectangle _rectangleObj = Rectangle.Empty, _rectanglePlayer;
         private RenderTarget2D _viewportRenderTarget, _lightRenderTarget;
         private int _scale = 5; // 1.0
+        private bool _useObjectHandles;
 
 
         private long _timePing;
@@ -396,7 +397,7 @@ namespace ClassicUO.Game.Scenes
             _renderListCount = 0;
             _objectHandlesCount = 0;
 
-            _useObjectHandles = NameOverHeadManager.IsToggled || _useObjectHandles;
+            _useObjectHandles = NameOverHeadManager.IsToggled || _ctrlAndShiftPressed;
 
             if (_useObjectHandles)
                 NameOverHeadManager.Open();

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -82,7 +82,7 @@ namespace ClassicUO.Game.Scenes
         private bool _wasShiftDown;
 
         private bool _requestedWarMode;
-        private bool _rightMousePressed, _continueRunning, _useObjectHandles, _arrowKeyPressed, _numPadKeyPressed;
+        private bool _rightMousePressed, _continueRunning, _ctrlAndShiftPressed, _arrowKeyPressed, _numPadKeyPressed;
         private (int, int) _selectionStart, _selectionEnd;
         private uint _holdMouse2secOverItemTime;
         private bool _isMouseLeftDown;
@@ -734,7 +734,7 @@ namespace ClassicUO.Game.Scenes
                 }
             }
 
-            _useObjectHandles = isshift && isctrl;
+            _ctrlAndShiftPressed = isshift && isctrl;
 
             if (macro != null && e.keysym.sym != SDL.SDL_Keycode.SDLK_UNKNOWN)
             {
@@ -824,7 +824,7 @@ namespace ClassicUO.Game.Scenes
 
             if ((e.keysym.mod & SDL.SDL_Keymod.KMOD_NUM) != SDL.SDL_Keymod.KMOD_NUM) _numPadKeyPressed = false;
 
-            _useObjectHandles = isctrl && isshift;
+            _ctrlAndShiftPressed = isctrl && isshift;
 
             if (e.keysym.sym == SDL.SDL_Keycode.SDLK_TAB && !Engine.Profile.Current.DisableTabBtn)
             {


### PR DESCRIPTION
When _useObjectHandles was **true**, it could not become **false** without keyboard input. Now it works with click macro buttons.