### PR TITLE
Fixed currently playing sounds volume change, disable and background

### DIFF
--- a/src/Game/Managers/AudioManager.cs
+++ b/src/Game/Managers/AudioManager.cs
@@ -176,9 +176,9 @@ namespace ClassicUO.Game.Managers
             if (volume < -1 || volume > 1f)
                 return;
 
-            foreach (UOSound sound in _currentSounds.ToArray())
+            for (int i = 0; i < _currentSounds.Count; i++)
             {
-                sound.Volume = volume;
+                _currentSounds[i].Volume = volume;
             }
         }
 
@@ -194,11 +194,12 @@ namespace ClassicUO.Game.Managers
 
         public void StopSounds()
         {
-            foreach (UOSound sound in _currentSounds.ToArray())
+            for (int i = 0; i < _currentSounds.Count; i++)
             {
+                var sound = _currentSounds[i];
                 sound.Stop();
                 sound.Dispose();
-                _currentSounds.Remove(sound);
+                _currentSounds.RemoveAt(i);
             }
         }
 
@@ -218,15 +219,22 @@ namespace ClassicUO.Game.Managers
 
             _currentMusic?.Update();
 
-            foreach (UOSound sound in _currentSounds.ToArray())
+            for (int i = 0; i < _currentSounds.Count; i++)
             {
-                if (Engine.Instance.IsActive)
-                {
-                    if (!Engine.Profile.Current.ReproduceSoundsInBackground) sound.Volume = Engine.Profile.Current.MusicVolume / Constants.SOUND_DELTA;
-                }
-                else if (!Engine.Profile.Current.ReproduceSoundsInBackground && sound.Volume != 0) sound.Volume = 0;
+                var sound = _currentSounds[i];
 
-                if (!sound.IsPlaying()) _currentSounds.Remove(sound);
+                if (!sound.IsPlaying())
+                {
+                    _currentSounds.RemoveAt(i);
+                }
+                else
+                {
+                    if (Engine.Instance.IsActive)
+                    {
+                        if (!Engine.Profile.Current.ReproduceSoundsInBackground) sound.Volume = Engine.Profile.Current.SoundVolume / Constants.SOUND_DELTA;
+                    }
+                    else if (!Engine.Profile.Current.ReproduceSoundsInBackground && sound.Volume != 0) sound.Volume = 0;
+                }
             }
         }
     }

--- a/src/Game/Managers/AudioManager.cs
+++ b/src/Game/Managers/AudioManager.cs
@@ -199,7 +199,7 @@ namespace ClassicUO.Game.Managers
                 var sound = _currentSounds[i];
                 sound.Stop();
                 sound.Dispose();
-                _currentSounds.RemoveAt(i);
+                _currentSounds.RemoveAt(i--);
             }
         }
 
@@ -225,7 +225,7 @@ namespace ClassicUO.Game.Managers
 
                 if (!sound.IsPlaying())
                 {
-                    _currentSounds.RemoveAt(i);
+                    _currentSounds.RemoveAt(i--);
                 }
                 else
                 {

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -1669,9 +1669,13 @@ namespace ClassicUO.Game.UI.Gumps
             Engine.GlobalSettings.LoginMusic = _loginMusic.IsChecked;
 
             Engine.SceneManager.CurrentScene.Audio.UpdateCurrentMusicVolume();
+            Engine.SceneManager.CurrentScene.Audio.UpdateCurrentSoundsVolume();
 
             if (!Engine.Profile.Current.EnableMusic)
                 Engine.SceneManager.CurrentScene.Audio.StopMusic();
+
+            if (!Engine.Profile.Current.EnableSound)
+                Engine.SceneManager.CurrentScene.Audio.StopSounds();
 
             // speech
             Engine.Profile.Current.ScaleSpeechDelay = _scaleSpeechDelay.IsChecked;

--- a/src/IO/Audio/Sound.cs
+++ b/src/IO/Audio/Sound.cs
@@ -166,6 +166,18 @@ namespace ClassicUO.IO.Audio
 
         public void Stop()
         {
+            foreach(Tuple<DynamicSoundEffectInstance, double> sound in m_EffectInstances)
+            {
+                sound.Item1.Stop();
+                sound.Item1.Dispose();
+            }
+
+            foreach (Tuple<DynamicSoundEffectInstance, double> music in m_MusicInstances)
+            {
+                music.Item1.Stop();
+                music.Item1.Dispose();
+            }
+
             AfterStop();
         }
 

--- a/src/IO/Audio/UOSound.cs
+++ b/src/IO/Audio/UOSound.cs
@@ -28,11 +28,18 @@ namespace ClassicUO.IO.Audio
     internal class UOSound : Sound
     {
         private readonly byte[] m_WaveBuffer;
+        private bool m_Playing;
 
         public UOSound(string name, int index, byte[] buffer)
             : base(name, index)
         {
+            m_Playing = false;
             m_WaveBuffer = buffer;
+        }
+
+        public bool IsPlaying()
+        {
+            return m_Playing;
         }
 
         protected override void OnBufferNeeded(object sender, EventArgs e)
@@ -43,6 +50,16 @@ namespace ClassicUO.IO.Audio
         protected override byte[] GetBuffer()
         {
             return m_WaveBuffer;
+        }
+
+        protected override void BeforePlay()
+        {
+            m_Playing = true;
+        }
+
+        protected override void AfterStop()
+        {
+            m_Playing = false;
         }
     }
 }


### PR DESCRIPTION
There's something annoying about changing Sound options in the current ClassicUO release.

When you change volume, for example, it will only work for new sound effects that aren't currently playing. I fixed it so it changes the volume of the sounds that are playing currently. That's also the case for disabling sound and also background sound play.