### PR TITLE
Updated DoubleClickToLoot logic

### DIFF
--- a/src/Game/UI/Controls/ItemGump.cs
+++ b/src/Game/UI/Controls/ItemGump.cs
@@ -30,6 +30,7 @@ using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Input;
 using ClassicUO.IO;
 using ClassicUO.Renderer;
+using ClassicUO.Game.Data;
 
 using Microsoft.Xna.Framework;
 
@@ -324,13 +325,13 @@ namespace ClassicUO.Game.UI.Controls
                 return false;
  
             Item item, container;
- 
-            if (
+
+            if ( !Input.Keyboard.Ctrl &&
                 Engine.Profile.Current.DoubleClickToLootInsideContainers &&
                 (item = World.Items.Get(LocalSerial)) != null &&
                 !item.ItemData.IsContainer && item.Items.Count == 0 &&
                 (container = World.Items.Get(item.RootContainer)) != null &&
-                container.IsCorpse
+                container != World.Player.Equipment[(int) Layer.Backpack]
             ){
                 GameActions.GrabItem(item, item.Amount);
             } else


### PR DESCRIPTION
This updates the 'Double click to loot' logic.
It will now loot from anything that isn't owned by the player.
That means that treasure chests and similar will behave like looting corpses, which makes a lot more sense.
You can now also override the loot behaviour by holding Ctrl while double clicking.