### PR TITLE
Added option Show Buff duration

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -165,6 +165,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool DebugGumpIsMinimized { get; set; } = true;
         [JsonProperty] public bool RestoreLastGameSize { get; set; }
         [JsonProperty] public bool CastSpellsByOneClick { get; set; }
+        [JsonProperty] public bool BuffBarTime { get; set; }
         [JsonProperty] public bool AutoOpenDoors { get; set; }
         [JsonProperty] public bool SmoothDoors { get; set; }
         [JsonProperty] public bool AutoOpenCorpses { get; set; }

--- a/src/Game/UI/Gumps/BuffGump.cs
+++ b/src/Game/UI/Gumps/BuffGump.cs
@@ -28,7 +28,7 @@ using System.Linq;
 
 using ClassicUO.Game.Data;
 using ClassicUO.Game.UI.Controls;
-using ClassicUO.IO;
+using ClassicUO.IO.Resources;
 using ClassicUO.Renderer;
 
 using Microsoft.Xna.Framework;
@@ -327,11 +327,13 @@ namespace ClassicUO.Game.UI.Gumps
                 _alpha = 0xFF;
                 _decreaseAlpha = true;
                 _timer = (uint) (icon.Timer <= 0 ? 0xFFFF_FFFF : Engine.Ticks + icon.Timer * 1000);
+                _gText = RenderedText.Create("", 0xFFFF, 2, true, FontStyle.Fixed | FontStyle.BlackBorder, TEXT_ALIGN_TYPE.TS_CENTER, Texture.Width);
 
                 SetTooltip(icon.Text);
             }
 
             public BuffIcon Icon { get; }
+            private readonly RenderedText _gText;
 
             protected override void OnInitialize()
             {
@@ -354,6 +356,11 @@ namespace ClassicUO.Game.UI.Gumps
                     TimeSpan span = TimeSpan.FromMilliseconds(delta);
                     SetTooltip($"{Icon.Text}\nTime left: {span.Hours:00}:{span.Minutes:00}:{span.Seconds:00}");
                     _updateTooltipTime = (float) totalMS + 1000;
+
+                    if (span.Hours > 0)
+                        _gText.Text = $"+{span.Hours}hr";
+                    else
+                        _gText.Text = span.Minutes > 0 ? $"{span.Minutes}:{span.Seconds}" : $"{span.Seconds}";
                 }
 
                 if (_timer != 0xFFFF_FFFF && delta < 10000)
@@ -396,7 +403,13 @@ namespace ClassicUO.Game.UI.Gumps
                 ResetHueVector();
                 ShaderHuesTraslator.GetHueVector(ref _hueVector, 0, false, 1.0f - _alpha / 255f, true);
 
-                return batcher.Draw2D(Texture, x, y, ref _hueVector);
+                if (Engine.Profile.Current != null && Engine.Profile.Current.BuffBarTime)
+                {
+                    batcher.Draw2D(Texture, x, y, ref _hueVector);
+                    return _gText.Draw(batcher, x - 3, y + Texture.Height / 2 - 3, _hueVector.Z);
+                }
+                else
+                    return batcher.Draw2D(Texture, x, y, ref _hueVector);
             }
         }
     }

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -50,7 +50,7 @@ namespace ClassicUO.Game.UI.Gumps
         private ScrollAreaItem _activeChatArea;
         private Combobox _autoOpenCorpseOptions;
         private TextBox _autoOpenCorpseRange;
-        private Checkbox _castSpellsByOneClick, _queryBeforAttackCheckbox, _spellColoringCheckbox, _spellFormatCheckbox;
+        private Checkbox _buffBarTime,_castSpellsByOneClick, _queryBeforAttackCheckbox, _spellColoringCheckbox, _spellFormatCheckbox;
         private HSliderBar _cellSize;
 
         // video
@@ -949,6 +949,7 @@ namespace ClassicUO.Game.UI.Gumps
             _spellFormatCheckbox = CreateCheckBox(rightArea, "Enable Overhead Spell Format", Engine.Profile.Current.EnabledSpellFormat, 0, 0);
             _spellColoringCheckbox = CreateCheckBox(rightArea, "Enable Overhead Spell Hue", Engine.Profile.Current.EnabledSpellHue, 0, 0);
             _castSpellsByOneClick = CreateCheckBox(rightArea, "Cast spells by one click", Engine.Profile.Current.CastSpellsByOneClick, 0, 0);
+            _buffBarTime = CreateCheckBox(rightArea, "Show buff duration", Engine.Profile.Current.BuffBarTime, 0, 0);
 
             _innocentColorPickerBox = CreateClickableColorBox(rightArea, 0, 20, Engine.Profile.Current.InnocentHue, "Innocent Color", 20, 20);
             _friendColorPickerBox = CreateClickableColorBox(rightArea, 0, 0, Engine.Profile.Current.FriendHue, "Friend Color", 20, 0);
@@ -1483,6 +1484,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _enemyColorPickerBox.SetColor(0x0031, FileManager.Hues.GetPolygoneColor(12, 0x0031));
                     _queryBeforAttackCheckbox.IsChecked = true;
                     _castSpellsByOneClick.IsChecked = false;
+                    _buffBarTime.IsChecked = false;
                     _beneficColorPickerBox.SetColor(0x0059, FileManager.Hues.GetPolygoneColor(12, 0x0059));
                     _harmfulColorPickerBox.SetColor(0x0020, FileManager.Hues.GetPolygoneColor(12, 0x0020));
                     _neutralColorPickerBox.SetColor(0x03B1, FileManager.Hues.GetPolygoneColor(12, 0x03B1));
@@ -1814,6 +1816,7 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.MurdererHue = _murdererColorPickerBox.Hue;
             Engine.Profile.Current.EnabledCriminalActionQuery = _queryBeforAttackCheckbox.IsChecked;
             Engine.Profile.Current.CastSpellsByOneClick = _castSpellsByOneClick.IsChecked;
+            Engine.Profile.Current.BuffBarTime = _buffBarTime.IsChecked;
 
             Engine.Profile.Current.BeneficHue = _beneficColorPickerBox.Hue;
             Engine.Profile.Current.HarmfulHue = _harmfulColorPickerBox.Hue;


### PR DESCRIPTION
This new option located under "Combat / Spells" will show a countdown timer on every buff in your buff bar.

![ClassicUO_2019-10-22_23-05-44](https://user-images.githubusercontent.com/1727541/67333306-a0614a80-f520-11e9-8604-5801f6fde72a.png)

Example:
![2019-10-22_21-28-00](https://user-images.githubusercontent.com/1727541/67333366-b40cb100-f520-11e9-94df-f4034f2f7108.gif)

It uses a Unicode font, which I've been told can be an issue, but I'm not sure why...
