### PR TITLE
Fix for arrowkeys and macro player movement

### DIFF
--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -846,9 +846,7 @@ namespace ClassicUO.Game.Scenes
             {
                 Macro macro = Macros.FindMacro(e.keysym.sym, isalt, isctrl, isshift);
 
-                if (macro == null)
-                    _isMacroMoveDown = _arrowKeyPressed = false;
-                else
+                if (macro != null)
                 {
                     switch (macro.FirstNode.SubCode)
                     {
@@ -875,7 +873,7 @@ namespace ClassicUO.Game.Scenes
                 }
             }
 
-            if (!(_isUpDown || _isDownDown || _isLeftDown || _isRightDown)) _arrowKeyPressed = false;
+            if (!(_isUpDown || _isDownDown || _isLeftDown || _isRightDown)) _isMacroMoveDown = _arrowKeyPressed = false;
 
             if ((e.keysym.mod & SDL.SDL_Keymod.KMOD_NUM) != SDL.SDL_Keymod.KMOD_NUM) _numPadKeyPressed = false;
 


### PR DESCRIPTION
This fixes some input issues when moving with the keyboard.
Not only will it correctly reset `_isMacroMoveDown ` to `false` (stuck on `true` without this fix), it will also fix the issue where pressing any button will halt the players movement when using the keyboard to move.