### PR TITLE
Invisible and Disabled gumps no longer grab any kind of input

### DIFF
--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -1013,7 +1013,7 @@ namespace ClassicUO.Game.Managers
 
             foreach (Control c in Gumps)
             {
-                if (ismodal && !c.ControlInfo.IsModal)
+                if (ismodal && !c.ControlInfo.IsModal || !c.IsVisible || !c.IsEnabled)
                 {
                     continue;
                 }


### PR DESCRIPTION
A simple fix for for disabled or invisible gumps grabbing input.
Nothing the user can't interact with should in any way grab input or block clicking.