### PR TITLE
Fixed item drag offset

### DIFF
--- a/src/Game/GameCursor.cs
+++ b/src/Game/GameCursor.cs
@@ -251,8 +251,7 @@ namespace ClassicUO.Game
         {
             _itemHold = hold;
             _draggedItemTexture = FileManager.Art.GetTexture(_itemHold.DisplayedGraphic);
-            _offset.X = _draggedItemTexture.Width >> 1;
-            _offset.Y = _draggedItemTexture.Height >> 1;
+            _offset = hold.Offset;
 
             _rect.Width = _draggedItemTexture.Width;
             _rect.Height = _draggedItemTexture.Height;

--- a/src/Game/ItemHold.cs
+++ b/src/Game/ItemHold.cs
@@ -21,10 +21,10 @@
 
 #endregion
 
-using System.Collections.Generic;
-
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
+
+using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Game
 {
@@ -32,6 +32,7 @@ namespace ClassicUO.Game
     {
         public bool OnGround { get; private set; }
         public Position Position { get; private set; }
+        public Point Offset { get; private set; }
         public Serial Container { get; private set; }
         public Serial Serial { get; private set; }
         public Graphic Graphic { get; private set; }
@@ -48,7 +49,7 @@ namespace ClassicUO.Game
         public bool Enabled { get; set; }
         public bool Dropped { get; set; }
 
-        public void Set(Item item, ushort amount)
+        public void Set(Item item, ushort amount, Point offset)
         {
             Enabled = true;
 
@@ -66,6 +67,7 @@ namespace ClassicUO.Game
             IsWearable = item.ItemData.IsWearable;
             Layer = item.Layer;
             Flags = item.Flags;
+            Offset = offset;
 
             Engine.UI.GameCursor.SetDraggedItem(this);
         }

--- a/src/Game/Scenes/GameSceneDragAndDropHandler.cs
+++ b/src/Game/Scenes/GameSceneDragAndDropHandler.cs
@@ -90,7 +90,7 @@ namespace ClassicUO.Game.Scenes
             if (World.Player.IsDead || HeldItem.Enabled || item == null || item.IsDestroyed /*|| (!HeldItem.Enabled && HeldItem.Dropped && HeldItem.Serial.IsValid)*/) return false;
 
             HeldItem.Clear();
-            HeldItem.Set(item, amount <= 0 ? item.Amount : (ushort) amount);
+            HeldItem.Set(item, amount <= 0 ? item.Amount : (ushort) amount, new Point(x, y));
 
             if (!item.OnGround)
             {
@@ -187,8 +187,8 @@ namespace ClassicUO.Game.Scenes
                             textureH = texture.Height;
                         }
 
-                        x -= textureW >> 1;
-                        y -= textureH >> 1;
+                        x -= (int)(HeldItem.Offset.X * scale);
+                        y -= (int)(HeldItem.Offset.Y * scale);
 
                         if (x + textureW > bounds.Width)
                             x = bounds.Width - textureW;

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -702,7 +702,7 @@ namespace ClassicUO.Game.Scenes
                             if (item.IsDamageable)
                                 goto mobile;
 
-                            PickupItemBegin(item, _dragOffset.X, _dragOffset.Y);
+                            PickupItemBegin(item, item.Bounds.Width >> 1, item.Bounds.Height >> 1);
 
                             break;
                     }

--- a/src/Game/UI/Controls/ItemGump.cs
+++ b/src/Game/UI/Controls/ItemGump.cs
@@ -160,6 +160,9 @@ namespace ClassicUO.Game.UI.Controls
             if (button != MouseButton.Left)
                 return;
 
+            _lastClickPosition.X = Mouse.Position.X;
+            _lastClickPosition.Y = Mouse.Position.Y;
+
             if (TargetManager.IsTargeting)
             {
                 if (Mouse.IsDragging && Mouse.LDroppedOffset != Point.Zero)
@@ -340,21 +343,37 @@ namespace ClassicUO.Game.UI.Controls
         {
             if (CanPickUp)
             {
+                // fetch texture for item
+                Rectangle bounds = Texture.Bounds;
+                Point offset = Point.Zero;
+
                 if (this is ItemGumpPaperdoll)
                 {
                     if (Item == null || Item.IsDestroyed)
-                    {
                         Dispose();
-                    }
 
                     if (IsDisposed)
                         return;
 
-                    Rectangle bounds = FileManager.Art.GetTexture(Item.DisplayedGraphic).Bounds;
-                    GameActions.PickUp(LocalSerial, bounds.Width >> 1, bounds.Height >> 1);
+                    // fetch DisplayedGraphic for paperdoll item
+                    bounds = FileManager.Art.GetTexture(Item.DisplayedGraphic).Bounds;
                 }
-                else
-                    GameActions.PickUp(LocalSerial, Point.Zero);
+                else if (Parent != null && Parent is ContainerGump)
+                {
+                    float scale = 1;
+                    if (Engine.Profile.Current != null && Engine.Profile.Current.ScaleItemsInsideContainers)
+                        scale = Engine.UI.ContainerScale;
+
+                    // drag with mouse offset from containers
+                    offset = new Point(
+                        (int)((_lastClickPosition.X - (ParentX + X)) / scale),
+                        (int)((_lastClickPosition.Y - (ParentY + Y)) / scale));
+                }
+
+                if (offset == Point.Zero) // drag from center by default
+                    offset = new Point(bounds.Width >> 1, bounds.Height >> 1);
+
+                GameActions.PickUp(LocalSerial, offset);
             }
         }
     }

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -198,7 +198,7 @@ namespace ClassicUO.Game.UI.Gumps
                 Engine.UI.AttemptDragControl(gump, Mouse.Position, true);
             }
             else
-                GameActions.PickUp(Entity);
+                GameActions.PickUp(Entity, Entity.Texture.Width >> 1, Entity.Texture.Height >> 1);
         }
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButton button)


### PR DESCRIPTION
This will fix the offset when dragging items.
Items not in a container (paperdoll, world etc.) will still be dragged from the center of the texture.

Without this fix:
![no_fix](https://user-images.githubusercontent.com/1727541/67596719-b31a9000-f769-11e9-850f-5a8c3e0391c9.gif)

With this fix:
![fix](https://user-images.githubusercontent.com/1727541/67596729-b746ad80-f769-11e9-814f-6e6c766c30f4.gif)