### PR TITLE
Object Info Command to Macro

### DIFF
--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -1107,6 +1107,12 @@ namespace ClassicUO.Game.Managers
                         }
                     }
                     break;
+
+                case MacroType.ObjectInfo:
+
+                    CommandManager.Execute("info");
+
+                    break;
             }
 
 
@@ -1421,6 +1427,7 @@ namespace ClassicUO.Game.Managers
         UsePotion,
         CloseAllHealthBars,
         RazorMacro,
+        ObjectInfo,
 
     }
 


### PR DESCRIPTION
Simply utilizes "-info" as a macro since say "-info" doesn't trigger the command.