### PR TITLE
drag offset for macro button creation, rearrange macrocontrol

### DIFF
--- a/src/Game/UI/Controls/MacroControl.cs
+++ b/src/Game/UI/Controls/MacroControl.cs
@@ -51,10 +51,10 @@ namespace ClassicUO.Game.UI.Controls
 
             Add(box);
 
-            Add(new NiceButton(0, box.Height + 3, 50, 25, ButtonAction.Activate, "Add") {IsSelectable = false});
-            Add(new NiceButton(52, box.Height + 3, 50, 25, ButtonAction.Activate, "Remove") {ButtonParameter = 1, IsSelectable = false});
+            Add(new NiceButton(0, box.Height + 3, 170, 25, ButtonAction.Activate, "+ Create macro button", 0, IO.Resources.TEXT_ALIGN_TYPE.TS_LEFT) { ButtonParameter = 2, IsSelectable = false });
 
-            Add(new NiceButton(0, box.Height + 30, 170, 25, ButtonAction.Activate, "+ Create macro button", 0, IO.Resources.TEXT_ALIGN_TYPE.TS_LEFT) { ButtonParameter = 2, IsSelectable = false });
+            Add(new NiceButton(0, box.Height + 30, 50, 25, ButtonAction.Activate, "Add") {IsSelectable = false});
+            Add(new NiceButton(52, box.Height + 30, 50, 25, ButtonAction.Activate, "Remove") {ButtonParameter = 1, IsSelectable = false});
 
 
             Add(_collection = new MacroCollectionControl(name, 280, 280)

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -708,7 +709,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                     nb.DragBegin += (sss, eee) =>
                     {
-                        if (Engine.UI.IsDragging
+                        if (Engine.UI.IsDragging || Math.Max(Math.Abs(Mouse.LDroppedOffset.X), Math.Abs(Mouse.LDroppedOffset.Y)) < 5
                             || nb.ScreenCoordinateX > Mouse.LDropPosition.X || nb.ScreenCoordinateX < Mouse.LDropPosition.X - nb.Width
                             || nb.ScreenCoordinateY > Mouse.LDropPosition.Y || nb.ScreenCoordinateY + nb.Height < Mouse.LDropPosition.Y)
                             return;
@@ -797,7 +798,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 nb.DragBegin += (sss, eee) =>
                 {
-                    if (Engine.UI.IsDragging
+                    if (Engine.UI.IsDragging || Math.Max(Math.Abs(Mouse.LDroppedOffset.X), Math.Abs(Mouse.LDroppedOffset.Y)) < 5
                         || nb.ScreenCoordinateX > Mouse.LDropPosition.X || nb.ScreenCoordinateX < Mouse.LDropPosition.X - nb.Width
                         || nb.ScreenCoordinateY > Mouse.LDropPosition.Y || nb.ScreenCoordinateY + nb.Height < Mouse.LDropPosition.Y)
                             return;


### PR DESCRIPTION
- Rearrange macro control, when modifying macros it's nicer to have add/remove buttons below / closer to the combo boxes (not that remove does anything atm..)
- Minimum drag offset for dragging a macro name to create a macro button