### PR TITLE
New option Skip empty corpse

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -172,6 +172,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool SmoothDoors { get; set; }
         [JsonProperty] public bool AutoOpenCorpses { get; set; }
         [JsonProperty] public int AutoOpenCorpseRange { get; set; } = 2;
+        [JsonProperty] public bool AutoCloseCorpses { get; set; }
         [JsonProperty] public int CorpseOpenOptions { get; set; } = 3;
         [JsonProperty] public bool DisableDefaultHotkeys { get; set; }
         [JsonProperty] public bool DisableArrowBtn { get; set; }

--- a/src/Game/GameActions.cs
+++ b/src/Game/GameActions.cs
@@ -74,6 +74,19 @@ namespace ClassicUO.Game
             DoubleClick(serial | 0x80000000);
         }
 
+        public static bool OpenCorpse(Serial serial)
+        {
+            if (!serial.IsItem) return false;
+
+            Item item = World.Items.Get(serial);
+            if (item == null || !item.IsCorpse) return false;
+
+            World.Player.ManualOpenedCorpses.Add(serial);
+            DoubleClick(serial);
+
+            return true;
+        }
+
         public static void Attack(Serial serial)
         {
             if (Engine.Profile.Current.EnabledCriminalActionQuery)

--- a/src/Game/GameActions.cs
+++ b/src/Game/GameActions.cs
@@ -79,7 +79,7 @@ namespace ClassicUO.Game
             if (!serial.IsItem) return false;
 
             Item item = World.Items.Get(serial);
-            if (item == null || !item.IsCorpse) return false;
+            if (item == null || !item.IsCorpse || item.IsDestroyed) return false;
 
             World.Player.ManualOpenedCorpses.Add(serial);
             DoubleClick(serial);

--- a/src/Game/GameObjects/PlayerMobile.cs
+++ b/src/Game/GameObjects/PlayerMobile.cs
@@ -1271,9 +1271,9 @@ namespace ClassicUO.Game.GameObjects
                 if ((Engine.Profile.Current.CorpseOpenOptions == 2 || Engine.Profile.Current.CorpseOpenOptions == 3) && IsHidden)
                     return;
 
-                foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && !OpenedCorpses.Contains(t.Serial) && t.Distance <= Engine.Profile.Current.AutoOpenCorpseRange))
+                foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && !AutoOpenedCorpses.Contains(t.Serial) && t.Distance <= Engine.Profile.Current.AutoOpenCorpseRange))
                 {
-                    OpenedCorpses.Add(c.Serial);
+                    AutoOpenedCorpses.Add(c.Serial);
                     GameActions.DoubleClickQueued(c.Serial);
                 }
             }
@@ -1860,7 +1860,8 @@ namespace ClassicUO.Game.GameObjects
                    || type >= 0x9B3C && type <= 0x9B4B;
         }
 
-        private readonly HashSet<Serial> OpenedCorpses = new HashSet<Serial>();
+        public readonly HashSet<Serial> AutoOpenedCorpses = new HashSet<Serial>();
+        public readonly HashSet<Serial> ManualOpenedCorpses = new HashSet<Serial>();
 #if JAEDAN_MOVEMENT_PATCH
         public override void ForcePosition(ushort x, ushort y, sbyte z, Direction dir)
         {

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -525,11 +525,8 @@ namespace ClassicUO.Game.Scenes
             {
                 case Item item:
                     result = true;
-
-                    if (item.IsCorpse)
-                        World.Player.ManualOpenedCorpses.Add(item.Serial);
-
-                    GameActions.DoubleClick(item);
+                    if (!GameActions.OpenCorpse(item))
+                        GameActions.DoubleClick(item);
 
                     break;
 

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -525,6 +525,10 @@ namespace ClassicUO.Game.Scenes
             {
                 case Item item:
                     result = true;
+
+                    if (item.IsCorpse)
+                        World.Player.ManualOpenedCorpses.Add(item.Serial);
+
                     GameActions.DoubleClick(item);
 
                     break;

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -43,6 +43,8 @@ namespace ClassicUO.Game.UI.Gumps
         private HitBox _iconizerArea;
         internal override HitBox IconizerArea => _iconizerArea;
         private long _corpseEyeTicks;
+        private bool _hadItems;
+        private bool _closeIfEmpty;
         private ContainerData _data;
         private int _eyeCorspeOffset;
         private GumpPic _eyeGumpPic;
@@ -118,6 +120,13 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (_isCorspeContainer)
             {
+                if (World.Player.ManualOpenedCorpses.Contains(this.LocalSerial))
+                {
+                    World.Player.ManualOpenedCorpses.Remove(this.LocalSerial);
+                } else if (World.Player.AutoOpenedCorpses.Contains(this.LocalSerial) &&
+                    Engine.Profile.Current != null && Engine.Profile.Current.AutoCloseCorpses)
+                    _closeIfEmpty = true;
+
                 _eyeGumpPic?.Dispose();
                 Add(_eyeGumpPic = new GumpPic((int) (45 * scale), (int) (30 * scale), 0x0045, 0));
 
@@ -189,6 +198,14 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (item == null || item.IsDestroyed)
             {
+                Dispose();
+                return;
+            }
+
+            if (item.Items.Count > 0)
+                _hadItems = true;
+
+            if (_closeIfEmpty && !_hadItems && item.Items.Count() == 0){
                 Dispose();
                 return;
             }

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -194,7 +194,13 @@ namespace ClassicUO.Game.UI.Gumps
                     if (World.Player.InWarMode)
                         GameActions.Attack(entity);
                     else
+                    {
+                        Item item;
+                        if ((item = World.Items.Get(LocalSerial)) != null && item.IsCorpse)
+                            World.Player.ManualOpenedCorpses.Add(entity.Serial);
+
                         GameActions.DoubleClick(entity);
+                    }
                 }
                 else
                 {
@@ -202,7 +208,7 @@ namespace ClassicUO.Game.UI.Gumps
                     Dispose();
                 }
             }
-
+            
             return true;
         }
 

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -193,17 +193,8 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     if (World.Player.InWarMode)
                         GameActions.Attack(entity);
-                    else
-                    {
-                        if (LocalSerial.IsItem)
-                        {
-                            Item item = World.Items.Get(LocalSerial);
-                            if (item != null && item.IsCorpse)
-                                World.Player.ManualOpenedCorpses.Add(LocalSerial);
-                        }
-
-                        GameActions.DoubleClick(entity);
-                    }
+                    else if (!GameActions.OpenCorpse(LocalSerial))
+                        GameActions.DoubleClick(LocalSerial);
                 }
                 else
                 {
@@ -211,7 +202,7 @@ namespace ClassicUO.Game.UI.Gumps
                     Dispose();
                 }
             }
-            
+
             return true;
         }
 

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -195,9 +195,12 @@ namespace ClassicUO.Game.UI.Gumps
                         GameActions.Attack(entity);
                     else
                     {
-                        Item item;
-                        if ((item = World.Items.Get(LocalSerial)) != null && item.IsCorpse)
-                            World.Player.ManualOpenedCorpses.Add(entity.Serial);
+                        if (LocalSerial.IsItem)
+                        {
+                            Item item = World.Items.Get(LocalSerial);
+                            if (item != null && item.IsCorpse)
+                                World.Player.ManualOpenedCorpses.Add(LocalSerial);
+                        }
 
                         GameActions.DoubleClick(entity);
                     }

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -193,8 +193,8 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     if (World.Player.InWarMode)
                         GameActions.Attack(entity);
-                    else if (!GameActions.OpenCorpse(LocalSerial))
-                        GameActions.DoubleClick(LocalSerial);
+                    else if (!GameActions.OpenCorpse(entity))
+                        GameActions.DoubleClick(entity);
                 }
                 else
                 {

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -210,18 +210,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (World.Player.InWarMode && Entity is Mobile)
                     GameActions.Attack(Entity);
-                else
-                {
-                    if (LocalSerial.IsItem)
-                    {
-                        Item item = World.Items.Get(LocalSerial);
-                        if (item != null && item.IsCorpse)
-                            World.Player.ManualOpenedCorpses.Add(LocalSerial);
-                    }
-                    
-                    GameActions.DoubleClick(Entity);
-                }
-                    
+                else if (!GameActions.OpenCorpse(LocalSerial))
+                    GameActions.DoubleClick(LocalSerial);
             }
             
             return true;

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -212,9 +212,12 @@ namespace ClassicUO.Game.UI.Gumps
                     GameActions.Attack(Entity);
                 else
                 {
-                    Item item;
-                    if ((item = World.Items.Get(LocalSerial)) != null && item.IsCorpse)
-                        World.Player.ManualOpenedCorpses.Add(Entity.Serial);
+                    if (LocalSerial.IsItem)
+                    {
+                        Item item = World.Items.Get(LocalSerial);
+                        if (item != null && item.IsCorpse)
+                            World.Player.ManualOpenedCorpses.Add(LocalSerial);
+                    }
                     
                     GameActions.DoubleClick(Entity);
                 }

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -210,10 +210,10 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (World.Player.InWarMode && Entity is Mobile)
                     GameActions.Attack(Entity);
-                else if (!GameActions.OpenCorpse(LocalSerial))
-                    GameActions.DoubleClick(LocalSerial);
+                else if (!GameActions.OpenCorpse(Entity))
+                    GameActions.DoubleClick(Entity);
             }
-            
+
             return true;
         }
 

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -211,9 +211,16 @@ namespace ClassicUO.Game.UI.Gumps
                 if (World.Player.InWarMode && Entity is Mobile)
                     GameActions.Attack(Entity);
                 else
+                {
+                    Item item;
+                    if ((item = World.Items.Get(LocalSerial)) != null && item.IsCorpse)
+                        World.Player.ManualOpenedCorpses.Add(Entity.Serial);
+                    
                     GameActions.DoubleClick(Entity);
+                }
+                    
             }
-
+            
             return true;
         }
 

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -66,7 +66,7 @@ namespace ClassicUO.Game.UI.Gumps
         private TextBox _rows, _columns, _highlightAmount, _abbreviatedAmount;
 
         //experimental
-        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _autoCloseCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG;
         private Combobox _overrideContainerLocationSetting;
 
         // sounds
@@ -1088,10 +1088,18 @@ namespace ClassicUO.Game.UI.Gumps
             _autoOpenCorpse = CreateCheckBox(rightArea, "Auto Open Corpses", Engine.Profile.Current.AutoOpenCorpses, 0, 5);
             _autoOpenCorpse.ValueChanged += (sender, e) => { _autoOpenCorpseArea.IsVisible = _autoOpenCorpse.IsChecked; };
 
-            _autoOpenCorpseRange = CreateInputField(_autoOpenCorpseArea, new TextBox(FONT, 2, 80, 80)
+           _autoCloseCorpse = new Checkbox(0x00D2, 0x00D3, "Skip empty corpses", FONT, HUE_FONT)
             {
                 X = 20,
-                Y = _cellSize.Y + _cellSize.Height - 15,
+                Y = 5,
+                IsChecked = Engine.Profile.Current.AutoCloseCorpses
+            };
+            _autoOpenCorpseArea.Add(_autoCloseCorpse);
+
+            _autoOpenCorpseRange = CreateInputField(_autoOpenCorpseArea, new TextBox(FONT, 2, 80, 80)
+            {
+                X = 25,
+                Y = _autoCloseCorpse.Y + _autoCloseCorpse.Height,
                 Width = 50,
                 Height = 30,
                 NumericOnly = true,
@@ -1110,8 +1118,8 @@ namespace ClassicUO.Game.UI.Gumps
             };*/
             var text = new Label("Corpse Open Options:", true, HUE_FONT)
             {
-                Y = _autoOpenCorpseRange.Y + 30,
-                X = 10
+                X = 20,
+                Y = _autoOpenCorpseRange.Y + 20
             };
             _autoOpenCorpseArea.Add(text);
 
@@ -1526,6 +1534,8 @@ namespace ClassicUO.Game.UI.Gumps
                     _showTargetRangeIndicator.IsChecked = false;
                     _customBars.IsChecked = false;
                     _customBarsBBG.IsChecked = false;
+                    _autoOpenCorpse.IsChecked = false;
+                    _autoCloseCorpse.IsChecked = false;
 
                     break;
 
@@ -1919,6 +1929,7 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.Profile.Current.AutoOpenCorpses = _autoOpenCorpse.IsChecked;
             Engine.Profile.Current.AutoOpenCorpseRange = int.Parse(_autoOpenCorpseRange.Text);
             Engine.Profile.Current.CorpseOpenOptions = _autoOpenCorpseOptions.SelectedIndex;
+            Engine.Profile.Current.AutoCloseCorpses = _autoCloseCorpse.IsChecked;
 
             Engine.Profile.Current.EnableDragSelect = _enableDragSelect.IsChecked;
             Engine.Profile.Current.DragSelectModifierKey = _dragSelectModifierKey.SelectedIndex;


### PR DESCRIPTION
Added the option "Skip empty corpses" as a sub-option for "Auto Open Corpses".
This will make it so that "Auto Open Corpses" never opens any empty corpses.
Now also supports Health Bars and Overhead Names!

![ClassicUO_2019-10-28_18-51-20](https://user-images.githubusercontent.com/1727541/67703586-f6683f00-f9b3-11e9-964e-f3787c247d46.png)
