### PR TITLE
Tweaks to alternative lightning

### DIFF
--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -789,7 +789,7 @@ namespace ClassicUO.Game.Scenes
 
                 hue.X = l.Color;
                 hue.Y = ShaderHuesTraslator.SHADER_LIGHTS;
-                hue.Z = 0.25f;
+                hue.Z = 0;
 
                 batcher.DrawSprite(texture, l.DrawX, l.DrawY, texture.Width, texture.Height, texture.Width >> 1, texture.Height >> 1, ref hue);
             }

--- a/src/Game/UI/Controls/WorldViewport.cs
+++ b/src/Game/UI/Controls/WorldViewport.cs
@@ -44,9 +44,8 @@ namespace ClassicUO.Game.UI.Controls
         private readonly BlendState _altLightsBlend = new BlendState
         {
             ColorSourceBlend = Blend.DestinationColor,
-            AlphaSourceBlend = Blend.One,
             ColorDestinationBlend = Blend.One,
-            AlphaDestinationBlend = Blend.One,
+
             ColorBlendFunction = BlendFunction.Add
         };
 
@@ -97,7 +96,9 @@ namespace ClassicUO.Game.UI.Controls
                 if (_scene.UseAltLights)
                 {
                     batcher.SetBlendState(_altLightsBlend);
+                    _hueVector.Z = 0.5f;
                     batcher.Draw2D(_scene.LightRenderTarget, x, y, Width, Height, ref _hueVector);
+                    _hueVector.Z = 0;
                     batcher.SetBlendState(null);
                 } 
                 else if (_scene.UseLights)


### PR DESCRIPTION
Some tweaks to the alternative lightning method.
Alpha is now used on the render target itself rather than per light, making things less overexposed in light heavy scenarios.
There will still be some overexposure, especially if the light colour matches the tile colour.