### PR TITLE
New macro OpenCorpses

### DIFF
--- a/src/Game/GameObjects/PlayerMobile.cs
+++ b/src/Game/GameObjects/PlayerMobile.cs
@@ -1279,6 +1279,15 @@ namespace ClassicUO.Game.GameObjects
             }
         }
 
+        public void OpenCorpses(byte range)
+        {
+            foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && t.Distance <= range))
+            {
+                OpenedCorpses.Add(c.Serial);
+                GameActions.DoubleClickQueued(c.Serial);
+            }
+        }
+
 
         protected override void OnDirectionChanged()
         {

--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -1107,6 +1107,11 @@ namespace ClassicUO.Game.Managers
                         }
                     }
                     break;
+
+                case MacroType.OpenCorpses:
+                    World.Player.OpenCorpses( 2 );
+
+                    break;
             }
 
 
@@ -1421,7 +1426,7 @@ namespace ClassicUO.Game.Managers
         UsePotion,
         CloseAllHealthBars,
         RazorMacro,
-
+        OpenCorpses
     }
 
     internal enum MacroSubType


### PR DESCRIPTION
This adds a simple "OpenCorpses" macro that will open any corpse near the player.
It also makes sure that the auto open corpse feature never opens that corpse.

![ClassicUO_2019-10-23_18-46-09](https://user-images.githubusercontent.com/1727541/67415486-64cc8c00-f5c5-11e9-9347-2e38b2e6660a.png)

This of course works no matter what setting you've got for "Auto Open Corses".
It doesn't even have to be enabled.
And this macro will always open all corpses and ignores any corpse in `OpenedCorpses`.
