### PR TITLE
New macro OpenHelp

### DIFF
--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -464,6 +464,11 @@ namespace ClassicUO.Game.Managers
 
                                     break;
 
+                                case MacroSubType.Help:
+                                    GameActions.RequestHelp();
+
+                                    break;
+
                                 case MacroSubType.PartyChat:
                                 case MacroSubType.CombatBook:
                                 case MacroSubType.RacialAbilitiesBook:
@@ -1456,6 +1461,7 @@ namespace ClassicUO.Game.Managers
         Guild,
         SpellWeavingSpellbook,
         QuestLog,
+        Help,
         MysticismSpellbook,
         RacialAbilitiesBook,
         BardSpellbook,


### PR DESCRIPTION
Simple macro for opening the help menu.
Especially useful on servers like Outlands that heavily relies on the help menu.

![ClassicUO_2019-10-24_19-43-04](https://user-images.githubusercontent.com/1727541/67511117-821d5b00-f696-11e9-8bc5-208ee06643da.png)
