### PR TITLE
Adds 6-7 character slot support on the 5.x clients

### DIFF
--- a/src/Game/UI/Gumps/Login/CharacterSelectionGump.cs
+++ b/src/Game/UI/Gumps/Login/CharacterSelectionGump.cs
@@ -50,15 +50,16 @@ namespace ClassicUO.Game.UI.Gumps.Login
             int yBonus = 0;
             int listTitleY = 106;
 
-            if (FileManager.ClientVersion >= ClientVersions.CV_6040)
+            LoginScene loginScene = CUOEnviroment.Client.GetScene<LoginScene>();
+            var lastSelected = loginScene.Characters.FirstOrDefault(o => o == Settings.GlobalSettings.LastCharacterName);
+
+            if ((FileManager.ClientVersion >= ClientVersions.CV_6040) ||
+                (FileManager.ClientVersion >= ClientVersions.CV_5020 && loginScene.Characters.Length > 5))
             {
                 listTitleY = 96;
                 yOffset = 125;
                 yBonus = 45;
             }
-
-            LoginScene loginScene = CUOEnviroment.Client.GetScene<LoginScene>();
-            var lastSelected = loginScene.Characters.FirstOrDefault(o => o == Settings.GlobalSettings.LastCharacterName);
 
             if (!string.IsNullOrEmpty(lastSelected))
                 _selectedCharacter = (uint) Array.IndexOf(loginScene.Characters, lastSelected);


### PR DESCRIPTION
The 5.x OSI client doesn't support more than 5 slots.  This will expand the gump like seen on newer versions if the account has more than 5 characters. 

Example of how it looks

![image](https://user-images.githubusercontent.com/577652/68998077-213b0a00-0873-11ea-8bc1-44b20c55fdf5.png)
