### PR TITLE
Custom Health Bar Gump

### DIFF
--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -323,6 +323,7 @@
     <Compile Include="Game\UI\Gumps\Login\ServerSelectionGump.cs" />
     <Compile Include="Game\UI\Gumps\QuestionGump.cs" />
     <Compile Include="Game\UI\Gumps\HealthBarGump.cs" />
+    <Compile Include="Game\UI\Gumps\HealthBarGumpCustom.cs" />
     <Compile Include="Game\UI\Gumps\OptionsGump.cs" />
     <Compile Include="Game\UI\Gumps\PartyGumpAdvanced.cs" />
     <Compile Include="Game\UI\Gumps\PopupMenuGump.cs" />

--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -183,6 +183,8 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool NameOverheadToggled { get; set; } = false;
         [JsonProperty] public bool ShowTargetRangeIndicator { get; set; }
         [JsonProperty] public bool PartyInviteGump { get; set; }
+        [JsonProperty] public bool CustomBarsToggled { get; set; }
+        [JsonProperty] public bool CBBlackBGToggled { get; set; }
 
         [JsonProperty] public bool ShowInfoBar { get; set; }
         [JsonProperty] public int InfoBarHighlightType { get; set; } // 0 = text colour changes, 1 = underline

--- a/src/Game/GameObjects/MobileAnimation.cs
+++ b/src/Game/GameObjects/MobileAnimation.cs
@@ -963,7 +963,7 @@ namespace ClassicUO.Game.GameObjects
                             {
                                 if ((flags & ANIMATION_FLAGS.AF_USE_UOP_ANIMATION) != 0)
                                 {
-                                    if (mobile.InWarMode)
+                                    if (mobile.InWarMode && FileManager.Animations.AnimationExists(graphic, 1))
                                         result = 1;
                                     else
                                         result = 25;
@@ -981,7 +981,7 @@ namespace ClassicUO.Game.GameObjects
                             else
                                 result = FileManager.Animations.AnimationExists(graphic, 1) ? (byte) 1 : (byte) 2;
                         }
-                        else if ((flags & ANIMATION_FLAGS.AF_USE_UOP_ANIMATION) != 0 && !mobile.InWarMode)
+                        else if ((flags & ANIMATION_FLAGS.AF_USE_UOP_ANIMATION) != 0 && (!mobile.InWarMode || !FileManager.Animations.AnimationExists(graphic, 0)))
                         {
                             result = 22;
                         }

--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -1093,10 +1093,11 @@ namespace ClassicUO.Game.Managers
                         GameActions.DoubleClick(potion);
 
                     break;
-                    
-                 case MacroType.CloseAllHealthBars:
 
-                    var healthBarGumps = Engine.UI.Gumps.OfType<HealthBarGump>();
+                case MacroType.CloseAllHealthBars:
+
+                    //Includes HealthBarGump/HealthBarGumpCustom
+                    var healthBarGumps = Engine.UI.Gumps.OfType<AnchorableGump>().Where(g => g is HealthBarGump || g is HealthBarGumpCustom);
 
                     foreach (var healthbar in healthBarGumps)
                     {

--- a/src/Game/Managers/PartyManager.cs
+++ b/src/Game/Managers/PartyManager.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -53,68 +53,139 @@ namespace ClassicUO.Game.Managers
                     add = true;
                     goto case 2;
                 case 2:
-                    byte count = p.ReadByte();
 
-                    if (count <= 1)
+                    if (Engine.Profile.Current.CustomBarsToggled == true)
                     {
-                        Leader = 0;
-                        Inviter = 0;
+                        byte count = p.ReadByte();
 
-                        for (int i = 0; i < PARTY_SIZE; i++)
+                        if (count <= 1)
                         {
-                            if (Members[i] == null || Members[i].Serial == 0)
-                                break;
+                            Leader = 0;
+                            Inviter = 0;
 
-                            HealthBarGump gump = Engine.UI.GetGump<HealthBarGump>(Members[i].Serial);
-
-
-                            if (gump != null)
+                            for (int i = 0; i < PARTY_SIZE; i++)
                             {
-                                if (code == 2)
-                                    Members[i].Serial = 0;
+                                if (Members[i] == null || Members[i].Serial == 0)
+                                    break;
 
-                                gump.Update();
+                                HealthBarGumpCustom gump = Engine.UI.GetGump<HealthBarGumpCustom>(Members[i].Serial);
+
+
+                                if (gump != null)
+                                {
+                                    if (code == 2)
+                                        Members[i].Serial = 0;
+
+                                    gump.Update();
+                                }
                             }
+
+                            Clear();
+                            Engine.UI.GetGump<PartyGumpAdvanced>()?.Update();
+
+                            break;
                         }
 
                         Clear();
+
+                        if (!add)
+                        {
+                            Engine.UI.GetGump<HealthBarGumpCustom>(p.ReadUInt())?.Update();
+                        }
+
+                        for (int i = 0; i < count; i++)
+                        {
+                            Serial serial = p.ReadUInt();
+                            Members[i] = new PartyMember(serial);
+
+                            if (i == 0)
+                                Leader = serial;
+
+                            HealthBarGumpCustom gump = Engine.UI.GetGump<HealthBarGumpCustom>(serial);
+
+                            if (gump != null)
+                            {
+                                GameActions.RequestMobileStatus(serial);
+                                gump.Update();
+                            }
+                            else
+                            {
+                                if (serial == World.Player)
+                                {
+                                }
+                            }
+                        }
+
                         Engine.UI.GetGump<PartyGumpAdvanced>()?.Update();
 
                         break;
                     }
-
-                    Clear();
-
-                    if (!add)
+                    else if (Engine.Profile.Current.CustomBarsToggled == false)
                     {
-                        Engine.UI.GetGump<HealthBarGump>(p.ReadUInt())?.Update();
-                    }
+                        byte count = p.ReadByte();
 
-                    for (int i = 0; i < count; i++)
-                    {
-                        Serial serial = p.ReadUInt();
-                        Members[i] = new PartyMember(serial);
-
-                        if (i == 0)
-                            Leader = serial;
-
-                        HealthBarGump gump = Engine.UI.GetGump<HealthBarGump>(serial);
-
-                        if (gump != null)
+                        if (count <= 1)
                         {
-                            GameActions.RequestMobileStatus(serial);
-                            gump.Update();
-                        }
-                        else
-                        {
-                            if (serial == World.Player)
+                            Leader = 0;
+                            Inviter = 0;
+
+                            for (int i = 0; i < PARTY_SIZE; i++)
                             {
+                                if (Members[i] == null || Members[i].Serial == 0)
+                                    break;
+
+                                HealthBarGump gump = Engine.UI.GetGump<HealthBarGump>(Members[i].Serial);
+
+
+                                if (gump != null)
+                                {
+                                    if (code == 2)
+                                        Members[i].Serial = 0;
+
+                                    gump.Update();
+                                }
+                            }
+
+                            Clear();
+                            Engine.UI.GetGump<PartyGumpAdvanced>()?.Update();
+
+                            break;
+                        }
+
+                        Clear();
+
+                        if (!add)
+                        {
+                            Engine.UI.GetGump<HealthBarGump>(p.ReadUInt())?.Update();
+                        }
+
+                        for (int i = 0; i < count; i++)
+                        {
+                            Serial serial = p.ReadUInt();
+                            Members[i] = new PartyMember(serial);
+
+                            if (i == 0)
+                                Leader = serial;
+
+                            HealthBarGump gump = Engine.UI.GetGump<HealthBarGump>(serial);
+
+                            if (gump != null)
+                            {
+                                GameActions.RequestMobileStatus(serial);
+                                gump.Update();
+                            }
+                            else
+                            {
+                                if (serial == World.Player)
+                                {
+                                }
                             }
                         }
+
+                        Engine.UI.GetGump<PartyGumpAdvanced>()?.Update();
+
+                        break;
                     }
-
-                    Engine.UI.GetGump<PartyGumpAdvanced>()?.Update();
-
                     break;
 
                 case 3:
@@ -162,7 +233,7 @@ namespace ClassicUO.Game.Managers
                 Members[i] = null;
         }
     }
-    
+
     internal class PartyMember : IEquatable<PartyMember>
     {
         private string _name;

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -100,13 +100,13 @@ namespace ClassicUO.Game.Scenes
                 int x = Engine.Profile.Current.GameWindowPosition.X + (Engine.Profile.Current.GameWindowSize.X >> 1);
                 int y = Engine.Profile.Current.GameWindowPosition.Y + (Engine.Profile.Current.GameWindowSize.Y >> 1);
 
-                Direction direction = (Direction) GameCursor.GetMouseDirection(x, y, Mouse.Position.X, Mouse.Position.Y, 1);
+                Direction direction = (Direction)GameCursor.GetMouseDirection(x, y, Mouse.Position.X, Mouse.Position.Y, 1);
                 double mouseRange = MathHelper.Hypotenuse(x - Mouse.Position.X, y - Mouse.Position.Y);
 
                 Direction facing = direction;
 
                 if (facing == Direction.North)
-                    facing = (Direction) 8;
+                    facing = (Direction)8;
 
                 bool run = mouseRange >= 190;
 
@@ -178,116 +178,227 @@ namespace ClassicUO.Game.Scenes
 
         private void DoDragSelect()
         {
-            SetDragSelectionStartEnd(ref _selectionStart, ref _selectionEnd);
-
-            _rectangleObj.X = _selectionStart.Item1;
-            _rectangleObj.Y = _selectionStart.Item2;
-            _rectangleObj.Width = _selectionEnd.Item1 - _selectionStart.Item1;
-            _rectangleObj.Height = _selectionEnd.Item2 - _selectionStart.Item2;
-
-            int finalX = 100;
-            int finalY = 100;
-
-            foreach (Mobile mobile in World.Mobiles)
+            if (Engine.Profile.Current.CustomBarsToggled == true)
             {
-                if (Engine.Profile.Current.DragSelectHumanoidsOnly && !mobile.IsHuman)
-                    continue;
+                SetDragSelectionStartEnd(ref _selectionStart, ref _selectionEnd);
 
-                int x = Engine.Profile.Current.GameWindowPosition.X + mobile.RealScreenPosition.X + (int) mobile.Offset.X + 22 + 5;
-                int y = Engine.Profile.Current.GameWindowPosition.Y + (mobile.RealScreenPosition.Y - (int) mobile.Offset.Z) + 22 + 5;
+                _rectangleObj.X = _selectionStart.Item1;
+                _rectangleObj.Y = _selectionStart.Item2;
+                _rectangleObj.Width = _selectionEnd.Item1 - _selectionStart.Item1;
+                _rectangleObj.Height = _selectionEnd.Item2 - _selectionStart.Item2;
 
-                x -= mobile.FrameInfo.X;
-                y -= mobile.FrameInfo.Y;
-                int w = mobile.FrameInfo.Width;
-                int h = mobile.FrameInfo.Height;
+                int finalX = 100;
+                int finalY = 100;
 
-                x = (int)(x * (1 / Scale));
-                y = (int)(y * (1 / Scale));
-
-                _rectanglePlayer.X = x;
-                _rectanglePlayer.Y = y;
-                _rectanglePlayer.Width = w;
-                _rectanglePlayer.Height = h;
-
-               
-
-                if (_rectangleObj.Intersects(_rectanglePlayer))
+                foreach (Mobile mobile in World.Mobiles)
                 {
-                    Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
+                    if (Engine.Profile.Current.DragSelectHumanoidsOnly && !mobile.IsHuman)
+                        continue;
 
-                    if (mobile != World.Player)
+                    int x = Engine.Profile.Current.GameWindowPosition.X + mobile.RealScreenPosition.X + (int)mobile.Offset.X + 22 + 5;
+                    int y = Engine.Profile.Current.GameWindowPosition.Y + (mobile.RealScreenPosition.Y - (int)mobile.Offset.Z) + 22 + 5;
+
+                    x -= mobile.FrameInfo.X;
+                    y -= mobile.FrameInfo.Y;
+                    int w = mobile.FrameInfo.Width;
+                    int h = mobile.FrameInfo.Height;
+
+                    x = (int)(x * (1 / Scale));
+                    y = (int)(y * (1 / Scale));
+
+                    _rectanglePlayer.X = x;
+                    _rectanglePlayer.Y = y;
+                    _rectanglePlayer.Width = w;
+                    _rectanglePlayer.Height = h;
+
+
+
+                    if (_rectangleObj.Intersects(_rectanglePlayer))
                     {
-                        //Instead of destroying existing HP bar, continue if already opened.
-                        if (Engine.UI.GetGump<HealthBarGump>(mobile)?.IsInitialized ?? false)
+                        Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
+
+                        if (mobile != World.Player)
                         {
-                            continue;
-                        }
-                        GameActions.RequestMobileStatus(mobile);
-                        HealthBarGump hbg = new HealthBarGump(mobile);
-                        // Need to initialize before setting X Y otherwise AnchorableGump.OnMove() is not called
-                        // if OnMove() is not called, _prevX _prevY are not set, anchoring is unpredictable
-                        // maybe should be fixed elsewhere
-                        hbg.Initialize();
-
-
-                        if (finalY >= Engine.Profile.Current.GameWindowPosition.Y + Engine.Profile.Current.GameWindowSize.Y - 100)
-                        {
-                            finalY = 100;
-                            finalX += rect.Width + 2;
-                        }
-
-                        if (finalX >= Engine.Profile.Current.GameWindowPosition.X + Engine.Profile.Current.GameWindowSize.X - 100)
-                        {
-                            finalX = 100;
-                        }
-
-                        hbg.X = finalX;
-                        hbg.Y = finalY;
-
-                        foreach (var bar in Engine.UI.Gumps
-                                                  .OfType<HealthBarGump>()
-                                                  .OrderBy(s => s.ScreenCoordinateX)
-                                                  .ThenBy(s => s.ScreenCoordinateY))
-                        {
-                            if (bar.Bounds.Intersects(hbg.Bounds))
+                            //Instead of destroying existing HP bar, continue if already opened.
+                            if (Engine.UI.GetGump<HealthBarGumpCustom>(mobile)?.IsInitialized ?? false)
                             {
-                                finalY = bar.Bounds.Bottom + 2;
-
-                                if (finalY >= Engine.Profile.Current.GameWindowPosition.Y + Engine.Profile.Current.GameWindowSize.Y - 100)
-                                {
-                                    finalY = 100;
-                                    finalX = bar.Bounds.Right + 2;
-                                }
-
-                                if (finalX >= Engine.Profile.Current.GameWindowPosition.X + Engine.Profile.Current.GameWindowSize.X - 100)
-                                {
-                                    finalX = 100;
-                                }
-
-                                hbg.X = finalX;
-                                hbg.Y = finalY;
+                                continue;
                             }
+                            GameActions.RequestMobileStatus(mobile);
+                            HealthBarGumpCustom hbgc = new HealthBarGumpCustom(mobile);
+                            // Need to initialize before setting X Y otherwise AnchorableGump.OnMove() is not called
+                            // if OnMove() is not called, _prevX _prevY are not set, anchoring is unpredictable
+                            // maybe should be fixed elsewhere
+                            hbgc.Initialize();
+
+
+                            if (finalY >= Engine.Profile.Current.GameWindowPosition.Y + Engine.Profile.Current.GameWindowSize.Y - 100)
+                            {
+                                finalY = 100;
+                                finalX += rect.Width + 2;
+                            }
+
+                            if (finalX >= Engine.Profile.Current.GameWindowPosition.X + Engine.Profile.Current.GameWindowSize.X - 100)
+                            {
+                                finalX = 100;
+                            }
+
+                            hbgc.X = finalX;
+                            hbgc.Y = finalY;
+
+                            foreach (var bar in Engine.UI.Gumps
+                                                      .OfType<HealthBarGumpCustom>()
+                                                      //.OrderBy(s => mobile.NotorietyFlag)
+                                                      //.OrderBy(s => s.ScreenCoordinateX) ///testing placement SYRUPZ SYRUPZ SYRUPZ
+                                                      .OrderBy(s => s.ScreenCoordinateX)
+                                                      .ThenBy(s => s.ScreenCoordinateY))
+                            {
+                                if (bar.Bounds.Intersects(hbgc.Bounds))
+                                {
+                                    finalY = bar.Bounds.Bottom + 2;
+
+                                    if (finalY >= Engine.Profile.Current.GameWindowPosition.Y + Engine.Profile.Current.GameWindowSize.Y - 100)
+                                    {
+                                        finalY = 100;
+                                        finalX = bar.Bounds.Right + 2;
+                                    }
+
+                                    if (finalX >= Engine.Profile.Current.GameWindowPosition.X + Engine.Profile.Current.GameWindowSize.X - 100)
+                                    {
+                                        finalX = 100;
+                                    }
+
+                                    hbgc.X = finalX;
+                                    hbgc.Y = finalY;
+                                }
+                            }
+
+
+                            finalY += rect.Height + 2;
+
+
+                            Engine.UI.Add(hbgc);
+
+                            hbgc.SetInScreen();
+
+
                         }
-
-    
-                        finalY += rect.Height + 2;
-
-
-                        //hbg.X = x - (rect.Width >> 1);
-                        //hbg.Y = y - (rect.Height >> 1) - 100;
-                        Engine.UI.Add(hbg);
-
-                        hbg.SetInScreen();
-
-
                     }
                 }
+
+                _isSelectionActive = false;
             }
+            else
+            {
+                SetDragSelectionStartEnd(ref _selectionStart, ref _selectionEnd);
 
-            _isSelectionActive = false;
+                _rectangleObj.X = _selectionStart.Item1;
+                _rectangleObj.Y = _selectionStart.Item2;
+                _rectangleObj.Width = _selectionEnd.Item1 - _selectionStart.Item1;
+                _rectangleObj.Height = _selectionEnd.Item2 - _selectionStart.Item2;
+
+                int finalX = 100;
+                int finalY = 100;
+
+                foreach (Mobile mobile in World.Mobiles)
+                {
+                    if (Engine.Profile.Current.DragSelectHumanoidsOnly && !mobile.IsHuman)
+                        continue;
+
+                    int x = Engine.Profile.Current.GameWindowPosition.X + mobile.RealScreenPosition.X + (int)mobile.Offset.X + 22 + 5;
+                    int y = Engine.Profile.Current.GameWindowPosition.Y + (mobile.RealScreenPosition.Y - (int)mobile.Offset.Z) + 22 + 5;
+
+                    x -= mobile.FrameInfo.X;
+                    y -= mobile.FrameInfo.Y;
+                    int w = mobile.FrameInfo.Width;
+                    int h = mobile.FrameInfo.Height;
+
+                    x = (int)(x * (1 / Scale));
+                    y = (int)(y * (1 / Scale));
+
+                    _rectanglePlayer.X = x;
+                    _rectanglePlayer.Y = y;
+                    _rectanglePlayer.Width = w;
+                    _rectanglePlayer.Height = h;
+
+
+
+                    if (_rectangleObj.Intersects(_rectanglePlayer))
+                    {
+                        Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
+
+                        if (mobile != World.Player)
+                        {
+                            //Instead of destroying existing HP bar, continue if already opened.
+                            if (Engine.UI.GetGump<HealthBarGump>(mobile)?.IsInitialized ?? false)
+                            {
+                                continue;
+                            }
+                            GameActions.RequestMobileStatus(mobile);
+                            HealthBarGump hbg = new HealthBarGump(mobile);
+                            // Need to initialize before setting X Y otherwise AnchorableGump.OnMove() is not called
+                            // if OnMove() is not called, _prevX _prevY are not set, anchoring is unpredictable
+                            // maybe should be fixed elsewhere
+                            hbg.Initialize();
+
+
+                            if (finalY >= Engine.Profile.Current.GameWindowPosition.Y + Engine.Profile.Current.GameWindowSize.Y - 100)
+                            {
+                                finalY = 100;
+                                finalX += rect.Width + 2;
+                            }
+
+                            if (finalX >= Engine.Profile.Current.GameWindowPosition.X + Engine.Profile.Current.GameWindowSize.X - 100)
+                            {
+                                finalX = 100;
+                            }
+
+                            hbg.X = finalX;
+                            hbg.Y = finalY;
+
+                            foreach (var bar in Engine.UI.Gumps
+                                                      .OfType<HealthBarGump>()
+                                                      .OrderBy(s => s.ScreenCoordinateX)
+                                                      .ThenBy(s => s.ScreenCoordinateY))
+                            {
+                                if (bar.Bounds.Intersects(hbg.Bounds))
+                                {
+                                    finalY = bar.Bounds.Bottom + 2;
+
+                                    if (finalY >= Engine.Profile.Current.GameWindowPosition.Y + Engine.Profile.Current.GameWindowSize.Y - 100)
+                                    {
+                                        finalY = 100;
+                                        finalX = bar.Bounds.Right + 2;
+                                    }
+
+                                    if (finalX >= Engine.Profile.Current.GameWindowPosition.X + Engine.Profile.Current.GameWindowSize.X - 100)
+                                    {
+                                        finalX = 100;
+                                    }
+
+                                    hbg.X = finalX;
+                                    hbg.Y = finalY;
+                                }
+                            }
+
+
+                            finalY += rect.Height + 2;
+
+
+                            //hbg.X = x - (rect.Width >> 1);
+                            //hbg.Y = y - (rect.Height >> 1) - 100;
+                            Engine.UI.Add(hbg);
+
+                            hbg.SetInScreen();
+
+
+                        }
+                    }
+                }
+
+                _isSelectionActive = false;
+            }
         }
-
-
         internal override void OnLeftMouseDown()
         {
             if (!IsMouseOverViewport)
@@ -632,7 +743,7 @@ namespace ClassicUO.Game.Scenes
 
                 if (Math.Abs(offset.X) > Constants.MIN_PICKUP_DRAG_DISTANCE_PIXELS || Math.Abs(offset.Y) > Constants.MIN_PICKUP_DRAG_DISTANCE_PIXELS)
                 {
-                    GameObject obj = Engine.Profile.Current.SallosEasyGrab && SelectedObject.LastObject is GameObject o? o : _dragginObject;
+                    GameObject obj = Engine.Profile.Current.SallosEasyGrab && SelectedObject.LastObject is GameObject o ? o : _dragginObject;
 
 
                     switch (obj)
@@ -643,22 +754,44 @@ namespace ClassicUO.Game.Scenes
                             if (entity == null)
                                 break;
 
-                            GameActions.RequestMobileStatus(entity);
-                            var gump = Engine.UI.GetGump<HealthBarGump>(entity);
-                            if(gump != null)
+                            if (Engine.Profile.Current.CustomBarsToggled == true)
                             {
-                                if (!gump.IsInitialized)
-                                    break;
-                                gump.Dispose();
+                                GameActions.RequestMobileStatus(entity);
+                                var customgump = Engine.UI.GetGump<HealthBarGumpCustom>(entity);
+                                if (customgump != null)
+                                {
+                                    if (!customgump.IsInitialized)
+                                        break;
+                                    customgump.Dispose();
+                                }
+
+                                if (entity == World.Player)
+                                    StatusGumpBase.GetStatusGump()?.Dispose();
+
+                                Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
+                                HealthBarGumpCustom currentCustomHealthBarGump;
+                                Engine.UI.Add(currentCustomHealthBarGump = new HealthBarGumpCustom(entity) { X = Mouse.Position.X - (rect.Width >> 1), Y = Mouse.Position.Y - (rect.Height >> 1) });
+                                Engine.UI.AttemptDragControl(currentCustomHealthBarGump, Mouse.Position, true);
                             }
+                            else
+                            {
+                                GameActions.RequestMobileStatus(entity);
+                                var gump = Engine.UI.GetGump<HealthBarGump>(entity);
+                                if (gump != null)
+                                {
+                                    if (!gump.IsInitialized)
+                                        break;
+                                    gump.Dispose();
+                                }
 
-                            if (entity == World.Player)
-                                StatusGumpBase.GetStatusGump()?.Dispose();
+                                if (entity == World.Player)
+                                    StatusGumpBase.GetStatusGump()?.Dispose();
 
-                            Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
-                            HealthBarGump currentHealthBarGump;
-                            Engine.UI.Add(currentHealthBarGump = new HealthBarGump(entity) { X = Mouse.Position.X - (rect.Width >> 1), Y = Mouse.Position.Y - (rect.Height >> 1) });
-                            Engine.UI.AttemptDragControl(currentHealthBarGump, Mouse.Position, true);
+                                Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
+                                HealthBarGump currentHealthBarGump;
+                                Engine.UI.Add(currentHealthBarGump = new HealthBarGump(entity) { X = Mouse.Position.X - (rect.Width >> 1), Y = Mouse.Position.Y - (rect.Height >> 1) });
+                                Engine.UI.AttemptDragControl(currentHealthBarGump, Mouse.Position, true);
+                            }
 
                             break;
 
@@ -743,6 +876,7 @@ namespace ClassicUO.Game.Scenes
                 Macros.Update();
             }
         }
+
 
 
 

--- a/src/Game/UI/Gumps/HealthBarGumpCustom.cs
+++ b/src/Game/UI/Gumps/HealthBarGumpCustom.cs
@@ -694,17 +694,21 @@ namespace ClassicUO.Game.UI.Gumps
                         });
 
                     }
-                    else if (_canChangeName) //## currently not fixed ##//
+                    else if (_canChangeName) //## Rename works - Does not align properly? ##//
                     {
-                        Add(new EditableLabel(_name, 0, hue: Notoriety.GetHue((entity as Mobile).NotorietyFlag), true, 100, style: FontStyle.Cropped)
-                        //Add(new MultiSelectionShrinkbox(0, 0, 100, _name, hue: Notoriety.GetHue((entity as Mobile).NotorietyFlag), 1, true, userArrow2: false)
+                        Add(_textBox = new TextBoxCHB(1, maxWidth: 120, width: 100, isunicode: true, hue: Notoriety.GetHue(mobile.NotorietyFlag), style: FontStyle.BlackBorder)
                         {
-                            Y = 0, //SINGLE BAR
-                            X = _name.Length,
+                            X = 10,
+                            Y = 0,
+                            Width = 120,                            
+                            Height = 15,
+                            IsEditable = false,
+                            AcceptMouseInput = _canChangeName,
+                            AcceptKeyboardInput = _canChangeName,
+                            SafeCharactersOnly = true,
+                            WantUpdateSize = false,
                             CanMove = true,
-                            IsEditable = true,
-                            WantUpdateSize = true,
-                            //Alpha = 100,
+                            Text = _name
                         });
                         if (_canChangeName) _textBox.MouseUp += TextBoxOnMouseUp;
                     }

--- a/src/Game/UI/Gumps/HealthBarGumpCustom.cs
+++ b/src/Game/UI/Gumps/HealthBarGumpCustom.cs
@@ -1,0 +1,830 @@
+#region license
+
+//  Copyright (C) 2019 ClassicUO Development Community on Github
+//
+//	This project is an alternative client for the game Ultima Online.
+//	The goal of this is to develop a lightweight client considering 
+//	new technologies.  
+//      
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+#region Health Bar Gump Custom
+
+// Health Bar Gump Custom v.1c by Syrupz(Alan)
+//
+// The goal of this was to simply modernize the Health Bar Gumps while still giving people
+// an option to continue using the classic Health Bar Gumps. The option to overide bar types
+// be it (straight line(custom) or graphic(classic) is directly included in this version
+// with no need to change art files in UO directory.
+//
+// Please report any problems with this to Alan#0084 on Discord and I will promptly work on fixing said issues.
+//
+// Lastly, I want to give a special thanks to Gaechti for helping me stress test this
+// and helping me work and organizing this in a timely fashion to get this released.
+// I would like to also thank KaRaShO, Roxya, Stalli, and Link for their input, tips, 
+// and advice to approach certain challenges that arose throughout development.
+// in different manners to get these Health Bars to function per my own vision; gratitude.
+//
+// Health Bar Gump Custom v.1c by Syrupz(Alan)
+
+#endregion
+
+using System;
+using System.IO;
+
+using ClassicUO.Game.Data;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Input;
+using ClassicUO.IO;
+using ClassicUO.IO.Resources;
+using ClassicUO.Network;
+using ClassicUO.Renderer;
+using ClassicUO.Utility;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using SDL2;
+
+
+namespace ClassicUO.Game.UI.Gumps
+{
+    internal class LineCHB : Line
+    {
+        public LineCHB(int x, int y, int w, int h, uint color) : base(x, y, w, h, color)
+        {
+            LineWidth = w;
+            LineColor = Textures.GetTexture(new Color() { PackedValue = color });
+
+            CanMove = true;
+        }
+        public int LineWidth { get; set; }
+        public Texture2D LineColor { get; set; }
+        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        {
+            ResetHueVector();
+            ShaderHuesTraslator.GetHueVector(ref _hueVector, 0, false, Alpha);
+
+            return batcher.Draw2D(LineColor, x, y, LineWidth, Height, ref _hueVector);
+        }
+    }
+
+    internal class TextBoxCHB : TextBox
+    {
+        public TextBoxCHB(byte font, int maxcharlength = -1, int maxWidth = 0, int width = 0, bool isunicode = true, FontStyle style = FontStyle.None, ushort hue = 0) : base(font, maxcharlength, maxWidth, width, isunicode, style, hue)
+        {
+        }
+        public int RenderedTextOffset { get; set; }
+        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        {
+            TxEntry.RenderText.Draw(batcher, x + RenderedTextOffset + TxEntry.Offset, y);
+
+            if (IsEditable && HasKeyboardFocus)
+                TxEntry.RenderCaret.Draw(batcher, x + RenderedTextOffset + TxEntry.Offset + TxEntry.CaretPosition.X, y + TxEntry.CaretPosition.Y);
+
+            return base.Draw(batcher, x, y);
+        }
+    }
+    internal class HealthBarGumpCustom : AnchorableGump
+    {
+
+        private readonly LineCHB[] _bars = new LineCHB[3];
+        private readonly LineCHB[] _border = new LineCHB[4];
+
+        private LineCHB _hpLineRed, _manaLineRed, _stamLineRed, _outline;
+
+        private bool _canChangeName;
+        private bool _isDead;
+        private string _name;
+        private int _oldHits, _oldStam, _oldMana;
+
+        private bool _oldWarMode, _normalHits, _poisoned, _yellowHits;
+        private bool _outOfRange;
+
+        private bool _targetBroke;
+
+        private TextBoxCHB _textBox;
+
+        private const int HPB_WIDTH = 120;
+        private const int HPB_HEIGHT_MULTILINE = 60;
+        private const int HPB_HEIGHT_SINGLELINE = 36;
+        private const int HPB_BORDERSIZE = 1;
+        private const int HPB_OUTLINESIZE = 1;
+
+        private const int HPB_BAR_SPACELEFT = (HPB_WIDTH - HPB_BAR_WIDTH) / 2;
+
+        private const int HPB_BAR_WIDTH = 100;
+        private const int HPB_BAR_HEIGHT = 8;
+
+        private Color HPB_COLOR_DRAW_RED = Color.Red;
+        private Color HPB_COLOR_DRAW_BLUE = Color.DodgerBlue;
+        private Color HPB_COLOR_DRAW_BLACK = Color.Black;
+
+        private Texture2D HPB_COLOR_BLUE = Textures.GetTexture(Color.DodgerBlue);
+        private Texture2D HPB_COLOR_GRAY = Textures.GetTexture(Color.Gray);
+        private Texture2D HPB_COLOR_RED = Textures.GetTexture(Color.Red);
+        private Texture2D HPB_COLOR_YELLOW = Textures.GetTexture(Color.Orange);
+        private Texture2D HPB_COLOR_POISON = Textures.GetTexture(Color.LimeGreen);
+        private Texture2D HPB_COLOR_BLACK = Textures.GetTexture(Color.Black);
+
+        public AlphaBlendControl _background;
+        public HealthBarGumpCustom(Entity entity) : this()
+        {
+
+            if (entity == null)
+            {
+                Dispose();
+
+                return;
+            }
+
+
+            _name = entity.Name;
+            _isDead = entity.Serial.IsMobile && ((Mobile)entity).IsDead;
+            LocalSerial = entity.Serial;
+
+            BuildCustomGump();
+        }
+        private enum MobileName
+        {
+            Name
+        }
+        public HealthBarGumpCustom(Serial mob) : this(World.Get(mob))
+        {
+        }
+        public HealthBarGumpCustom() : base(0, 0)
+        {
+            CanMove = true;
+            AnchorGroupName = "healthbar";
+        }
+        public override int GroupMatrixWidth
+        {
+            get => Width;
+            protected set { }
+        }
+        public override int GroupMatrixHeight
+        {
+            get => Height;
+            protected set { }
+        }
+        public void Update()
+        {
+            Clear();
+            Children.Clear();
+
+            _background = null;
+            _hpLineRed = _manaLineRed = _stamLineRed = null;
+
+            _textBox = null;
+
+            BuildCustomGump();
+            Initialize();
+        }
+        public override void Update(double totalMS, double frameMS)
+        {
+            base.Update(totalMS, frameMS);
+
+            if (IsDisposed)
+                return;
+
+            bool inparty = World.Party.Contains(LocalSerial);
+
+
+            Hue textColor = 0x0386;
+
+            Entity entity = World.Get(LocalSerial);
+
+            if (entity == null || entity.IsDestroyed)
+            {
+
+                if (LocalSerial != World.Player && (Engine.Profile.Current.CloseHealthBarType == 1 ||
+                                                    Engine.Profile.Current.CloseHealthBarType == 2 && World.CorpseManager.Exists(0, LocalSerial | 0x8000_0000)))
+                {
+                    //### KEEPS PARTY BAR ACTIVE WHEN PARTY MEMBER DIES & MOBILEBAR CLOSE SELECTED ###//
+                    if (!inparty)
+                    {
+                        Dispose();
+
+                        return;
+                    }
+                    //### KEEPS PARTY BAR ACTIVE WHEN PARTY MEMBER DIES & MOBILEBAR CLOSE SELECTED ###//
+                }
+
+                if (_isDead)
+                    _isDead = false;
+
+                if (!_outOfRange)
+                {
+
+                    _outOfRange = true;
+
+                    if (inparty)
+                    {
+
+                        textColor = 912;
+
+                        if (_textBox.Hue != textColor)
+                            _textBox.Hue = textColor;
+
+                        Add(new Label(_name, true, style: FontStyle.Cropped, hue: Notoriety.GetHue((entity as Mobile)?.NotorietyFlag ?? NotorietyFlag.Gray), maxwidth: 100, align: TEXT_ALIGN_TYPE.TS_CENTER)
+                        {
+                            X = 8,
+                            Y = 3
+                        });
+
+                        _bars[1].IsVisible = false;
+                        _bars[2].IsVisible = false;
+                    }
+                    else
+                    {
+                        if (_textBox.Hue != textColor)
+                            _textBox.Hue = textColor;
+
+                        Add(new Label(_name, true, style: FontStyle.Cropped, hue: Notoriety.GetHue((entity as Mobile)?.NotorietyFlag ?? NotorietyFlag.Gray), maxwidth: 100, align: TEXT_ALIGN_TYPE.TS_CENTER)
+                        {
+                            X = 8,
+                            Y = 0
+                        });
+
+                        if (_canChangeName)
+                            _textBox.MouseUp -= TextBoxOnMouseUp;
+                    }
+
+                    if (_background.Hue != 0)
+                        _background.Hue = 912;
+
+                    if (_hpLineRed.LineColor != HPB_COLOR_GRAY)
+                    {
+                        _hpLineRed.LineColor = HPB_COLOR_GRAY;
+                        _border[0].LineColor = _border[1].LineColor = _border[2].LineColor = _border[3].LineColor = HPB_COLOR_BLACK;
+
+
+                        if (_manaLineRed != null && _stamLineRed != null)
+                            _manaLineRed.LineColor = _stamLineRed.LineColor = HPB_COLOR_GRAY;
+                    }
+
+                    _bars[0].IsVisible = false;
+                }
+            }
+
+            if (entity != null && !entity.IsDestroyed)
+            {
+                Mobile mobile = entity.Serial.IsMobile ? (Mobile)entity : null;
+
+                if (!_isDead && entity != World.Player && (mobile != null && mobile.IsDead) && Engine.Profile.Current.CloseHealthBarType == 2) // is dead
+                {
+
+                    if (!inparty)
+                    {
+                        Dispose();
+
+                        return;
+                    }
+
+                }
+
+                if (!(mobile != null && mobile.IsDead) && _isDead) _isDead = false;
+
+                if (mobile.IsDead)
+                    if (!string.IsNullOrEmpty(entity.Name) && _name != entity.Name)
+                    {
+
+                        string _newname = entity.Name;
+
+                        int width = FileManager.Fonts.GetWidthUnicode(_textBox.Font, _newname);
+
+                        if (width > 100)
+                        {
+                            _newname = FileManager.Fonts.GetTextByWidthUnicode(_textBox.Font, _newname, 100, true, TEXT_ALIGN_TYPE.TS_CENTER, (ushort)FontStyle.BlackBorder);
+                            width = 100;
+                        }
+
+
+                        _textBox.Width = width;
+
+                        _textBox.Text = _newname;
+
+                        Width = _background.Width = Math.Max(_textBox.Width + 4, HPB_WIDTH);
+                        Height = _background.Height = _textBox.Height + 4;
+
+
+                        if (_textBox != null)
+                            _textBox.Text = _newname;
+                    }
+
+                if (_outOfRange)
+                {
+                    if (entity.HitsMax == 0)
+                        GameActions.RequestMobileStatus(entity);
+
+                    _outOfRange = false;
+
+                    textColor = Notoriety.GetHue(mobile.NotorietyFlag);
+
+                    if (inparty && mobile != null)
+                    {
+                        textColor = Notoriety.GetHue(mobile.NotorietyFlag);
+
+
+                        Add(new Label(_name, true, style: FontStyle.Cropped, hue: Notoriety.GetHue((entity as Mobile)?.NotorietyFlag ?? NotorietyFlag.Gray), maxwidth: 100, align: TEXT_ALIGN_TYPE.TS_CENTER)
+                        {
+                            X = 8,
+                            Y = 3
+                        });
+
+                    }
+                    else
+                    {
+                        _canChangeName = mobile != null && mobile.IsRenamable;
+
+
+                        Add(new Label(_name, true, style: FontStyle.Cropped, hue: Notoriety.GetHue((entity as Mobile)?.NotorietyFlag ?? NotorietyFlag.Gray), maxwidth: 100, align: TEXT_ALIGN_TYPE.TS_CENTER)
+                        {
+                            X = 8,
+                            Y = 0
+                        });
+
+                        if (_canChangeName)
+                        {
+                            textColor = 0x000E;
+                            _textBox.MouseUp += TextBoxOnMouseUp;
+                        }
+                    }
+
+                    if (_textBox.Hue != textColor)
+                        _textBox.Hue = textColor;
+
+                    if (inparty)
+                    {
+                        _bars[1].IsVisible = true;
+                        _bars[2].IsVisible = true;
+                    }
+
+                    if (_hpLineRed.LineColor != HPB_COLOR_RED)
+                    {
+                        _hpLineRed.LineColor = HPB_COLOR_RED;
+                        _border[0].LineColor = _border[1].LineColor = _border[2].LineColor = _border[3].LineColor = HPB_COLOR_BLACK;
+
+                        if (_manaLineRed != null && _stamLineRed != null)
+                            _manaLineRed.LineColor = _stamLineRed.LineColor = HPB_COLOR_RED;
+                    }
+
+                    _bars[0].IsVisible = true;
+                }
+
+                Hue barColor = entity == World.Player || mobile == null || mobile.NotorietyFlag == NotorietyFlag.Criminal || mobile.NotorietyFlag == NotorietyFlag.Gray ? Notoriety.GetHue(mobile.NotorietyFlag) : Notoriety.GetHue(mobile.NotorietyFlag);
+
+                if (_background.Hue != barColor)
+                {
+
+                    if (inparty && mobile.IsDead)
+                    {
+                        _background.Hue = 912;
+                    }
+                    else if (mobile.IsDead)
+                    {
+                        _background.Hue = 912;
+                    }
+                    else if (!Engine.Profile.Current.CBBlackBGToggled)
+                    {
+                        _background.Hue = barColor;
+                    }
+
+                }
+                if (_background.Hue != 912)
+                {
+
+                    if (inparty && mobile.IsDead)
+                    {
+                        _background.Hue = 912;
+                    }
+                    else if (mobile.IsDead)
+                    {
+                        _background.Hue = 912;
+                    }
+                    else if (Engine.Profile.Current.CBBlackBGToggled)
+                    {
+                        _background.Hue = 912;
+                    }
+                }
+
+                if (mobile != null && mobile.IsPoisoned && !_poisoned)
+                {
+
+                    _bars[0].LineColor = HPB_COLOR_POISON;
+
+                    _poisoned = true;
+                    _normalHits = false;
+                }
+                else if (mobile != null && mobile.IsYellowHits && !_yellowHits)
+                {
+
+                    _bars[0].LineColor = HPB_COLOR_YELLOW;
+
+                    _yellowHits = true;
+                    _normalHits = false;
+                }
+                else if (!_normalHits && (mobile != null && !mobile.IsPoisoned && !mobile.IsYellowHits) && (_poisoned || _yellowHits))
+                {
+
+                    _bars[0].LineColor = HPB_COLOR_BLUE;
+
+                    _poisoned = false;
+                    _yellowHits = false;
+                    _normalHits = true;
+                }
+
+                int barW = HPB_BAR_WIDTH;
+
+                int hits = CalculatePercents(entity.HitsMax, entity.Hits, barW);
+
+                if (hits != _oldHits)
+                {
+                    _bars[0].LineWidth = hits;
+                    _oldHits = hits;
+                }
+
+                if ((inparty || CanBeSaved) && mobile != null && _bars != null)
+                {
+                    int mana = CalculatePercents(mobile.ManaMax, mobile.Mana, barW);
+                    int stam = CalculatePercents(mobile.StaminaMax, mobile.Stamina, barW);
+
+                    if (mana != _oldMana)
+                    {
+                        _bars[1].LineWidth = mana;
+                        _oldMana = mana;
+                    }
+
+                    if (stam != _oldStam)
+                    {
+                        _bars[2].LineWidth = stam;
+                        _oldStam = stam;
+                    }
+                }
+
+                if (Engine.UI.MouseOverControl != null && Engine.UI.MouseOverControl.RootParent == this)
+                {
+                    SelectedObject.HealthbarObject = entity;
+                    SelectedObject.Object = entity;
+                    SelectedObject.LastObject = entity;
+                }
+            }
+
+            if (CanBeSaved)
+            {
+                if (World.Player.InWarMode != _oldWarMode)
+                {
+                    _oldWarMode = !_oldWarMode;
+
+                    _border[0].LineColor = _border[1].LineColor = _border[2].LineColor = _border[3].LineColor = World.Player.InWarMode ? HPB_COLOR_RED : HPB_COLOR_BLACK;
+                }
+            }
+        }
+        public override void Dispose()
+        {
+            var entity = World.Get(LocalSerial);
+
+            if (FileManager.ClientVersion >= ClientVersions.CV_200 && World.InGame && entity != null)
+                NetClient.Socket.Send(new PCloseStatusBarGump(entity));
+
+            if (SelectedObject.HealthbarObject == entity && entity != null)
+                SelectedObject.HealthbarObject = null;
+            base.Dispose();
+        }
+        public override void Save(BinaryWriter writer)
+        {
+            base.Save(writer);
+            writer.Write(LocalSerial);
+        }
+        public override void Restore(BinaryReader reader)
+        {
+            base.Restore(reader);
+            LocalSerial = reader.ReadUInt32();
+
+            if (LocalSerial == World.Player)
+            {
+                _name = World.Player.Name;
+                BuildCustomGump();
+            }
+            else
+                Dispose();
+        }
+        private void BuildCustomGump()
+        {
+            CanBeSaved = LocalSerial == World.Player;
+
+            WantUpdateSize = false;
+
+            var entity = World.Get(LocalSerial);
+
+
+            if (World.Party.Contains(LocalSerial))
+            {
+
+                Height = HPB_HEIGHT_MULTILINE;
+                Width = HPB_WIDTH;
+                Add(new GameBorder(0, 0, HPB_WIDTH, HPB_HEIGHT_MULTILINE, 1 / 2));
+                Add(_background = new AlphaBlendControl(0.3f) { Width = Width, Height = Height });
+
+
+                if (CanBeSaved)
+                {
+                    Add(_textBox = new TextBoxCHB(3, width: HPB_BAR_WIDTH, isunicode: true, style: FontStyle.Cropped, hue: Notoriety.GetHue(World.Player.NotorietyFlag))
+                    {
+                        X = 0,
+                        Y = -2,
+                        IsEditable = false,
+                        CanMove = true,
+                        //Text = "name"                  
+
+                    });
+
+                    Add(new Label(_name, true, style: FontStyle.Cropped, hue: Notoriety.GetHue((entity as Mobile).NotorietyFlag), maxwidth: 100, align: TEXT_ALIGN_TYPE.TS_CENTER)
+                    {
+                        X = 8,
+                        Y = 3
+                    });
+                }
+                else
+                {
+                    Add(_textBox = new TextBoxCHB(3, width: HPB_BAR_WIDTH, isunicode: true, style: FontStyle.Cropped | FontStyle.BlackBorder, hue: Notoriety.GetHue((entity as Mobile)?.NotorietyFlag ?? NotorietyFlag.Gray))
+                    {
+                        X = 0,
+                        Y = -2,
+                        IsEditable = false,
+                        CanMove = true,
+                        //Text = _name
+                    });
+
+                    Add(new Label(_name, true, style: FontStyle.Cropped, hue: Notoriety.GetHue((entity as Mobile).NotorietyFlag), maxwidth: 100, align: TEXT_ALIGN_TYPE.TS_CENTER)
+                    {
+                        X = 8,
+                        Y = 3
+                    });
+                }
+
+                Add(_outline = new LineCHB(HPB_BAR_SPACELEFT - HPB_OUTLINESIZE, 27 - HPB_OUTLINESIZE, HPB_BAR_WIDTH + (HPB_OUTLINESIZE * 2), (HPB_BAR_HEIGHT * 3) + 2 + (HPB_OUTLINESIZE * 2), HPB_COLOR_DRAW_BLACK.PackedValue));
+                Add(_hpLineRed = new LineCHB(HPB_BAR_SPACELEFT, 27, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_RED.PackedValue));
+                Add(_manaLineRed = new LineCHB(HPB_BAR_SPACELEFT, 36, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_RED.PackedValue));
+                Add(_stamLineRed = new LineCHB(HPB_BAR_SPACELEFT, 45, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_RED.PackedValue));
+
+                Add(_bars[0] = new LineCHB(HPB_BAR_SPACELEFT, 27, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_BLUE.PackedValue));
+                Add(_bars[1] = new LineCHB(HPB_BAR_SPACELEFT, 36, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_BLUE.PackedValue));
+                Add(_bars[2] = new LineCHB(HPB_BAR_SPACELEFT, 45, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_BLUE.PackedValue));
+
+                Add(_border[0] = new LineCHB(0, 0, HPB_WIDTH, HPB_BORDERSIZE, HPB_COLOR_DRAW_BLACK.PackedValue));
+                Add(_border[1] = new LineCHB(0, HPB_HEIGHT_MULTILINE - HPB_BORDERSIZE, HPB_WIDTH, HPB_BORDERSIZE, HPB_COLOR_DRAW_BLACK.PackedValue));
+                Add(_border[2] = new LineCHB(0, 0, HPB_BORDERSIZE, HPB_HEIGHT_MULTILINE, HPB_COLOR_DRAW_BLACK.PackedValue));
+                Add(_border[3] = new LineCHB(HPB_WIDTH - HPB_BORDERSIZE, 0, HPB_BORDERSIZE, HPB_HEIGHT_MULTILINE, HPB_COLOR_DRAW_BLACK.PackedValue));
+
+
+            }
+            else
+            {
+                if (CanBeSaved)
+                {
+                    _oldWarMode = World.Player.InWarMode;
+                    Height = HPB_HEIGHT_MULTILINE;
+                    Width = HPB_WIDTH;
+                    Add(new GameBorder(0, 0, HPB_WIDTH, HPB_HEIGHT_MULTILINE, 1 / 2));
+                    Add(_background = new AlphaBlendControl(0.3f) { Width = Width, Height = Height });
+
+                    Add(_textBox = new TextBoxCHB(3, width: HPB_BAR_WIDTH, isunicode: true, style: FontStyle.Cropped | FontStyle.BlackBorder, hue: Notoriety.GetHue((entity as Mobile)?.NotorietyFlag ?? NotorietyFlag.Gray))
+                    {
+                        X = 0,
+                        Y = 0,
+                        IsEditable = false,
+                        CanMove = true,
+                        //Text = ""
+
+                    });
+
+                    int nameOffset = Math.Max(0, HPB_WIDTH - _name.Length - 4) >> 1;
+
+                    Add(new Label(_name, true, style: FontStyle.Cropped, hue: Notoriety.GetHue((entity as Mobile).NotorietyFlag), maxwidth: 100, align: TEXT_ALIGN_TYPE.TS_CENTER)
+
+                    {
+                        X = 8,
+                        Y = 3
+                    });
+
+                    Add(_outline = new LineCHB(HPB_BAR_SPACELEFT - HPB_OUTLINESIZE, 27 - HPB_OUTLINESIZE, HPB_BAR_WIDTH + (HPB_OUTLINESIZE * 2), (HPB_BAR_HEIGHT * 3) + 2 + (HPB_OUTLINESIZE * 2), HPB_COLOR_DRAW_BLACK.PackedValue));
+                    Add(_hpLineRed = new LineCHB(HPB_BAR_SPACELEFT, 27, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_RED.PackedValue));
+                    Add(new LineCHB(HPB_BAR_SPACELEFT, 36, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_RED.PackedValue));
+                    Add(new LineCHB(HPB_BAR_SPACELEFT, 45, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_RED.PackedValue));
+
+                    Add(_bars[0] = new LineCHB(HPB_BAR_SPACELEFT, 27, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_BLUE.PackedValue));
+                    Add(_bars[1] = new LineCHB(HPB_BAR_SPACELEFT, 36, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_BLUE.PackedValue));
+                    Add(_bars[2] = new LineCHB(HPB_BAR_SPACELEFT, 45, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_BLUE.PackedValue));
+
+                    Add(_border[0] = new LineCHB(0, 0, HPB_WIDTH, HPB_BORDERSIZE, HPB_COLOR_DRAW_BLACK.PackedValue));
+                    Add(_border[1] = new LineCHB(0, HPB_HEIGHT_MULTILINE - HPB_BORDERSIZE, HPB_WIDTH, HPB_BORDERSIZE, HPB_COLOR_DRAW_BLACK.PackedValue));
+                    Add(_border[2] = new LineCHB(0, 0, HPB_BORDERSIZE, HPB_HEIGHT_MULTILINE, HPB_COLOR_DRAW_BLACK.PackedValue));
+                    Add(_border[3] = new LineCHB(HPB_WIDTH - HPB_BORDERSIZE, 0, HPB_BORDERSIZE, HPB_HEIGHT_MULTILINE, HPB_COLOR_DRAW_BLACK.PackedValue));
+
+                    _border[0].LineColor = _border[1].LineColor = _border[2].LineColor = _border[3].LineColor = _oldWarMode ? HPB_COLOR_RED : HPB_COLOR_BLACK;
+                }
+                else
+                {
+                    Hue textColor = 0x0386;
+                    Hue hitsColor = 0x0386;
+
+                    Mobile mobile = entity != null && entity.Serial.IsMobile ? (Mobile)entity : null;
+
+                    if (entity != null)
+                    {
+                        hitsColor = 0;
+                        _canChangeName = mobile != null && mobile.IsRenamable;
+
+                        if (_canChangeName)
+                            textColor = 0x000E;
+                    }
+
+                    Hue barColor = entity == null || entity == World.Player || mobile == null || mobile.NotorietyFlag == NotorietyFlag.Criminal || mobile.NotorietyFlag == NotorietyFlag.Gray ? (Hue)0 : Notoriety.GetHue(mobile.NotorietyFlag);
+
+                    Height = HPB_HEIGHT_SINGLELINE;
+                    Width = HPB_WIDTH;
+                    Add(new GameBorder(0, 0, HPB_WIDTH, HPB_HEIGHT_MULTILINE, 1 / 2));
+                    Add(_background = new AlphaBlendControl(0.3f) { Width = Width, Height = Height });
+
+                    Add(_outline = new LineCHB(HPB_BAR_SPACELEFT - HPB_OUTLINESIZE, 21 - HPB_OUTLINESIZE, HPB_BAR_WIDTH + (HPB_OUTLINESIZE * 2), HPB_BAR_HEIGHT + (HPB_OUTLINESIZE * 2), HPB_COLOR_DRAW_BLACK.PackedValue));
+                    Add(_hpLineRed = new LineCHB(HPB_BAR_SPACELEFT, 21, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_RED.PackedValue));
+
+                    Add(_bars[0] = new LineCHB(HPB_BAR_SPACELEFT, 21, HPB_BAR_WIDTH, HPB_BAR_HEIGHT, HPB_COLOR_DRAW_BLUE.PackedValue));
+
+                    Add(_border[0] = new LineCHB(0, 0, HPB_WIDTH, HPB_BORDERSIZE, HPB_COLOR_DRAW_BLACK.PackedValue));
+                    Add(_border[1] = new LineCHB(0, HPB_HEIGHT_SINGLELINE - HPB_BORDERSIZE, HPB_WIDTH, HPB_BORDERSIZE, HPB_COLOR_DRAW_BLACK.PackedValue));
+                    Add(_border[2] = new LineCHB(0, 0, HPB_BORDERSIZE, HPB_HEIGHT_SINGLELINE, HPB_COLOR_DRAW_BLACK.PackedValue));
+                    Add(_border[3] = new LineCHB(HPB_WIDTH - HPB_BORDERSIZE, 0, HPB_BORDERSIZE, HPB_HEIGHT_SINGLELINE, HPB_COLOR_DRAW_BLACK.PackedValue));
+
+                    Add(_textBox = new TextBoxCHB(3, width: HPB_BAR_WIDTH, isunicode: true, hue: Notoriety.GetHue(mobile.NotorietyFlag), style: FontStyle.BlackBorder)
+                    {
+                        X = 0,
+                        Y = 0,
+                        Width = HPB_WIDTH,
+                        Height = 15,
+                        IsEditable = false,
+                        AcceptMouseInput = _canChangeName,
+                        AcceptKeyboardInput = _canChangeName,
+                        SafeCharactersOnly = true,
+                        WantUpdateSize = false,
+                        CanMove = true,
+                        //Text = _name
+                    });
+
+                    if (!_canChangeName)
+                    {
+                        Add(new Label(_name, true, style: FontStyle.Cropped, hue: Notoriety.GetHue((entity as Mobile).NotorietyFlag), maxwidth: 100, align: TEXT_ALIGN_TYPE.TS_CENTER)
+                        {
+                            X = 8,
+                            Y = 0
+                        });
+
+                    }
+                    else if (_canChangeName) //## currently not fixed ##//
+                    {
+                        Add(new EditableLabel(_name, 0, hue: Notoriety.GetHue((entity as Mobile).NotorietyFlag), true, 100, style: FontStyle.Cropped)
+                        //Add(new MultiSelectionShrinkbox(0, 0, 100, _name, hue: Notoriety.GetHue((entity as Mobile).NotorietyFlag), 1, true, userArrow2: false)
+                        {
+                            Y = 0, //SINGLE BAR
+                            X = _name.Length,
+                            CanMove = true,
+                            IsEditable = true,
+                            WantUpdateSize = true,
+                            //Alpha = 100,
+                        });
+                        if (_canChangeName) _textBox.MouseUp += TextBoxOnMouseUp;
+                    }
+                }
+            }
+        }
+        private void TextBoxOnMouseUp(object sender, MouseEventArgs e)
+        {
+            if (e.Button != MouseButton.Left)
+                return;
+
+            Point p = Mouse.LDroppedOffset;
+
+            if (Math.Max(Math.Abs(p.X), Math.Abs(p.Y)) >= 1) return;
+
+            if (TargetManager.IsTargeting)
+            {
+                TargetManager.TargetGameObject(World.Get(LocalSerial));
+                Mouse.LastLeftButtonClickTime = 0;
+            }
+            else if (_canChangeName && !_targetBroke)
+            {
+                _textBox.IsEditable = true;
+                _textBox.SetKeyboardFocus();
+            }
+
+            _targetBroke = false;
+        }
+        private static int CalculatePercents(int max, int current, int maxValue)
+        {
+            if (max > 0)
+            {
+                max = current * 100 / max;
+
+                if (max > 100)
+                    max = 100;
+
+                if (max > 1)
+                    max = maxValue * max / 100;
+            }
+
+            return max;
+        }
+        protected override void OnMouseDown(int x, int y, MouseButton button)
+        {
+            if (button != MouseButton.Left)
+                return;
+
+            if (TargetManager.IsTargeting)
+            {
+                _targetBroke = true;
+                TargetManager.TargetGameObject(World.Get(LocalSerial));
+                Mouse.LastLeftButtonClickTime = 0;
+            }
+            else if (_canChangeName)
+            {
+                _textBox.IsEditable = false;
+                Engine.UI.SystemChat.SetFocus();
+            }
+        }
+        protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)
+        {
+            if (button != MouseButton.Left)
+                return false;
+
+            var entity = World.Get(LocalSerial);
+
+            if (entity != null)
+            {
+                if (entity != World.Player)
+                {
+                    if (World.Player.InWarMode)
+                        GameActions.Attack(entity);
+                    else
+                        GameActions.DoubleClick(entity);
+                }
+                else
+                {
+                    StatusGumpBase.AddStatusGump(ScreenCoordinateX, ScreenCoordinateY);
+                    Dispose();
+                }
+            }
+
+            return true;
+        }
+        protected override void OnKeyDown(SDL.SDL_Keycode key, SDL.SDL_Keymod mod)
+        {
+            var entity = World.Get(LocalSerial);
+
+            if (entity == null || entity.Serial.IsItem)
+                return;
+
+            if ((key == SDL.SDL_Keycode.SDLK_RETURN || key == SDL.SDL_Keycode.SDLK_KP_ENTER) && _textBox.IsEditable)
+            {
+                GameActions.Rename(entity, _textBox.Text);
+                Engine.UI.SystemChat?.SetFocus();
+                _textBox.IsEditable = false;
+            }
+        }
+        protected override void OnMouseOver(int x, int y)
+        {
+            var entity = World.Get(LocalSerial);
+
+            if (entity != null)
+            {
+                SelectedObject.HealthbarObject = entity;
+                SelectedObject.Object = entity;
+            }
+
+            base.OnMouseOver(x, y);
+        }
+        protected override void OnMouseExit(int x, int y)
+        {
+            var entity = World.Get(LocalSerial);
+
+            if (entity != null && SelectedObject.HealthbarObject == entity)
+            {
+                SelectedObject.HealthbarObject = null;
+                SelectedObject.Object = null;
+            }
+        }
+    }
+}

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -57,7 +57,7 @@ namespace ClassicUO.Game.UI.Gumps
             CanCloseWithRightClick = true;
             Entity = entity;
 
-            Hue hue = entity is Mobile m ? Notoriety.GetHue(m.NotorietyFlag) : (Hue) 0x0481;
+            Hue hue = entity is Mobile m ? Notoriety.GetHue(m.NotorietyFlag) : (Hue)0x0481;
 
             _renderedText = RenderedText.Create(String.Empty, hue, 0xFF, true, FontStyle.BlackBorder, TEXT_ALIGN_TYPE.TS_CENTER, 100, 30, true);
 
@@ -81,12 +81,12 @@ namespace ClassicUO.Game.UI.Gumps
                         t = StringHelper.CapitalizeAllWords(item.ItemData.Name);
 
                         if (string.IsNullOrEmpty(t))
-                            t = FileManager.Cliloc.Translate(1020000 + item.Graphic, capitalize:true);
+                            t = FileManager.Cliloc.Translate(1020000 + item.Graphic, capitalize: true);
                     }
 
                     if (string.IsNullOrEmpty(t))
                         return false;
-                    
+
                     FileManager.Fonts.SetUseHTML(true);
                     FileManager.Fonts.RecalculateWidthByInfo = true;
 
@@ -149,7 +149,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                     _renderedText.Text = t;
 
-                    Width = _background.Width = Math.Max(_renderedText.Width + 4, MIN_WIDTH);                    
+                    Width = _background.Width = Math.Max(_renderedText.Width + 4, MIN_WIDTH);
                     Height = _background.Height = _renderedText.Height + 4;
 
                     WantUpdateSize = false;
@@ -162,7 +162,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             return true;
         }
-        
+
 
         protected override void CloseWithRightClick()
         {
@@ -179,15 +179,30 @@ namespace ClassicUO.Game.UI.Gumps
 
                 GameActions.RequestMobileStatus(Entity);
 
-                Engine.UI.GetGump<HealthBarGump>(Entity)?.Dispose();
+                if (Engine.Profile.Current.CustomBarsToggled == true)
+                {
+                    Engine.UI.GetGump<HealthBarGumpCustom>(Entity)?.Dispose();
 
-                if (Entity == World.Player)
-                    StatusGumpBase.GetStatusGump()?.Dispose();
+                    if (Entity == World.Player)
+                        StatusGumpBase.GetStatusGump()?.Dispose();
 
-                Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
-                HealthBarGump currentHealthBarGump;
-                Engine.UI.Add(currentHealthBarGump = new HealthBarGump(Entity) {X = Mouse.Position.X - (rect.Width >> 1), Y = Mouse.Position.Y - (rect.Height >> 1)});
-                Engine.UI.AttemptDragControl(currentHealthBarGump, Mouse.Position, true);
+                    Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
+                    HealthBarGumpCustom currentHealthBarGump;
+                    Engine.UI.Add(currentHealthBarGump = new HealthBarGumpCustom(Entity) { X = Mouse.Position.X - (rect.Width >> 1), Y = Mouse.Position.Y - (rect.Height >> 1) });
+                    Engine.UI.AttemptDragControl(currentHealthBarGump, Mouse.Position, true);
+                }
+                else
+                {
+                    Engine.UI.GetGump<HealthBarGump>(Entity)?.Dispose();
+
+                    if (Entity == World.Player)
+                        StatusGumpBase.GetStatusGump()?.Dispose();
+
+                    Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
+                    HealthBarGump currentHealthBarGump;
+                    Engine.UI.Add(currentHealthBarGump = new HealthBarGump(Entity) { X = Mouse.Position.X - (rect.Width >> 1), Y = Mouse.Position.Y - (rect.Height >> 1) });
+                    Engine.UI.AttemptDragControl(currentHealthBarGump, Mouse.Position, true);
+                }
             }
             else
                 GameActions.PickUp(Entity);
@@ -301,8 +316,8 @@ namespace ClassicUO.Game.UI.Gumps
                                                               out int width,
                                                               out int height);
 
-                _lockedPosition.X = (int) ((Entity.RealScreenPosition.X + m.Offset.X + 22) / scale);
-                _lockedPosition.Y = (int) ((Entity.RealScreenPosition.Y + (m.Offset.Y - m.Offset.Z) - (height + centerY + 8) + (!m.IsMounted ? 22 : 0)) / scale);
+                _lockedPosition.X = (int)((Entity.RealScreenPosition.X + m.Offset.X + 22) / scale);
+                _lockedPosition.Y = (int)((Entity.RealScreenPosition.Y + (m.Offset.Y - m.Offset.Z) - (height + centerY + 8) + (!m.IsMounted ? 22 : 0)) / scale);
             }
 
             base.OnMouseOver(x, y);
@@ -331,7 +346,7 @@ namespace ClassicUO.Game.UI.Gumps
                     return;
                 }
 
-                _clickTiming -= (float) frameMS;
+                _clickTiming -= (float)frameMS;
 
                 if (_clickTiming <= 0)
                 {
@@ -378,8 +393,8 @@ namespace ClassicUO.Game.UI.Gumps
                                                                   out int width,
                                                                   out int height);
 
-                    x = (int) ((Entity.RealScreenPosition.X + m.Offset.X + 22) / scale);
-                    y = (int) ((Entity.RealScreenPosition.Y + (m.Offset.Y - m.Offset.Z) - (height + centerY + 8) + (!m.IsMounted ? 22 : 0)) / scale);
+                    x = (int)((Entity.RealScreenPosition.X + m.Offset.X + 22) / scale);
+                    y = (int)((Entity.RealScreenPosition.Y + (m.Offset.Y - m.Offset.Z) - (height + centerY + 8) + (!m.IsMounted ? 22 : 0)) / scale);
                 }
             }
             else if (Entity.Texture != null)
@@ -398,8 +413,8 @@ namespace ClassicUO.Game.UI.Gumps
             }
             else
             {
-                x = (int) ((Entity.RealScreenPosition.X + 22) / scale);
-                y = (int) ((Entity.RealScreenPosition.Y + 22) / scale);
+                x = (int)((Entity.RealScreenPosition.X + 22) / scale);
+                y = (int)((Entity.RealScreenPosition.Y + 22) / scale);
             }
 
             x -= Width >> 1;

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -1921,6 +1921,25 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.ShowTargetRangeIndicator = _showTargetRangeIndicator.IsChecked;
 
             Engine.Profile.Current.CustomBarsToggled = _CustomBars.IsChecked;
+            var hbgstandard = Engine.UI.Gumps.OfType<HealthBarGump>().ToList();
+            var hbgcustom = Engine.UI.Gumps.OfType<HealthBarGumpCustom>().ToList();
+            if (_CustomBars.IsChecked)
+            {               
+                foreach (var healthbar in hbgstandard)
+                {
+                    Engine.UI.Add(new HealthBarGumpCustom(healthbar.LocalSerial) { X = healthbar.X, Y = healthbar.Y });
+                    healthbar.Dispose();
+                }
+            }
+            else if (!_CustomBars.IsChecked)
+            {                 
+                foreach (var customhealthbar in hbgcustom)
+                {
+                    Engine.UI.Add(new HealthBarGump(customhealthbar.LocalSerial) { X = customhealthbar.X, Y = customhealthbar.Y });
+                    customhealthbar.Dispose();
+                }
+
+            }
             Engine.Profile.Current.CBBlackBGToggled = _CustomBarsBBG.IsChecked;
 
             // network

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -65,7 +65,7 @@ namespace ClassicUO.Game.UI.Gumps
         private TextBox _rows, _columns, _highlightAmount, _abbreviatedAmount;
 
         //experimental
-        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _CustomBars, _CustomBarsBBG;
         private Combobox _overrideContainerLocationSetting;
 
         // sounds
@@ -1215,6 +1215,9 @@ namespace ClassicUO.Game.UI.Gumps
 
             rightArea.Add(_showTargetRangeIndicator);
 
+            _CustomBars = CreateCheckBox(rightArea, "Use Custom Health Bars", Engine.Profile.Current.CustomBarsToggled, 0, 5);
+            _CustomBarsBBG = CreateCheckBox(rightArea, "Use All Black Backgrounds", Engine.Profile.Current.CBBlackBGToggled, 20, 5);
+
             Add(rightArea, PAGE);
 
             _autoOpenCorpseArea.IsVisible = _autoOpenCorpse.IsChecked;
@@ -1515,6 +1518,8 @@ namespace ClassicUO.Game.UI.Gumps
                     _overrideContainerLocationSetting.SelectedIndex = 0;
                     _dragSelectHumanoidsOnly.IsChecked = false;
                     _showTargetRangeIndicator.IsChecked = false;
+                    _CustomBars.IsChecked = false;
+                    _CustomBarsBBG.IsChecked = false;
 
                     break;
 
@@ -1914,6 +1919,9 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.OverrideContainerLocationSetting = _overrideContainerLocationSetting.SelectedIndex;
 
             Engine.Profile.Current.ShowTargetRangeIndicator = _showTargetRangeIndicator.IsChecked;
+
+            Engine.Profile.Current.CustomBarsToggled = _CustomBars.IsChecked;
+            Engine.Profile.Current.CBBlackBGToggled = _CustomBarsBBG.IsChecked;
 
             // network
             Engine.Profile.Current.ShowNetworkStats = _showNetStats.IsChecked;

--- a/src/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/Game/UI/Gumps/PaperdollGump.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -73,7 +73,7 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 Mobile = mobile;
                 Title = mobileTitle;
-                if(mobile == World.Player)
+                if (mobile == World.Player)
                 {
                     _Iconized = new GumpPic(0, 0, 0x7EE, 0);
                     _IconizerArea = new HitBox(228, 260, 16, 16);
@@ -118,7 +118,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (gs.IsHoldingItem)
             {
-                Item it = new Item(gs.HeldItem.Serial) {Graphic = gs.HeldItem.Graphic, Hue = gs.HeldItem.Hue};
+                Item it = new Item(gs.HeldItem.Serial) { Graphic = gs.HeldItem.Graphic, Hue = gs.HeldItem.Hue };
 
                 _paperDollInteractable.AddFakeDress(it);
             }
@@ -136,50 +136,64 @@ namespace ClassicUO.Game.UI.Gumps
                 Add(new GumpPic(0, 0, 0x07d0, 0));
 
                 //HELP BUTTON
-                Add(new Button((int) Buttons.Help, 0x07ef, 0x07f0, 0x07f1)
+                Add(new Button((int)Buttons.Help, 0x07ef, 0x07f0, 0x07f1)
                 {
-                    X = 185, Y = 44 + 27 * 0, ButtonAction = ButtonAction.Activate
+                    X = 185,
+                    Y = 44 + 27 * 0,
+                    ButtonAction = ButtonAction.Activate
                 });
 
                 //OPTIONS BUTTON
-                Add(new Button((int) Buttons.Options, 0x07d6, 0x07d7, 0x07d8)
+                Add(new Button((int)Buttons.Options, 0x07d6, 0x07d7, 0x07d8)
                 {
-                    X = 185, Y = 44 + 27 * 1, ButtonAction = ButtonAction.Activate
+                    X = 185,
+                    Y = 44 + 27 * 1,
+                    ButtonAction = ButtonAction.Activate
                 });
 
                 // LOG OUT BUTTON
-                Add(new Button((int) Buttons.LogOut, 0x07d9, 0x07da, 0x07db)
+                Add(new Button((int)Buttons.LogOut, 0x07d9, 0x07da, 0x07db)
                 {
-                    X = 185, Y = 44 + 27 * 2, ButtonAction = ButtonAction.Activate
+                    X = 185,
+                    Y = 44 + 27 * 2,
+                    ButtonAction = ButtonAction.Activate
                 });
 
                 // QUESTS BUTTON
-                Add(new Button((int) Buttons.Quests, 0x57b5, 0x57b7, 0x57b6)
+                Add(new Button((int)Buttons.Quests, 0x57b5, 0x57b7, 0x57b6)
                 {
-                    X = 185, Y = 44 + 27 * 3, ButtonAction = ButtonAction.Activate
+                    X = 185,
+                    Y = 44 + 27 * 3,
+                    ButtonAction = ButtonAction.Activate
                 });
 
                 // SKILLS BUTTON
-                Add(new Button((int) Buttons.Skills, 0x07df, 0x07e0, 0x07e1)
+                Add(new Button((int)Buttons.Skills, 0x07df, 0x07e0, 0x07e1)
                 {
-                    X = 185, Y = 44 + 27 * 4, ButtonAction = ButtonAction.Activate
+                    X = 185,
+                    Y = 44 + 27 * 4,
+                    ButtonAction = ButtonAction.Activate
                 });
 
                 // GUILD BUTTON
-                Add(new Button((int) Buttons.Guild, 0x57b2, 0x57b4, 0x57b3)
+                Add(new Button((int)Buttons.Guild, 0x57b2, 0x57b4, 0x57b3)
                 {
-                    X = 185, Y = 44 + 27 * 5, ButtonAction = ButtonAction.Activate
+                    X = 185,
+                    Y = 44 + 27 * 5,
+                    ButtonAction = ButtonAction.Activate
                 });
                 // TOGGLE PEACE/WAR BUTTON
                 _isWarMode = Mobile.InWarMode;
                 ushort[] btngumps = _isWarMode ? WarModeBtnGumps : PeaceModeBtnGumps;
 
-                Add(_warModeBtn = new Button((int) Buttons.PeaceWarToggle, btngumps[0], btngumps[1], btngumps[2])
+                Add(_warModeBtn = new Button((int)Buttons.PeaceWarToggle, btngumps[0], btngumps[1], btngumps[2])
                 {
-                    X = 185, Y = 44 + 27 * 6, ButtonAction = ButtonAction.Activate
+                    X = 185,
+                    Y = 44 + 27 * 6,
+                    ButtonAction = ButtonAction.Activate
                 });
 
-                
+
                 int profileX = 25;
                 const int SCROLLS_STEP = 14;
 
@@ -246,7 +260,8 @@ namespace ClassicUO.Game.UI.Gumps
             // Name and title
             Label titleLabel = new Label(Title, false, 0x0386, 185)
             {
-                X = 39, Y = 262
+                X = 39,
+                Y = 262
             };
             Add(titleLabel);
         }
@@ -368,7 +383,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override void OnButtonClick(int buttonID)
         {
-            switch ((Buttons) buttonID)
+            switch ((Buttons)buttonID)
             {
                 case Buttons.Help:
                     GameActions.RequestHelp();
@@ -427,7 +442,14 @@ namespace ClassicUO.Game.UI.Gumps
 
                     if (Mobile == World.Player)
                     {
-                        Engine.UI.GetGump<HealthBarGump>(Mobile)?.Dispose();
+                        if (Engine.Profile.Current.CustomBarsToggled == true)
+                        {
+                            Engine.UI.GetGump<HealthBarGumpCustom>(Mobile)?.Dispose();
+                        }
+                        else
+                        {
+                            Engine.UI.GetGump<HealthBarGump>(Mobile)?.Dispose();
+                        }
 
                         StatusGumpBase status = StatusGumpBase.GetStatusGump();
 
@@ -438,18 +460,36 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                     else
                     {
-                        if (Engine.UI.GetGump<HealthBarGump>(Mobile) != null)
-                            break;
-
-                        GameActions.RequestMobileStatus(Mobile);
-
-                        Rectangle bounds = FileManager.Gumps.GetTexture(0x0804).Bounds;
-
-                        Engine.UI.Add(new HealthBarGump(Mobile)
+                        if (Engine.Profile.Current.CustomBarsToggled == true)
                         {
-                            X = Mouse.Position.X - (bounds.Width >> 1),
-                            Y = Mouse.Position.Y - 5
-                        });
+                            if (Engine.UI.GetGump<HealthBarGumpCustom>(Mobile) != null)
+                                break;
+
+                            GameActions.RequestMobileStatus(Mobile);
+
+                            Rectangle bounds = FileManager.Gumps.GetTexture(0x0804).Bounds;
+
+                            Engine.UI.Add(new HealthBarGumpCustom(Mobile)
+                            {
+                                X = Mouse.Position.X - (bounds.Width >> 1),
+                                Y = Mouse.Position.Y - 5
+                            });
+                        }
+                        else
+                        {
+                            if (Engine.UI.GetGump<HealthBarGump>(Mobile) != null)
+                                break;
+
+                            GameActions.RequestMobileStatus(Mobile);
+
+                            Rectangle bounds = FileManager.Gumps.GetTexture(0x0804).Bounds;
+
+                            Engine.UI.Add(new HealthBarGump(Mobile)
+                            {
+                                X = Mouse.Position.X - (bounds.Width >> 1),
+                                Y = Mouse.Position.Y - 5
+                            });
+                        }
                     }
 
                     break;
@@ -531,7 +571,7 @@ namespace ClassicUO.Game.UI.Gumps
                             Height = 18,
                             HighlightOnMouseOver = false,
                             CanPickUp = World.InGame && (World.Player == _mobile || _paperDollGump.CanLift),
-                            
+
                         });
                     }
                 }
@@ -589,7 +629,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                     return batcher.Draw2D(Texture, x + _point.X, y + _point.Y,
                                           _originalSize.X, _originalSize.Y,
-                                          _rect.X, _rect.Y, 
+                                          _rect.X, _rect.Y,
                                           _rect.Width, _rect.Height,
                                           ref _hueVector);
                 }

--- a/src/Game/UI/Gumps/PartyGumpAdvanced.cs
+++ b/src/Game/UI/Gumps/PartyGumpAdvanced.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -76,66 +76,88 @@ namespace ClassicUO.Game.UI.Gumps
 
             Add(new Label("Bar", true, 1153)
             {
-                X = 30, Y = 25
+                X = 30,
+                Y = 25
             });
 
             Add(new Label("Kick", true, 1153)
             {
-                X = 60, Y = 25
+                X = 60,
+                Y = 25
             });
 
             Add(new Label("Player", true, 1153)
             {
-                X = 100, Y = 25
+                X = 100,
+                Y = 25
             });
 
             Add(new Label("Status", true, 1153)
             {
-                X = 250, Y = 25
+                X = 250,
+                Y = 25
             });
 
             //======================================================
-            Add(_messagePartyButton = new Button((int) Buttons.Message, 0xFAB, 0xFAC, 0xFAD)
+            Add(_messagePartyButton = new Button((int)Buttons.Message, 0xFAB, 0xFAC, 0xFAD)
             {
-                X = 30, Y = 275, ButtonAction = ButtonAction.Activate, IsVisible = false
+                X = 30,
+                Y = 275,
+                ButtonAction = ButtonAction.Activate,
+                IsVisible = false
             });
 
             Add(_messagePartyLabel = new Label("Message party", true, 1153)
             {
-                X = 70, Y = 275, IsVisible = false
+                X = 70,
+                Y = 275,
+                IsVisible = false
             });
 
             //======================================================
-            Add(_lootMeButton = new Button((int) Buttons.Loot, 0xFA2, 0xFA3, 0xFA4)
+            Add(_lootMeButton = new Button((int)Buttons.Loot, 0xFA2, 0xFA3, 0xFA4)
             {
-                X = 30, Y = 300, ButtonAction = ButtonAction.Activate, IsVisible = false
+                X = 30,
+                Y = 300,
+                ButtonAction = ButtonAction.Activate,
+                IsVisible = false
             });
 
             Add(_lootMeLabel = new Label("Party CANNOT loot me", true, 1153)
             {
-                X = 70, Y = 300, IsVisible = false
+                X = 70,
+                Y = 300,
+                IsVisible = false
             });
 
             //======================================================
-            Add(_leaveButton = new Button((int) Buttons.Leave, 0xFAE, 0xFAF, 0xFB0)
+            Add(_leaveButton = new Button((int)Buttons.Leave, 0xFAE, 0xFAF, 0xFB0)
             {
-                X = 30, Y = 325, ButtonAction = ButtonAction.Activate, IsVisible = false
+                X = 30,
+                Y = 325,
+                ButtonAction = ButtonAction.Activate,
+                IsVisible = false
             });
 
             Add(_leaveLabel = new Label("Leave party", true, 1153)
             {
-                X = 70, Y = 325, IsVisible = false
+                X = 70,
+                Y = 325,
+                IsVisible = false
             });
 
             //======================================================
-            Add(_createAddButton = new Button((int) Buttons.Add, 0xFA8, 0xFA9, 0xFAA)
+            Add(_createAddButton = new Button((int)Buttons.Add, 0xFA8, 0xFA9, 0xFAA)
             {
-                X = 30, Y = 350, ButtonAction = ButtonAction.Activate
+                X = 30,
+                Y = 350,
+                ButtonAction = ButtonAction.Activate
             });
 
             Add(_createAddLabel = new Label("Add party member", true, 1153)
             {
-                X = 70, Y = 350
+                X = 70,
+                Y = 350
             });
             //======================================================
 
@@ -254,7 +276,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override void OnButtonClick(int buttonID)
         {
-            switch ((Buttons) buttonID)
+            switch ((Buttons)buttonID)
             {
                 case Buttons.Add:
                     //World.Party.TriggerAddPartyMember();
@@ -344,19 +366,33 @@ namespace ClassicUO.Game.UI.Gumps
             Mobile mobile = World.Mobiles.Get(member.Serial);
 
             //======================================================
-            Add(_status = new GumpPic(240, 0, 0x29F6, (Hue) (mobile != null && mobile.IsDead ? 0 : 0x43)));
+            Add(_status = new GumpPic(240, 0, 0x29F6, (Hue)(mobile != null && mobile.IsDead ? 0 : 0x43)));
 
             //======================================================
-            Button pmButton = new Button((int) Buttons.GetBar, 0xFAE, 0xFAF, 0xFB0)
+            if (Engine.Profile.Current.CustomBarsToggled == true)
             {
-                X = 10, ButtonAction = ButtonAction.Activate
-            };
-            Add(pmButton);
+                Button cpmButton = new Button((int)Buttons.GetBar, 0xFAE, 0xFAF, 0xFB0)
+                {
+                    X = 10,
+                    ButtonAction = ButtonAction.Activate
+                };
+                Add(cpmButton);
+            }
+            else
+            {
+                Button pmButton = new Button((int)Buttons.GetBar, 0xFAE, 0xFAF, 0xFB0)
+                {
+                    X = 10,
+                    ButtonAction = ButtonAction.Activate
+                };
+                Add(pmButton);
+            }
 
             //======================================================
-            Button kickButton = new Button((int) Buttons.Kick, 0xFB1, 0xFB2, 0xFB3)
+            Button kickButton = new Button((int)Buttons.Kick, 0xFB1, 0xFB2, 0xFB3)
             {
-                X = 40, ButtonAction = ButtonAction.Activate
+                X = 40,
+                ButtonAction = ButtonAction.Activate
             };
             Add(kickButton);
         }
@@ -394,7 +430,7 @@ namespace ClassicUO.Game.UI.Gumps
             if (member == null)
                 return;
 
-            switch ((Buttons) buttonID)
+            switch ((Buttons)buttonID)
             {
                 case Buttons.Kick:
                     //
@@ -412,8 +448,20 @@ namespace ClassicUO.Game.UI.Gumps
                         StatusGumpBase.GetStatusGump()?.Dispose();
 
                     Rectangle rect = FileManager.Gumps.GetTexture(0x0804).Bounds;
-                    Engine.UI.Add(new HealthBarGump(member.Serial) {X = Mouse.Position.X - (rect.Width >> 1), Y = Mouse.Position.Y - (rect.Height >> 1)});
+                    Engine.UI.Add(new HealthBarGump(member.Serial) { X = Mouse.Position.X - (rect.Width >> 1), Y = Mouse.Position.Y - (rect.Height >> 1) });
 
+                    break;
+
+                case Buttons.GetCustomBar:
+
+
+                    Engine.UI.GetGump<HealthBarGumpCustom>(member.Serial)?.Dispose();
+
+                    if (member.Serial == World.Player)
+                        StatusGumpBase.GetStatusGump()?.Dispose();
+
+
+                    Engine.UI.Add(new HealthBarGumpCustom(member.Serial) { X = World.Player.X, Y = World.Player.Y });
                     break;
             }
         }
@@ -421,7 +469,8 @@ namespace ClassicUO.Game.UI.Gumps
         private enum Buttons
         {
             Kick = 1,
-            GetBar
+            GetBar,
+            GetCustomBar
         }
     }
 }

--- a/src/Game/UI/Gumps/StatusGump.cs
+++ b/src/Game/UI/Gumps/StatusGump.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
@@ -56,7 +56,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override void OnButtonClick(int buttonID)
         {
-            switch ((ButtonType) buttonID)
+            switch ((ButtonType)buttonID)
             {
                 case ButtonType.BuffIcon:
 
@@ -90,11 +90,19 @@ namespace ClassicUO.Game.UI.Gumps
 
                     if (Math.Abs(offset.X) < 5 && Math.Abs(offset.Y) < 5)
                     {
-                        Engine.UI.GetGump<HealthBarGump>(World.Player)?.Dispose();
-                        Engine.UI.Add(new HealthBarGump(World.Player) { X = ScreenCoordinateX, Y = ScreenCoordinateY });
+                        if (Engine.Profile.Current.CustomBarsToggled == true)
+                        {
+                            Engine.UI.GetGump<HealthBarGumpCustom>(World.Player)?.Dispose();
+                            Engine.UI.Add(new HealthBarGumpCustom(World.Player) { X = ScreenCoordinateX, Y = ScreenCoordinateY });
+                        }
+                        else
+                        {
+                            Engine.UI.GetGump<HealthBarGump>(World.Player)?.Dispose();
+                            Engine.UI.Add(new HealthBarGump(World.Player) { X = ScreenCoordinateX, Y = ScreenCoordinateY });
+                        }
                         Dispose();
                     }
-                   
+
                 }
             }
         }
@@ -153,21 +161,21 @@ namespace ClassicUO.Game.UI.Gumps
                 case 0: // modern
 
                     Engine.UI.Add(new StatusGumpModern
-                                      {X = x, Y = y});
+                    { X = x, Y = y });
 
                     break;
 
                 case 1: // old
 
                     Engine.UI.Add(new StatusGumpOld
-                                      {X = x, Y = y});
+                    { X = x, Y = y });
 
                     break;
 
                 case 2: // outlands
 
                     Engine.UI.Add(new StatusGumpOutlands
-                                      {X = x, Y = y});
+                    { X = x, Y = y });
 
                     break;
 
@@ -237,7 +245,7 @@ namespace ClassicUO.Game.UI.Gumps
         public StatusGumpOld()
         {
             Point p = Point.Zero;
-            _labels = new Label[(int) MobileStats.NumStats];
+            _labels = new Label[(int)MobileStats.NumStats];
 
             Add(new GumpPic(0, 0, 0x0802, 0));
             p.X = 244;
@@ -255,7 +263,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 86,
                 Y = 42
             };
-            _labels[(int) MobileStats.Name] = text;
+            _labels[(int)MobileStats.Name] = text;
             Add(text);
 
 
@@ -264,7 +272,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 86,
                 Y = 61
             };
-            _labels[(int) MobileStats.Strength] = text;
+            _labels[(int)MobileStats.Strength] = text;
             Add(text);
 
             text = new Label(World.Player.Dexterity.ToString(), false, 0x0386, font: 1)
@@ -272,7 +280,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 86,
                 Y = 73
             };
-            _labels[(int) MobileStats.Dexterity] = text;
+            _labels[(int)MobileStats.Dexterity] = text;
             Add(text);
 
             text = new Label(World.Player.Intelligence.ToString(), false, 0x0386, font: 1)
@@ -280,7 +288,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 86,
                 Y = 85
             };
-            _labels[(int) MobileStats.Intelligence] = text;
+            _labels[(int)MobileStats.Intelligence] = text;
             Add(text);
 
             text = new Label(!World.Player.IsMale ? "F" : "M", false, 0x0386, font: 1)
@@ -288,7 +296,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 86,
                 Y = 97
             };
-            _labels[(int) MobileStats.Sex] = text;
+            _labels[(int)MobileStats.Sex] = text;
             Add(text);
 
             text = new Label(World.Player.PhysicalResistence.ToString(), false, 0x0386, font: 1)
@@ -296,7 +304,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 86,
                 Y = 109
             };
-            _labels[(int) MobileStats.AR] = text;
+            _labels[(int)MobileStats.AR] = text;
             Add(text);
 
             text = new Label($"{World.Player.Hits}/{World.Player.HitsMax}", false, 0x0386, font: 1)
@@ -304,7 +312,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 171,
                 Y = 61
             };
-            _labels[(int) MobileStats.HealthCurrent] = text;
+            _labels[(int)MobileStats.HealthCurrent] = text;
             Add(text);
 
             text = new Label($"{World.Player.Mana}/{World.Player.ManaMax}", false, 0x0386, font: 1)
@@ -312,7 +320,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 171,
                 Y = 73
             };
-            _labels[(int) MobileStats.ManaCurrent] = text;
+            _labels[(int)MobileStats.ManaCurrent] = text;
             Add(text);
 
             text = new Label($"{World.Player.Stamina}/{World.Player.StaminaMax}", false, 0x0386, font: 1)
@@ -320,7 +328,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 171,
                 Y = 85
             };
-            _labels[(int) MobileStats.StaminaCurrent] = text;
+            _labels[(int)MobileStats.StaminaCurrent] = text;
             Add(text);
 
             text = new Label(World.Player.Gold.ToString(), false, 0x0386, font: 1)
@@ -328,7 +336,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 171,
                 Y = 97
             };
-            _labels[(int) MobileStats.Gold] = text;
+            _labels[(int)MobileStats.Gold] = text;
             Add(text);
 
             text = new Label(World.Player.Weight.ToString(), false, 0x0386, font: 1)
@@ -336,7 +344,7 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 171,
                 Y = 109
             };
-            _labels[(int) MobileStats.WeightCurrent] = text;
+            _labels[(int)MobileStats.WeightCurrent] = text;
             Add(text);
 
             _point = p;
@@ -349,19 +357,19 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (_refreshTime < totalMS)
             {
-                _refreshTime = (long) totalMS + 250;
+                _refreshTime = (long)totalMS + 250;
 
-                _labels[(int) MobileStats.Name].Text = !string.IsNullOrEmpty(World.Player.Name) ? World.Player.Name : string.Empty;
-                _labels[(int) MobileStats.Strength].Text = World.Player.Strength.ToString();
-                _labels[(int) MobileStats.Dexterity].Text = World.Player.Dexterity.ToString();
-                _labels[(int) MobileStats.Intelligence].Text = World.Player.Intelligence.ToString();
-                _labels[(int) MobileStats.Sex].Text = !World.Player.IsMale ? "F" : "M";
-                _labels[(int) MobileStats.AR].Text = World.Player.PhysicalResistence.ToString();
-                _labels[(int) MobileStats.HealthCurrent].Text = $"{World.Player.Hits}/{World.Player.HitsMax}";
-                _labels[(int) MobileStats.ManaCurrent].Text = $"{World.Player.Mana}/{World.Player.ManaMax}";
-                _labels[(int) MobileStats.StaminaCurrent].Text = $"{World.Player.Stamina}/{World.Player.StaminaMax}";
-                _labels[(int) MobileStats.Gold].Text = World.Player.Gold.ToString();
-                _labels[(int) MobileStats.WeightCurrent].Text = World.Player.Weight.ToString();
+                _labels[(int)MobileStats.Name].Text = !string.IsNullOrEmpty(World.Player.Name) ? World.Player.Name : string.Empty;
+                _labels[(int)MobileStats.Strength].Text = World.Player.Strength.ToString();
+                _labels[(int)MobileStats.Dexterity].Text = World.Player.Dexterity.ToString();
+                _labels[(int)MobileStats.Intelligence].Text = World.Player.Intelligence.ToString();
+                _labels[(int)MobileStats.Sex].Text = !World.Player.IsMale ? "F" : "M";
+                _labels[(int)MobileStats.AR].Text = World.Player.PhysicalResistence.ToString();
+                _labels[(int)MobileStats.HealthCurrent].Text = $"{World.Player.Hits}/{World.Player.HitsMax}";
+                _labels[(int)MobileStats.ManaCurrent].Text = $"{World.Player.Mana}/{World.Player.ManaMax}";
+                _labels[(int)MobileStats.StaminaCurrent].Text = $"{World.Player.Stamina}/{World.Player.StaminaMax}";
+                _labels[(int)MobileStats.Gold].Text = World.Player.Gold.ToString();
+                _labels[(int)MobileStats.WeightCurrent].Text = World.Player.Weight.ToString();
             }
 
             base.Update(totalMS, frameMS);
@@ -398,7 +406,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             Point p = Point.Zero;
             int xOffset = 0;
-            _labels = new Label[(int) MobileStats.NumStats];
+            _labels = new Label[(int)MobileStats.NumStats];
 
             Add(new GumpPic(0, 0, 0x2A6C, 0));
 
@@ -413,7 +421,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (FileManager.ClientVersion >= ClientVersions.CV_5020)
                 {
-                    Add(new Button((int) ButtonType.BuffIcon, 0x7538, 0x7539, 0x7539)
+                    Add(new Button((int)ButtonType.BuffIcon, 0x7538, 0x7539, 0x7539)
                     {
                         X = 40,
                         Y = 50,
@@ -433,7 +441,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 _lockers[0].MouseUp += (sender, e) =>
                 {
-                    World.Player.StrLock = (Lock) (((byte) World.Player.StrLock + 1) % 3);
+                    World.Player.StrLock = (Lock)(((byte)World.Player.StrLock + 1) % 3);
                     GameActions.ChangeStatLock(0, World.Player.StrLock);
                     Lock st = World.Player.StrLock;
                     ushort gumpid = 0x0984; //Up
@@ -464,7 +472,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 _lockers[1].MouseUp += (sender, e) =>
                 {
-                    World.Player.DexLock = (Lock) (((byte) World.Player.DexLock + 1) % 3);
+                    World.Player.DexLock = (Lock)(((byte)World.Player.DexLock + 1) % 3);
                     GameActions.ChangeStatLock(1, World.Player.DexLock);
                     Lock st = World.Player.DexLock;
                     ushort gumpid = 0x0984; //Up
@@ -494,7 +502,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 _lockers[2].MouseUp += (sender, e) =>
                 {
-                    World.Player.IntLock = (Lock) (((byte) World.Player.IntLock + 1) % 3);
+                    World.Player.IntLock = (Lock)(((byte)World.Player.IntLock + 1) % 3);
                     GameActions.ChangeStatLock(2, World.Player.IntLock);
                     Lock st = World.Player.IntLock;
                     ushort gumpid = 0x0984; //Up
@@ -661,7 +669,7 @@ namespace ClassicUO.Game.UI.Gumps
                 Y = y
             };
 
-            _labels[(int) stat] = label;
+            _labels[(int)stat] = label;
             Add(label);
         }
 
@@ -672,61 +680,61 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (_refreshTime < totalMS)
             {
-                _refreshTime = (long) totalMS + 250;
+                _refreshTime = (long)totalMS + 250;
 
-                _labels[(int) MobileStats.Name].Text = !string.IsNullOrEmpty(World.Player.Name) ? World.Player.Name : string.Empty;
-
-                if (_useUOPGumps)
-                    _labels[(int) MobileStats.HitChanceInc].Text = World.Player.HitChanceIncrease.ToString();
-                _labels[(int) MobileStats.Strength].Text = World.Player.Strength.ToString();
-                _labels[(int) MobileStats.Dexterity].Text = World.Player.Dexterity.ToString();
-                _labels[(int) MobileStats.Intelligence].Text = World.Player.Intelligence.ToString();
+                _labels[(int)MobileStats.Name].Text = !string.IsNullOrEmpty(World.Player.Name) ? World.Player.Name : string.Empty;
 
                 if (_useUOPGumps)
-                    _labels[(int) MobileStats.DefenseChanceInc].Text = $"{World.Player.DefenseChanceIncrease}/{World.Player.MaxDefenseChanceIncrease}";
-                _labels[(int) MobileStats.HealthCurrent].Text = World.Player.Hits.ToString();
-                _labels[(int) MobileStats.HealthMax].Text = World.Player.HitsMax.ToString();
-                _labels[(int) MobileStats.StaminaCurrent].Text = World.Player.Stamina.ToString();
-                _labels[(int) MobileStats.StaminaMax].Text = World.Player.StaminaMax.ToString();
-                _labels[(int) MobileStats.ManaCurrent].Text = World.Player.Mana.ToString();
-                _labels[(int) MobileStats.ManaMax].Text = World.Player.ManaMax.ToString();
+                    _labels[(int)MobileStats.HitChanceInc].Text = World.Player.HitChanceIncrease.ToString();
+                _labels[(int)MobileStats.Strength].Text = World.Player.Strength.ToString();
+                _labels[(int)MobileStats.Dexterity].Text = World.Player.Dexterity.ToString();
+                _labels[(int)MobileStats.Intelligence].Text = World.Player.Intelligence.ToString();
 
                 if (_useUOPGumps)
-                    _labels[(int) MobileStats.LowerManaCost].Text = World.Player.LowerManaCost.ToString();
-                _labels[(int) MobileStats.StatCap].Text = World.Player.StatsCap.ToString();
-                _labels[(int) MobileStats.Luck].Text = World.Player.Luck.ToString();
-                _labels[(int) MobileStats.WeightCurrent].Text = World.Player.Weight.ToString();
-                _labels[(int) MobileStats.WeightMax].Text = World.Player.WeightMax.ToString();
+                    _labels[(int)MobileStats.DefenseChanceInc].Text = $"{World.Player.DefenseChanceIncrease}/{World.Player.MaxDefenseChanceIncrease}";
+                _labels[(int)MobileStats.HealthCurrent].Text = World.Player.Hits.ToString();
+                _labels[(int)MobileStats.HealthMax].Text = World.Player.HitsMax.ToString();
+                _labels[(int)MobileStats.StaminaCurrent].Text = World.Player.Stamina.ToString();
+                _labels[(int)MobileStats.StaminaMax].Text = World.Player.StaminaMax.ToString();
+                _labels[(int)MobileStats.ManaCurrent].Text = World.Player.Mana.ToString();
+                _labels[(int)MobileStats.ManaMax].Text = World.Player.ManaMax.ToString();
+
+                if (_useUOPGumps)
+                    _labels[(int)MobileStats.LowerManaCost].Text = World.Player.LowerManaCost.ToString();
+                _labels[(int)MobileStats.StatCap].Text = World.Player.StatsCap.ToString();
+                _labels[(int)MobileStats.Luck].Text = World.Player.Luck.ToString();
+                _labels[(int)MobileStats.WeightCurrent].Text = World.Player.Weight.ToString();
+                _labels[(int)MobileStats.WeightMax].Text = World.Player.WeightMax.ToString();
 
                 if (_useUOPGumps)
                 {
-                    _labels[(int) MobileStats.DamageChanceInc].Text = World.Player.DamageIncrease.ToString();
-                    _labels[(int) MobileStats.SwingSpeedInc].Text = World.Player.SwingSpeedIncrease.ToString();
+                    _labels[(int)MobileStats.DamageChanceInc].Text = World.Player.DamageIncrease.ToString();
+                    _labels[(int)MobileStats.SwingSpeedInc].Text = World.Player.SwingSpeedIncrease.ToString();
                 }
 
-                _labels[(int) MobileStats.Gold].Text = World.Player.Gold.ToString();
-                _labels[(int) MobileStats.Damage].Text = $"{World.Player.DamageMin}-{World.Player.DamageMax}";
-                _labels[(int) MobileStats.Followers].Text = $"{World.Player.Followers}/{World.Player.FollowersMax}";
+                _labels[(int)MobileStats.Gold].Text = World.Player.Gold.ToString();
+                _labels[(int)MobileStats.Damage].Text = $"{World.Player.DamageMin}-{World.Player.DamageMax}";
+                _labels[(int)MobileStats.Followers].Text = $"{World.Player.Followers}/{World.Player.FollowersMax}";
 
                 if (_useUOPGumps)
                 {
-                    _labels[(int) MobileStats.LowerReagentCost].Text = World.Player.LowerReagentCost.ToString();
-                    _labels[(int) MobileStats.SpellDamageInc].Text = World.Player.SpellDamageIncrease.ToString();
-                    _labels[(int) MobileStats.FasterCasting].Text = World.Player.FasterCasting.ToString();
-                    _labels[(int) MobileStats.FasterCastRecovery].Text = World.Player.FasterCastRecovery.ToString();
-                    _labels[(int) MobileStats.AR].Text = $"{World.Player.PhysicalResistence}/{World.Player.MaxPhysicResistence}";
-                    _labels[(int) MobileStats.RF].Text = $"{World.Player.FireResistance}/{World.Player.MaxFireResistence}";
-                    _labels[(int) MobileStats.RC].Text = $"{World.Player.ColdResistance}/{World.Player.MaxColdResistence}";
-                    _labels[(int) MobileStats.RP].Text = $"{World.Player.PoisonResistance}/{World.Player.MaxPoisonResistence}";
-                    _labels[(int) MobileStats.RE].Text = $"{World.Player.EnergyResistance}/{World.Player.MaxEnergyResistence}";
+                    _labels[(int)MobileStats.LowerReagentCost].Text = World.Player.LowerReagentCost.ToString();
+                    _labels[(int)MobileStats.SpellDamageInc].Text = World.Player.SpellDamageIncrease.ToString();
+                    _labels[(int)MobileStats.FasterCasting].Text = World.Player.FasterCasting.ToString();
+                    _labels[(int)MobileStats.FasterCastRecovery].Text = World.Player.FasterCastRecovery.ToString();
+                    _labels[(int)MobileStats.AR].Text = $"{World.Player.PhysicalResistence}/{World.Player.MaxPhysicResistence}";
+                    _labels[(int)MobileStats.RF].Text = $"{World.Player.FireResistance}/{World.Player.MaxFireResistence}";
+                    _labels[(int)MobileStats.RC].Text = $"{World.Player.ColdResistance}/{World.Player.MaxColdResistence}";
+                    _labels[(int)MobileStats.RP].Text = $"{World.Player.PoisonResistance}/{World.Player.MaxPoisonResistence}";
+                    _labels[(int)MobileStats.RE].Text = $"{World.Player.EnergyResistance}/{World.Player.MaxEnergyResistence}";
                 }
                 else
                 {
-                    _labels[(int) MobileStats.AR].Text = World.Player.PhysicalResistence.ToString();
-                    _labels[(int) MobileStats.RF].Text = World.Player.FireResistance.ToString();
-                    _labels[(int) MobileStats.RC].Text = World.Player.ColdResistance.ToString();
-                    _labels[(int) MobileStats.RP].Text = World.Player.PoisonResistance.ToString();
-                    _labels[(int) MobileStats.RE].Text = World.Player.EnergyResistance.ToString();
+                    _labels[(int)MobileStats.AR].Text = World.Player.PhysicalResistence.ToString();
+                    _labels[(int)MobileStats.RF].Text = World.Player.FireResistance.ToString();
+                    _labels[(int)MobileStats.RC].Text = World.Player.ColdResistance.ToString();
+                    _labels[(int)MobileStats.RP].Text = World.Player.PoisonResistance.ToString();
+                    _labels[(int)MobileStats.RE].Text = World.Player.EnergyResistance.ToString();
                 }
             }
 
@@ -786,7 +794,7 @@ namespace ClassicUO.Game.UI.Gumps
         public StatusGumpOutlands()
         {
             Point pos = Point.Zero;
-            _labels = new Label[(int) MobileStats.Max];
+            _labels = new Label[(int)MobileStats.Max];
 
             Add(new GumpPic(0, 0, 0x2A6C, 0));
             Add(new GumpPic(34, 12, 0x0805, 0)); // Health bar
@@ -795,7 +803,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (FileManager.ClientVersion >= ClientVersions.CV_5020)
             {
-                Add(new Button((int) ButtonType.BuffIcon, 0x837, 0x838, 0x838)
+                Add(new Button((int)ButtonType.BuffIcon, 0x837, 0x838, 0x838)
                 {
                     X = 159,
                     Y = 40,
@@ -810,13 +818,13 @@ namespace ClassicUO.Game.UI.Gumps
                 gumpIdHp = 0x0808;
             else if (World.Player.IsYellowHits) gumpIdHp = 0x0809;
 
-            _fillBars[(int) FillStats.Hits] = new GumpPicWithWidth(34, 12, gumpIdHp, 0, 0);
-            _fillBars[(int) FillStats.Mana] = new GumpPicWithWidth(34, 25, 0x0806, 0, 0);
-            _fillBars[(int) FillStats.Stam] = new GumpPicWithWidth(34, 38, 0x0806, 0, 0);
+            _fillBars[(int)FillStats.Hits] = new GumpPicWithWidth(34, 12, gumpIdHp, 0, 0);
+            _fillBars[(int)FillStats.Mana] = new GumpPicWithWidth(34, 25, 0x0806, 0, 0);
+            _fillBars[(int)FillStats.Stam] = new GumpPicWithWidth(34, 38, 0x0806, 0, 0);
 
-            Add(_fillBars[(int) FillStats.Hits]);
-            Add(_fillBars[(int) FillStats.Mana]);
-            Add(_fillBars[(int) FillStats.Stam]);
+            Add(_fillBars[(int)FillStats.Hits]);
+            Add(_fillBars[(int)FillStats.Mana]);
+            Add(_fillBars[(int)FillStats.Stam]);
 
             UpdateStatusFillBar(FillStats.Hits, World.Player.Hits, World.Player.HitsMax);
             UpdateStatusFillBar(FillStats.Mana, World.Player.Mana, World.Player.ManaMax);
@@ -829,42 +837,42 @@ namespace ClassicUO.Game.UI.Gumps
                 Y = 12
             };
 
-            _labels[(int) MobileStats.Name] = text;
+            _labels[(int)MobileStats.Name] = text;
             Add(text);
 
 
             // Stat locks
-            Add(_lockers[(int) StatType.Str] = new GumpPic(
+            Add(_lockers[(int)StatType.Str] = new GumpPic(
                                                            10, 73, GetStatLockGraphic(World.Player.StrLock), 0));
 
-            Add(_lockers[(int) StatType.Dex] = new GumpPic(
+            Add(_lockers[(int)StatType.Dex] = new GumpPic(
                                                            10, 102, GetStatLockGraphic(World.Player.DexLock), 0));
 
-            Add(_lockers[(int) StatType.Int] = new GumpPic(
+            Add(_lockers[(int)StatType.Int] = new GumpPic(
                                                            10, 130, GetStatLockGraphic(World.Player.IntLock), 0));
 
-            _lockers[(int) StatType.Str].MouseUp += (sender, e) =>
+            _lockers[(int)StatType.Str].MouseUp += (sender, e) =>
             {
-                World.Player.StrLock = (Lock) (((byte) World.Player.StrLock + 1) % 3);
-                GameActions.ChangeStatLock((byte) StatType.Str, World.Player.StrLock);
-                _lockers[(int) StatType.Str].Graphic = GetStatLockGraphic(World.Player.StrLock);
-                _lockers[(int) StatType.Str].Texture = FileManager.Gumps.GetTexture(GetStatLockGraphic(World.Player.StrLock));
+                World.Player.StrLock = (Lock)(((byte)World.Player.StrLock + 1) % 3);
+                GameActions.ChangeStatLock((byte)StatType.Str, World.Player.StrLock);
+                _lockers[(int)StatType.Str].Graphic = GetStatLockGraphic(World.Player.StrLock);
+                _lockers[(int)StatType.Str].Texture = FileManager.Gumps.GetTexture(GetStatLockGraphic(World.Player.StrLock));
             };
 
-            _lockers[(int) StatType.Dex].MouseUp += (sender, e) =>
+            _lockers[(int)StatType.Dex].MouseUp += (sender, e) =>
             {
-                World.Player.DexLock = (Lock) (((byte) World.Player.DexLock + 1) % 3);
-                GameActions.ChangeStatLock((byte) StatType.Dex, World.Player.DexLock);
-                _lockers[(int) StatType.Dex].Graphic = GetStatLockGraphic(World.Player.DexLock);
-                _lockers[(int) StatType.Dex].Texture = FileManager.Gumps.GetTexture(GetStatLockGraphic(World.Player.DexLock));
+                World.Player.DexLock = (Lock)(((byte)World.Player.DexLock + 1) % 3);
+                GameActions.ChangeStatLock((byte)StatType.Dex, World.Player.DexLock);
+                _lockers[(int)StatType.Dex].Graphic = GetStatLockGraphic(World.Player.DexLock);
+                _lockers[(int)StatType.Dex].Texture = FileManager.Gumps.GetTexture(GetStatLockGraphic(World.Player.DexLock));
             };
 
-            _lockers[(int) StatType.Int].MouseUp += (sender, e) =>
+            _lockers[(int)StatType.Int].MouseUp += (sender, e) =>
             {
-                World.Player.IntLock = (Lock) (((byte) World.Player.IntLock + 1) % 3);
-                GameActions.ChangeStatLock((byte) StatType.Int, World.Player.IntLock);
-                _lockers[(int) StatType.Int].Graphic = GetStatLockGraphic(World.Player.IntLock);
-                _lockers[(int) StatType.Int].Texture = FileManager.Gumps.GetTexture(GetStatLockGraphic(World.Player.IntLock));
+                World.Player.IntLock = (Lock)(((byte)World.Player.IntLock + 1) % 3);
+                GameActions.ChangeStatLock((byte)StatType.Int, World.Player.IntLock);
+                _lockers[(int)StatType.Int].Graphic = GetStatLockGraphic(World.Player.IntLock);
+                _lockers[(int)StatType.Int].Texture = FileManager.Gumps.GetTexture(GetStatLockGraphic(World.Player.IntLock));
             };
 
             // Str/dex/int text labels
@@ -1003,34 +1011,34 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (_refreshTime < totalMS)
             {
-                _refreshTime = (long) totalMS + 250;
+                _refreshTime = (long)totalMS + 250;
 
                 UpdateStatusFillBar(FillStats.Hits, World.Player.Hits, World.Player.HitsMax);
                 UpdateStatusFillBar(FillStats.Mana, World.Player.Mana, World.Player.ManaMax);
                 UpdateStatusFillBar(FillStats.Stam, World.Player.Stamina, World.Player.StaminaMax);
 
-                _labels[(int) MobileStats.Name].Text = !string.IsNullOrEmpty(World.Player.Name) ? World.Player.Name : string.Empty;
-                _labels[(int) MobileStats.Strength].Text = World.Player.Strength.ToString();
-                _labels[(int) MobileStats.Dexterity].Text = World.Player.Dexterity.ToString();
-                _labels[(int) MobileStats.Intelligence].Text = World.Player.Intelligence.ToString();
-                _labels[(int) MobileStats.HealthCurrent].Text = World.Player.Hits.ToString();
-                _labels[(int) MobileStats.HealthMax].Text = World.Player.HitsMax.ToString();
-                _labels[(int) MobileStats.StaminaCurrent].Text = World.Player.Stamina.ToString();
-                _labels[(int) MobileStats.StaminaMax].Text = World.Player.StaminaMax.ToString();
-                _labels[(int) MobileStats.ManaCurrent].Text = World.Player.Mana.ToString();
-                _labels[(int) MobileStats.ManaMax].Text = World.Player.ManaMax.ToString();
-                _labels[(int) MobileStats.Followers].Text = $"{World.Player.Followers}/{World.Player.FollowersMax}";
-                _labels[(int) MobileStats.AR].Text = World.Player.PhysicalResistence.ToString();
-                _labels[(int) MobileStats.WeightCurrent].Text = World.Player.Weight.ToString();
-                _labels[(int) MobileStats.WeightMax].Text = World.Player.WeightMax.ToString();
-                _labels[(int) MobileStats.Damage].Text = $"{World.Player.DamageMin}-{World.Player.DamageMax}";
-                _labels[(int) MobileStats.Gold].Text = World.Player.Gold.ToString();
-                _labels[(int) MobileStats.HungerSatisfactionMinutes].Text = World.Player.Luck.ToString(); // FIXME: packet handling
-                _labels[(int) MobileStats.MurderCount].Text = World.Player.StatsCap.ToString(); // FIXME: packet handling
-                _labels[(int) MobileStats.MurderCountDecayHours].Text = World.Player.FireResistance.ToString(); // FIXME: packet handling
-                _labels[(int) MobileStats.CriminalTimerSeconds].Text = World.Player.ColdResistance.ToString(); // FIXME: packet handling
-                _labels[(int) MobileStats.PvpCooldownSeconds].Text = World.Player.PoisonResistance.ToString(); // FIXME: packet handling
-                _labels[(int) MobileStats.BandageTimerSeconds].Text = World.Player.EnergyResistance.ToString(); // FIXME: packet handling
+                _labels[(int)MobileStats.Name].Text = !string.IsNullOrEmpty(World.Player.Name) ? World.Player.Name : string.Empty;
+                _labels[(int)MobileStats.Strength].Text = World.Player.Strength.ToString();
+                _labels[(int)MobileStats.Dexterity].Text = World.Player.Dexterity.ToString();
+                _labels[(int)MobileStats.Intelligence].Text = World.Player.Intelligence.ToString();
+                _labels[(int)MobileStats.HealthCurrent].Text = World.Player.Hits.ToString();
+                _labels[(int)MobileStats.HealthMax].Text = World.Player.HitsMax.ToString();
+                _labels[(int)MobileStats.StaminaCurrent].Text = World.Player.Stamina.ToString();
+                _labels[(int)MobileStats.StaminaMax].Text = World.Player.StaminaMax.ToString();
+                _labels[(int)MobileStats.ManaCurrent].Text = World.Player.Mana.ToString();
+                _labels[(int)MobileStats.ManaMax].Text = World.Player.ManaMax.ToString();
+                _labels[(int)MobileStats.Followers].Text = $"{World.Player.Followers}/{World.Player.FollowersMax}";
+                _labels[(int)MobileStats.AR].Text = World.Player.PhysicalResistence.ToString();
+                _labels[(int)MobileStats.WeightCurrent].Text = World.Player.Weight.ToString();
+                _labels[(int)MobileStats.WeightMax].Text = World.Player.WeightMax.ToString();
+                _labels[(int)MobileStats.Damage].Text = $"{World.Player.DamageMin}-{World.Player.DamageMax}";
+                _labels[(int)MobileStats.Gold].Text = World.Player.Gold.ToString();
+                _labels[(int)MobileStats.HungerSatisfactionMinutes].Text = World.Player.Luck.ToString(); // FIXME: packet handling
+                _labels[(int)MobileStats.MurderCount].Text = World.Player.StatsCap.ToString(); // FIXME: packet handling
+                _labels[(int)MobileStats.MurderCountDecayHours].Text = World.Player.FireResistance.ToString(); // FIXME: packet handling
+                _labels[(int)MobileStats.CriminalTimerSeconds].Text = World.Player.ColdResistance.ToString(); // FIXME: packet handling
+                _labels[(int)MobileStats.PvpCooldownSeconds].Text = World.Player.PoisonResistance.ToString(); // FIXME: packet handling
+                _labels[(int)MobileStats.BandageTimerSeconds].Text = World.Player.EnergyResistance.ToString(); // FIXME: packet handling
             }
 
             base.Update(totalMS, frameMS);
@@ -1052,8 +1060,17 @@ namespace ClassicUO.Game.UI.Gumps
 
                     if (rect.Contains(p))
                     {
-                        Engine.UI.GetGump<HealthBarGump>(World.Player)?.Dispose();
-                        Engine.UI.Add(new HealthBarGump(World.Player) { X = ScreenCoordinateX, Y = ScreenCoordinateY });
+                        //TCH whole if else
+                        if (Engine.Profile.Current.CustomBarsToggled == true)
+                        {
+                            Engine.UI.GetGump<HealthBarGumpCustom>(World.Player)?.Dispose();
+                            Engine.UI.Add(new HealthBarGumpCustom(World.Player) { X = ScreenCoordinateX, Y = ScreenCoordinateY });
+                        }
+                        else
+                        {
+                            Engine.UI.GetGump<HealthBarGump>(World.Player)?.Dispose();
+                            Engine.UI.Add(new HealthBarGump(World.Player) { X = ScreenCoordinateX, Y = ScreenCoordinateY });
+                        }
                         Dispose();
                     }
                 }
@@ -1098,8 +1115,8 @@ namespace ClassicUO.Game.UI.Gumps
                 //    percent = (109 * percent) / 100;
                 //}
 
-                _fillBars[(int) id].Percent = CalculatePercents(max, current, 109);
-                _fillBars[(int) id].Texture = FileManager.Gumps.GetTexture(gumpId);
+                _fillBars[(int)id].Percent = CalculatePercents(max, current, 109);
+                _fillBars[(int)id].Texture = FileManager.Gumps.GetTexture(gumpId);
             }
         }
 
@@ -1112,7 +1129,7 @@ namespace ClassicUO.Game.UI.Gumps
                 Y = y
             };
 
-            _labels[(int) stat] = label;
+            _labels[(int)stat] = label;
             Add(label);
         }
 


### PR DESCRIPTION
![CHBG PR Video](https://user-images.githubusercontent.com/53979689/67166359-6d6e5980-f35c-11e9-8868-73fe767c4835.gif)

Custom Health Bar Gump
- Create Custom Health Bar Gump without modded art files.
- Option added to use Notoriety colored background or All black background.
- Only found one issue present (with renaming, you can but it's ugly left example options to seek public input on how to fix).
- This should have all the fixes from before (paperdoll status to custom, name over head to custom, drag select for custom, macro manager(closeallhealthbars) to include custom, party add to manage custom.
- Options are in Experimental, can be moved later if wished.