### PR TITLE
Fix TargetLine and HealthLine

### DIFF
--- a/src/Game/Managers/HealthLinesManager.cs
+++ b/src/Game/Managers/HealthLinesManager.cs
@@ -80,7 +80,7 @@ namespace ClassicUO.Game.Managers
                 int current = mobile.Hits;
                 int max = mobile.HitsMax;
 
-                if (showWhen == 1 && current == max || TargetManager.LastTarget == mobile)
+                if (showWhen == 1 && current == max)
                     continue;
 
                 int x = screenX + mobile.RealScreenPosition.X;
@@ -161,7 +161,7 @@ namespace ClassicUO.Game.Managers
                 if (y < screenY || y > screenY + screenH - BAR_HEIGHT)
                     continue;
 
-                if (mode >= 1)
+                if (mode >= 1 && TargetManager.LastTarget != mobile)
                 {
                     if (max > 0)
                     {

--- a/src/Game/Managers/HealthLinesManager.cs
+++ b/src/Game/Managers/HealthLinesManager.cs
@@ -51,7 +51,7 @@ namespace ClassicUO.Game.Managers
             if (!IsEnabled)
                 return;
 
-            const int BAR_WIDTH = 27;
+            const int BAR_WIDTH = 28;
             const int BAR_HEIGHT = 3;
             const int BAR_WIDTH_HALF = BAR_WIDTH >> 1;
             const int BAR_HEIGHT_HALF = BAR_HEIGHT >> 1;
@@ -80,18 +80,14 @@ namespace ClassicUO.Game.Managers
                 int current = mobile.Hits;
                 int max = mobile.HitsMax;
 
-                if (showWhen == 1 && current == max)
+                if (showWhen == 1 && current == max || TargetManager.LastTarget == mobile)
                     continue;
 
                 int x = screenX + mobile.RealScreenPosition.X;
                 int y = screenY + mobile.RealScreenPosition.Y;
 
-                x += (int) mobile.Offset.X + 22;
-                y += (int) (mobile.Offset.Y - mobile.Offset.Z) + 22 + 5;
-
-                x += 5;
-
-               
+                x += (int) mobile.Offset.X + 22 ;
+                y += (int) (mobile.Offset.Y - mobile.Offset.Z) + 22;
 
                 x = (int) (x / scale);
                 y = (int) (y / scale);
@@ -99,6 +95,9 @@ namespace ClassicUO.Game.Managers
                 y -= (int) (screenY / scale);
                 x += screenX;
                 y += screenY;
+
+                x += 5;
+                y += 5;
 
                 x -= BAR_WIDTH_HALF;
                 y -= BAR_HEIGHT_HALF;

--- a/src/Game/UI/Gumps/TargetLineGump.cs
+++ b/src/Game/UI/Gumps/TargetLineGump.cs
@@ -111,11 +111,20 @@ namespace ClassicUO.Game.UI.Gumps
             int w = Engine.Profile.Current.GameWindowSize.X;
             int h = Engine.Profile.Current.GameWindowSize.Y;
 
-            x = (int) ((Mobile.RealScreenPosition.X + Mobile.Offset.X - (Width >> 1) + 22) / scale);
-            y = (int) ((Mobile.RealScreenPosition.Y + Mobile.Offset.Y - Mobile.Offset.Z + 22) / scale);
+            x = gx + Mobile.RealScreenPosition.X;
+            y = gy + Mobile.RealScreenPosition.Y;
 
-            x += gx + 6;
+            x += (int) Mobile.Offset.X + 22;
+            y += (int) (Mobile.Offset.Y - Mobile.Offset.Z) + 22;
+
+            x = (int) (x / scale);
+            y = (int) (y / scale);
+            x -= (int) (gx / scale);
+            y -= (int) (gy / scale);
+            x += gx;
             y += gy;
+
+            x -= 12;
 
             X = x;
             Y = y;


### PR DESCRIPTION
This not only fixes issue https://github.com/andreakarasho/ClassicUO/issues/697 by hiding the HealthLine when the TargetLine is drawn for that mobile.
It also fixes the incorrect position for the TargetLine gump.

Without this fix:
![2019-10-18_05-03-55](https://user-images.githubusercontent.com/1727541/67063385-ead07900-f166-11e9-8ef1-99e202cdebf5.gif)

With this fix:
![2019-10-18_05-02-16](https://user-images.githubusercontent.com/1727541/67063520-62060d00-f167-11e9-96ee-feddcd4f5a2e.gif)
