### PR TITLE
Experimental ForceGumpsOnScreen

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -170,6 +170,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool BuffBarTime { get; set; }
         [JsonProperty] public bool AutoOpenDoors { get; set; }
         [JsonProperty] public bool SmoothDoors { get; set; }
+        [JsonProperty] public bool ForceGumpsOnScreen { get; set; }
         [JsonProperty] public bool AutoOpenCorpses { get; set; }
         [JsonProperty] public int AutoOpenCorpseRange { get; set; } = 2;
         [JsonProperty] public int CorpseOpenOptions { get; set; } = 3;

--- a/src/Game/UI/Gumps/Gump.cs
+++ b/src/Game/UI/Gumps/Gump.cs
@@ -60,6 +60,21 @@ namespace ClassicUO.Game.UI.Gumps
         {
             if (ActivePage == 0)
                 ActivePage = 1;
+
+            if (Engine.Profile.Current != null && Engine.Profile.Current.ForceGumpsOnScreen)
+            {
+                int widthLimit = Width / 5;
+                int heightLimit = Height / 5;
+                int screenWidth = Engine.Instance.Window.ClientBounds.Width;
+                int screenHeight = Engine.Instance.Window.ClientBounds.Height;
+
+                if (X + Width < widthLimit) X = widthLimit - Width;
+                if (X > screenWidth - widthLimit) X = screenWidth - widthLimit;
+
+                if (Y + Height < heightLimit) Y = heightLimit - Height;
+                if (Y > screenHeight - heightLimit) Y = screenHeight - heightLimit;
+            }
+            
             base.Update(totalMS, frameMS);
         }
 
@@ -76,13 +91,16 @@ namespace ClassicUO.Game.UI.Gumps
 
         public void SetInScreen()
         {
-            Rectangle rect = new Rectangle(0, 0, Engine.WindowWidth, Engine.WindowHeight);
+            if (Engine.Profile.Current != null && !Engine.Profile.Current.ForceGumpsOnScreen)
+            {
+                Rectangle rect = new Rectangle(0, 0, Engine.WindowWidth, Engine.WindowHeight);
 
-            if (rect.Intersects(Bounds))
-                return;
+                if (rect.Intersects(Bounds))
+                    return;
 
-            X = 0;
-            Y = 0;
+                X = 0;
+                Y = 0;
+            }
         }
 
         public virtual void Restore(BinaryReader reader)
@@ -91,22 +109,25 @@ namespace ClassicUO.Game.UI.Gumps
 
         protected override void OnDragEnd(int x, int y)
         {
-            Point position = Location;
-            int halfWidth = Width - (Width >> 2);
-            int halfHeight = Height - (Height >> 2);
+            if (Engine.Profile.Current != null && !Engine.Profile.Current.ForceGumpsOnScreen)
+            {
+                Point position = Location;
+                int halfWidth = Width - (Width >> 2);
+                int halfHeight = Height - (Height >> 2);
 
-            if (X < -halfWidth)
-                position.X = -halfWidth;
+                if (X < -halfWidth)
+                    position.X = -halfWidth;
 
-            if (Y < -halfHeight)
-                position.Y = -halfHeight;
+                if (Y < -halfHeight)
+                    position.Y = -halfHeight;
 
-            if (X > Engine.Instance.Window.ClientBounds.Width - (Width - halfWidth))
-                position.X = Engine.Instance.Window.ClientBounds.Width - (Width - halfWidth);
+                if (X > Engine.Instance.Window.ClientBounds.Width - (Width - halfWidth))
+                    position.X = Engine.Instance.Window.ClientBounds.Width - (Width - halfWidth);
 
-            if (Y > Engine.Instance.Window.ClientBounds.Height - (Height - halfHeight))
-                position.Y = Engine.Instance.Window.ClientBounds.Height - (Height - halfHeight);
-            Location = position;
+                if (Y > Engine.Instance.Window.ClientBounds.Height - (Height - halfHeight))
+                    position.Y = Engine.Instance.Window.ClientBounds.Height - (Height - halfHeight);
+                Location = position;
+            }
         }
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -66,7 +66,7 @@ namespace ClassicUO.Game.UI.Gumps
         private TextBox _rows, _columns, _highlightAmount, _abbreviatedAmount;
 
         //experimental
-        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG, _forceGumpsOnScreen;
         private Combobox _overrideContainerLocationSetting;
 
         // sounds
@@ -1080,6 +1080,8 @@ namespace ClassicUO.Game.UI.Gumps
             _debugGumpIsDisabled = CreateCheckBox(rightArea, "Disable Debug Gump", Engine.Profile.Current.DebugGumpIsDisabled, 0, 0);
             _restoreLastGameSize = CreateCheckBox(rightArea, "Disable automatic maximize. Restore windows size after re-login", Engine.Profile.Current.RestoreLastGameSize, 0, 0);
 
+            _forceGumpsOnScreen = CreateCheckBox(rightArea, "Force Gumps on screen", Engine.Profile.Current.ForceGumpsOnScreen, 0, 0);
+
             _autoOpenDoors = CreateCheckBox(rightArea, "Auto Open Doors", Engine.Profile.Current.AutoOpenDoors, 0, 0);
             _smoothDoors = CreateCheckBox(rightArea, "Smooth doors", Engine.Profile.Current.SmoothDoors, 20, 5);
 
@@ -1526,6 +1528,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _showTargetRangeIndicator.IsChecked = false;
                     _customBars.IsChecked = false;
                     _customBarsBBG.IsChecked = false;
+                    _forceGumpsOnScreen.IsChecked = false;
 
                     break;
 
@@ -1916,6 +1919,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             Engine.Profile.Current.AutoOpenDoors = _autoOpenDoors.IsChecked;
             Engine.Profile.Current.SmoothDoors = _smoothDoors.IsChecked;
+            Engine.Profile.Current.ForceGumpsOnScreen = _forceGumpsOnScreen.IsChecked;
             Engine.Profile.Current.AutoOpenCorpses = _autoOpenCorpse.IsChecked;
             Engine.Profile.Current.AutoOpenCorpseRange = int.Parse(_autoOpenCorpseRange.Text);
             Engine.Profile.Current.CorpseOpenOptions = _autoOpenCorpseOptions.SelectedIndex;


### PR DESCRIPTION
A lot of people seem to have their Gumps disappear outside the window border.
This new method will force Gumps to always be on screen by checking the window position on `Update`.
I feel like this should be the default way, but I added it to the "Experimental" tab as an option just to be safe.

![2019-10-31_17-31-47](https://user-images.githubusercontent.com/1727541/67966713-adf39000-fc04-11e9-936a-c0f28873b8eb.gif)