### PR TITLE
New option SkipEmptyCorpse

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -173,6 +173,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool AutoOpenCorpses { get; set; }
         [JsonProperty] public int AutoOpenCorpseRange { get; set; } = 2;
         [JsonProperty] public int CorpseOpenOptions { get; set; } = 3;
+        [JsonProperty] public bool SkipEmptyCorpse { get; set; }
         [JsonProperty] public bool DisableDefaultHotkeys { get; set; }
         [JsonProperty] public bool DisableArrowBtn { get; set; }
         [JsonProperty] public bool DisableTabBtn { get; set; }

--- a/src/Game/GameActions.cs
+++ b/src/Game/GameActions.cs
@@ -75,6 +75,19 @@ namespace ClassicUO.Game
             DoubleClick(serial | 0x80000000);
         }
 
+        public static bool OpenCorpse(Serial serial)
+        {
+            if (!serial.IsItem) return false;
+
+            Item item = World.Items.Get(serial);
+            if (item == null || !item.IsCorpse || item.IsDestroyed) return false;
+
+            World.Player.ManualOpenedCorpses.Add(serial);
+            DoubleClick(serial);
+
+            return true;
+        }
+
         public static void Attack(Serial serial)
         {
             if (ProfileManager.Current.EnabledCriminalActionQuery)

--- a/src/Game/GameObjects/PlayerMobile.cs
+++ b/src/Game/GameObjects/PlayerMobile.cs
@@ -1271,9 +1271,9 @@ namespace ClassicUO.Game.GameObjects
                 if ((ProfileManager.Current.CorpseOpenOptions == 2 || ProfileManager.Current.CorpseOpenOptions == 3) && IsHidden)
                     return;
 
-                foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && !OpenedCorpses.Contains(t.Serial) && t.Distance <= ProfileManager.Current.AutoOpenCorpseRange))
+                foreach (var c in World.Items.Where(t => t.Graphic == 0x2006 && !AutoOpenedCorpses.Contains(t.Serial) && t.Distance <= ProfileManager.Current.AutoOpenCorpseRange))
                 {
-                    OpenedCorpses.Add(c.Serial);
+                    AutoOpenedCorpses.Add(c.Serial);
                     GameActions.DoubleClickQueued(c.Serial);
                 }
             }
@@ -1864,7 +1864,8 @@ namespace ClassicUO.Game.GameObjects
                    || type >= 0x9B3C && type <= 0x9B4B;
         }
 
-        private readonly HashSet<Serial> OpenedCorpses = new HashSet<Serial>();
+        public readonly HashSet<Serial> AutoOpenedCorpses = new HashSet<Serial>();
+        public readonly HashSet<Serial> ManualOpenedCorpses = new HashSet<Serial>();
 #if JAEDAN_MOVEMENT_PATCH
         public override void ForcePosition(ushort x, ushort y, sbyte z, Direction dir)
         {

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -526,7 +526,8 @@ namespace ClassicUO.Game.Scenes
             {
                 case Item item:
                     result = true;
-                    GameActions.DoubleClick(item);
+                    if (!GameActions.OpenCorpse(item))
+                        GameActions.DoubleClick(item);
 
                     break;
 

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -45,6 +45,8 @@ namespace ClassicUO.Game.UI.Gumps
         private HitBox _iconizerArea;
         internal override HitBox IconizerArea => _iconizerArea;
         private long _corpseEyeTicks;
+        private int _hadItems;
+        private bool _hideIfEmpty;
         private ContainerData _data;
         private int _eyeCorspeOffset;
         private GumpPic _eyeGumpPic;
@@ -120,6 +122,15 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (_isCorspeContainer)
             {
+                if (World.Player.ManualOpenedCorpses.Contains(LocalSerial))
+                    World.Player.ManualOpenedCorpses.Remove(LocalSerial);
+                else if(World.Player.AutoOpenedCorpses.Contains(LocalSerial) &&
+                ProfileManager.Current != null && ProfileManager.Current.SkipEmptyCorpse)
+                {
+                    IsVisible = false;
+                    _hideIfEmpty = true;
+                }
+
                 _eyeGumpPic?.Dispose();
                 Add(_eyeGumpPic = new GumpPic((int) (45 * scale), (int) (30 * scale), 0x0045, 0));
 
@@ -268,6 +279,10 @@ namespace ClassicUO.Game.UI.Gumps
                     itemControl.Height = (int)(itemControl.Height * scale);
                 }
 
+                if (_hideIfEmpty && !IsVisible)
+                    IsVisible = true;
+
+                _hadItems++;
                 Add(itemControl);
             }
         }

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -45,7 +45,6 @@ namespace ClassicUO.Game.UI.Gumps
         private HitBox _iconizerArea;
         internal override HitBox IconizerArea => _iconizerArea;
         private long _corpseEyeTicks;
-        private int _hadItems;
         private bool _hideIfEmpty;
         private ContainerData _data;
         private int _eyeCorspeOffset;
@@ -282,7 +281,6 @@ namespace ClassicUO.Game.UI.Gumps
                 if (_hideIfEmpty && !IsVisible)
                     IsVisible = true;
 
-                _hadItems++;
                 Add(itemControl);
             }
         }

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -194,7 +194,7 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     if (World.Player.InWarMode)
                         GameActions.Attack(entity);
-                    else
+                    else if (!GameActions.OpenCorpse(entity))
                         GameActions.DoubleClick(entity);
                 }
                 else

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -219,8 +219,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (World.Player.InWarMode && Entity is Mobile)
                     GameActions.Attack(Entity);
-                else
-                    GameActions.DoubleClick(Entity);
+                else if (!GameActions.OpenCorpse(Entity))
+                        GameActions.DoubleClick(Entity);
             }
 
             return true;

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -220,7 +220,7 @@ namespace ClassicUO.Game.UI.Gumps
                 if (World.Player.InWarMode && Entity is Mobile)
                     GameActions.Attack(Entity);
                 else if (!GameActions.OpenCorpse(Entity))
-                        GameActions.DoubleClick(Entity);
+                    GameActions.DoubleClick(Entity);
             }
 
             return true;

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -67,7 +67,7 @@ namespace ClassicUO.Game.UI.Gumps
         private TextBox _rows, _columns, _highlightAmount, _abbreviatedAmount;
 
         //experimental
-        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _skipEmptyCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG;
         private Combobox _overrideContainerLocationSetting;
 
         // sounds
@@ -1103,10 +1103,18 @@ namespace ClassicUO.Game.UI.Gumps
             _autoOpenCorpse = CreateCheckBox(rightArea, "Auto Open Corpses", ProfileManager.Current.AutoOpenCorpses, 0, 5);
             _autoOpenCorpse.ValueChanged += (sender, e) => { _autoOpenCorpseArea.IsVisible = _autoOpenCorpse.IsChecked; };
 
-            _autoOpenCorpseRange = CreateInputField(_autoOpenCorpseArea, new TextBox(FONT, 2, 80, 80)
+           _skipEmptyCorpse = new Checkbox(0x00D2, 0x00D3, "Skip empty corpses", FONT, HUE_FONT)
             {
                 X = 20,
                 Y = _cellSize.Y + _cellSize.Height - 15,
+                IsChecked = ProfileManager.Current.SkipEmptyCorpse
+            };
+            _autoOpenCorpseArea.Add(_skipEmptyCorpse);
+
+            _autoOpenCorpseRange = CreateInputField(_autoOpenCorpseArea, new TextBox(FONT, 2, 80, 80)
+            {
+                X = 25,
+                Y = _skipEmptyCorpse.Y + _skipEmptyCorpse.Height,
                 Width = 50,
                 Height = 30,
                 NumericOnly = true,
@@ -1125,8 +1133,8 @@ namespace ClassicUO.Game.UI.Gumps
             };*/
             var text = new Label("Corpse Open Options:", true, HUE_FONT)
             {
-                Y = _autoOpenCorpseRange.Y + 30,
-                X = 10
+                Y = _autoOpenCorpseRange.Y + 20,
+                X = 20
             };
             _autoOpenCorpseArea.Add(text);
 
@@ -1542,7 +1550,9 @@ namespace ClassicUO.Game.UI.Gumps
                     _showTargetRangeIndicator.IsChecked = false;
                     _customBars.IsChecked = false;
                     _customBarsBBG.IsChecked = false;
-
+                    _autoOpenCorpse.IsChecked = false;
+                    _skipEmptyCorpse.IsChecked = false;
+                    
                     break;
 
                 case 11:
@@ -1941,6 +1951,7 @@ namespace ClassicUO.Game.UI.Gumps
             ProfileManager.Current.AutoOpenCorpses = _autoOpenCorpse.IsChecked;
             ProfileManager.Current.AutoOpenCorpseRange = int.Parse(_autoOpenCorpseRange.Text);
             ProfileManager.Current.CorpseOpenOptions = _autoOpenCorpseOptions.SelectedIndex;
+            ProfileManager.Current.SkipEmptyCorpse = _skipEmptyCorpse.IsChecked;
 
             ProfileManager.Current.EnableDragSelect = _enableDragSelect.IsChecked;
             ProfileManager.Current.DragSelectModifierKey = _dragSelectModifierKey.SelectedIndex;


### PR DESCRIPTION
Added the option "Skip empty corpses" as a sub-option for "Auto Open Corpses".
This will make it so that "Auto Open Corpses" never opens any empty corpses.

![ClassicUO_2019-10-28_18-51-20](https://user-images.githubusercontent.com/1727541/67703586-f6683f00-f9b3-11e9-964e-f3787c247d46.png)

I've updated the way this works to make it more secure.
Basically; if a corpse is opened by the auto open corpse feature, the gump will be invisible until the server sends its content.
If no content is ever sent; the gump will instead close when the player walks away, or the corpse no longer exists.
That means that there's no risk of ever having the corpse container close before the server has had time to send the containing items.