### PR TITLE
Do not append characters after '\0' which terminates the string.

### DIFF
--- a/src/Network/Packet.cs
+++ b/src/Network/Packet.cs
@@ -136,16 +136,6 @@ namespace ClassicUO.Network
             }
 
             return _sb.ToString();
-
-            //int start = Position;
-            //int end = 0;
-            //while (Position < Length)
-            //{
-            //    if (_data[Position++] == 0)
-            //        break;
-            //    end++;
-            //}
-            //return end == 0 ? Empty : Encoding.ASCII.GetString(_data, start, end);
         }
 
         public string ReadASCII(int length, bool exitIfNull = false)
@@ -167,24 +157,12 @@ namespace ClassicUO.Network
             for (int i = 0; i < length; i++)
             {
                 char c = (char) ReadByte();
-                if (c != '\0')
-                    _sb.Append(c);
+                if (c == '\0')
+                    break;
+                _sb.Append(c);
             }
 
             return _sb.ToString();
-
-            //int index = str.IndexOf('\0');
-
-
-            //int start = Position;
-            //Position += length;
-
-            //if (length <= 0)
-            //    return string.Empty;
-
-            //var str = Encoding.ASCII.GetString(_data, start, length);
-            //var nulIndex = str.IndexOf('\0');
-            //return nulIndex <= 0 ? str : str.Substring(0, nulIndex);
         }
 
         public string ReadUTF8StringSafe()


### PR DESCRIPTION
Older Sphere versions don't initialize strings, so it leaks random memory content.