### PR TITLE
Add better check for non-lootable items

### DIFF
--- a/src/Game/GameObjects/Item.cs
+++ b/src/Game/GameObjects/Item.cs
@@ -218,6 +218,16 @@ namespace ClassicUO.Game.GameObjects
             }
         }
 
+        public bool IsLootable =>
+            ItemData.Layer != (int) Layer.Hair &&
+            ItemData.Layer != (int) Layer.Beard &&
+            ItemData.Layer != (int) Layer.Face &&
+            // TODO: Remove this check when the issue with non-lootable items will be resolved on the server side
+            // Skip non-lootable items (the check below is for UO:Outlands only)
+            // These items appear only on humanoid NPC corpses so they don't look naked
+            // They are always a piece of equipment and server always sends their position as 0,0,0
+            // So the check works next way: it's true if not Outlands, it's true if it isn't equipment, it's true if position in container is not "0.0.0"
+            (Engine.GlobalSettings.ShardType != 2 || ItemData.Layer == (int) Layer.Invalid || (X != 0 || Y != 0 || Z != 0));
 
         private void LoadMulti()
         {

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -70,7 +70,7 @@ namespace ClassicUO.Game.UI.Gumps
             foreach (var c in Children.OfType<ItemGump>())
                 c.Dispose();
 
-            foreach (Item i in item.Items.Where(s => s.ItemData.Layer != (int) Layer.Hair && s.ItemData.Layer != (int) Layer.Beard && s.ItemData.Layer != (int) Layer.Face))
+            foreach (Item i in item.Items.Where(s => s != null && s.IsLootable))
                 //FIXME: this should be disabled. Server sends the right position
                 //CheckItemPosition(i);
                 Add(new ItemGump(i));
@@ -251,7 +251,7 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 var item = World.Items.Get(s);
 
-                if (item == null || item.ItemData.Layer == (int) Layer.Hair || item.ItemData.Layer == (int) Layer.Beard || item.ItemData.Layer == (int) Layer.Face)
+                if (item == null || !item.IsLootable)
                     continue;
 
 

--- a/src/Game/UI/Gumps/GridLootGump.cs
+++ b/src/Game/UI/Gumps/GridLootGump.cs
@@ -117,11 +117,8 @@ namespace ClassicUO.Game.UI.Gumps
             int count = 0;
             _pagesCount = 1;
 
-            foreach (Item item in _corpse.Items)
+            foreach (Item item in _corpse.Items.Where(s => s != null && s.IsLootable))
             {
-                if (item == null || item.ItemData.Layer == (int) Layer.Hair || item.ItemData.Layer == (int) Layer.Beard || item.ItemData.Layer == (int) Layer.Face)
-                    continue;
-
                 GridLootItem gridItem = new GridLootItem(item);
 
                 if (x >= _background.Width - 20)


### PR DESCRIPTION
Skip non-lootable items (the check below is for UO:Outlands only).
These items appear only on humanoid NPC corpses so they don't look naked.
They are always a piece of equipment and server always forces their position as 0,0,0 which is almost the same as Position.INVALID (you can't place an item in 0,0,0).
So the check works the next way: show an item if the shard type is not Outlands, show the item if it isn't equipment, show the item if position in container is not 0,0,0.