### PR TITLE
Fix for sound volume

### DIFF
--- a/src/Game/Constants.cs
+++ b/src/Game/Constants.cs
@@ -116,7 +116,7 @@ namespace ClassicUO.Game
 
         public const int DEATH_SCREEN_TIMER = 1500;
 
-        public const float SOUND_DELTA = 1000f;
+        public const float SOUND_DELTA = 250;
 
         public const uint JOURNAL_LOCALSERIAL = 0xFFFFFFE1;
         public const uint SKILLSTD_LOCALSERIAL = 0xFFFFFFE2;


### PR DESCRIPTION
This sets `SOUND_DELTA` to 250 instead of 1000.
The value 250 may not be as nice and round as 1000, but it will make the volume peak at 90% instead of below 50%.
200 is rounder and nice, and seems to peak at about 98% volume, but I feel like that is cutting it close.

![2019-10-23_00-25-40](https://user-images.githubusercontent.com/1727541/67339544-ba545a80-f52b-11e9-88f1-55eb1c041fa3.gif)
