### PR TITLE
New option AutoLootGold

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -174,6 +174,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public int AutoOpenCorpseRange { get; set; } = 2;
         [JsonProperty] public int CorpseOpenOptions { get; set; } = 3;
         [JsonProperty] public bool SkipEmptyCorpse { get; set; }
+        [JsonProperty] public bool AutoLootGold { get; set; }
         [JsonProperty] public bool DisableDefaultHotkeys { get; set; }
         [JsonProperty] public bool DisableArrowBtn { get; set; }
         [JsonProperty] public bool DisableTabBtn { get; set; }

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -67,7 +67,7 @@ namespace ClassicUO.Game.UI.Gumps
         private TextBox _rows, _columns, _highlightAmount, _abbreviatedAmount;
 
         //experimental
-        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _skipEmptyCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _skipEmptyCorpse, _autoLootGold, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG;
         private Combobox _overrideContainerLocationSetting;
 
         // sounds
@@ -1149,6 +1149,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             rightArea.Add(_autoOpenCorpseArea);
 
+           _autoLootGold = CreateCheckBox(rightArea, "Auto loot gold from corpses", ProfileManager.Current.AutoLootGold, 0, 0);
+
             // [BLOCK] disable hotkeys
             {
                 _disableDefaultHotkeys = new Checkbox(0x00D2, 0x00D3, "Disable default UO hotkeys", FONT, HUE_FONT)
@@ -1552,7 +1554,8 @@ namespace ClassicUO.Game.UI.Gumps
                     _customBarsBBG.IsChecked = false;
                     _autoOpenCorpse.IsChecked = false;
                     _skipEmptyCorpse.IsChecked = false;
-                    
+                    _autoLootGold.IsChecked = false;
+
                     break;
 
                 case 11:
@@ -1952,6 +1955,7 @@ namespace ClassicUO.Game.UI.Gumps
             ProfileManager.Current.AutoOpenCorpseRange = int.Parse(_autoOpenCorpseRange.Text);
             ProfileManager.Current.CorpseOpenOptions = _autoOpenCorpseOptions.SelectedIndex;
             ProfileManager.Current.SkipEmptyCorpse = _skipEmptyCorpse.IsChecked;
+            ProfileManager.Current.AutoLootGold = _autoLootGold.IsChecked;
 
             ProfileManager.Current.EnableDragSelect = _enableDragSelect.IsChecked;
             ProfileManager.Current.DragSelectModifierKey = _dragSelectModifierKey.SelectedIndex;


### PR DESCRIPTION
This PR might be a bit controversial, but I figured I'd share it anyway.
It adds a new experimental option called "Auto loot gold from corpses".
![ClassicUO_2019-11-17_23-35-15](https://user-images.githubusercontent.com/1727541/69015316-0495f380-0993-11ea-8059-eb26eddd12ff.png)
It will automatically loot any gold found in any corpse container you've opened and place the gold into your grab bag. It does _not_ require "Auto open corpses" to be enabled to function.

![2019-11-17_23-31-08](https://user-images.githubusercontent.com/1727541/69015349-40c95400-0993-11ea-85ad-1dbe37761fdd.gif)
