### PR TITLE
Update instructions of how to build on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,23 +56,20 @@ Open a terminal instance and put the following commands:
 # Building (macOS)
 All the commands should be executed in terminal. All global package installs should be done only if not yet installed.
 
-1. Install Homebrew, a package manager for macOS (if not yet installed):
+1. Install Homebrew, a package manager for macOS:
 Follow instructions on https://brew.sh/
 
-2. Install Mono (https://www.mono-project.com/):
+2. Install Mono, a cross platform, open source .NET framework (https://www.mono-project.com/):
 `brew install mono`
 
-3. Install Paket, a dependency manager for .NET and mono projects (https://fsprojects.github.io/Paket/):
-`brew install paket`
+3. Install NuGet, a package manager for .NET (https://www.nuget.org/):
+`brew install nuget`
 
-4. Navigate to ClassicUO root folder:
+4. Navigate to your ClassicUO root folder:
 `cd /your/path/to/ClassicUO`
 
-5. Initialize Paket environment:
-`paket init`
-
-6. Install required/missing dependencies:
-`paket add Newtonsoft.Json --version 12.0.2`
+5. Restore required packages:
+`nuget restore`
 
 7. Build:
   - Debug version: `msbuild /t:Rebuild`
@@ -82,10 +79,8 @@ Follow instructions on https://brew.sh/
   - Debug version: `./bin/Debug/ClassicUO-mono.sh`
   - Release version: `./bin/Release/ClassicUO-mono.sh`
 
-Other useful commands:
-- `msbuild /t:Clean`
-- `msbuild /t:Clean /p:Configuration=Release`
-- `msbuild /t:RestorePackages`
+X. [Optional] If you want to run a debugger for .NET (in VS Code, for example), install .NET SDK:
+`brew cask install dotnet-sdk`
 
 # Contribute
 Everyone is welcome to contribute! The GitHub issues and project tracker are kept up to date with tasks that need work.


### PR DESCRIPTION
Use `nuget` package manager to restore packages defined in `src/packages.config` instead of `paket` with its own packaging structure, so the `<HintPath>` for `Newtonsoft.Json.dll` will be exactly the same as defined in `src/ClassicUO.csproj` (Visual Studio on Windows uses `nuget` internally to manage packages).