### PR TITLE
Animations: Fix frame interval calculations

### DIFF
--- a/src/Game/Constants.cs
+++ b/src/Game/Constants.cs
@@ -44,7 +44,7 @@ namespace ClassicUO.Game
         public const int LOGIN_SCREEN_FPS = 60;
 
         public const int CHARACTER_ANIMATION_DELAY = 80;
-        public const int ITEM_EFFECT_ANIMATION_DELAY = 50;
+        public const int ITEM_EFFECT_ANIMATION_DELAY = 80;
 
         public const int MAX_STEP_COUNT = 5;
         public const int TURN_DELAY = 80; // original client 12.5 fps = 80ms delay

--- a/src/Game/GameObjects/AnimatedItemEffect.cs
+++ b/src/Game/GameObjects/AnimatedItemEffect.cs
@@ -3,9 +3,9 @@
 //  Copyright (C) 2019 ClassicUO Development Community on Github
 //
 //	This project is an alternative client for the game Ultima Online.
-//	The goal of this is to develop a lightweight client considering 
-//	new technologies.  
-//      
+//	The goal of this is to develop a lightweight client considering
+//	new technologies.
+//
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
@@ -30,17 +30,8 @@ namespace ClassicUO.Game.GameObjects
             Graphic = graphic;
             Hue = hue;
             Duration = duration > 0 ? Time.Ticks + duration : -1;
-            Speed = speed;
             Load();
-        }
-
-        public AnimatedItemEffect(GameObject source, ushort graphic, ushort hue, int duration, int speed) : this(graphic, hue, duration, speed)
-        {
-            SetSource(source);
-        }
-
-        public AnimatedItemEffect(uint source, ushort graphic, ushort hue, int duration, int speed) : this(source, 0, 0, 0, graphic, hue, duration, speed)
-        {
+            IntervalInMs = (speed + 1) * Constants.ITEM_EFFECT_ANIMATION_DELAY;
         }
 
         public AnimatedItemEffect(int sourceX, int sourceY, int sourceZ, ushort graphic, ushort hue, int duration, int speed) : this(graphic, hue, duration, speed)

--- a/src/Game/GameObjects/GameEffect.cs
+++ b/src/Game/GameObjects/GameEffect.cs
@@ -52,9 +52,9 @@ namespace ClassicUO.Game.GameObjects
 
         protected int TargetZ;
 
-        public int Speed;
+        public int IntervalInMs;
 
-        public long LastChangeFrameTime;
+        public long NextChangeFrameTime;
 
         public bool IsEnabled;
 
@@ -71,7 +71,7 @@ namespace ClassicUO.Game.GameObjects
             AnimDataFrame = UOFileManager.AnimData.CalculateCurrentGraphic(Graphic);
             IsEnabled = true;
             AnimIndex = 0;
-            Speed += AnimDataFrame.FrameInterval != 0 ? AnimDataFrame.FrameInterval * Constants.ITEM_EFFECT_ANIMATION_DELAY : Constants.ITEM_EFFECT_ANIMATION_DELAY;
+            IntervalInMs = (AnimDataFrame.FrameInterval + 1) * Constants.ITEM_EFFECT_ANIMATION_DELAY;
         }
 
         public override void Update(double totalMS, double frameMS)
@@ -107,7 +107,7 @@ namespace ClassicUO.Game.GameObjects
                 //    _start += frameMS;
                 //}
 
-                else if (LastChangeFrameTime < totalMS)
+                else if (NextChangeFrameTime < totalMS)
                 {
 
                     if (AnimDataFrame.FrameCount != 0)
@@ -128,7 +128,7 @@ namespace ClassicUO.Game.GameObjects
                             AnimationGraphic = Graphic;
                     }
 
-                    LastChangeFrameTime = (long) totalMS + Speed;
+                    NextChangeFrameTime = (long) totalMS + IntervalInMs;
                 }
             }
             else if (Graphic != AnimationGraphic)

--- a/src/Game/GameObjects/Item.cs
+++ b/src/Game/GameObjects/Item.cs
@@ -302,7 +302,7 @@ namespace ClassicUO.Game.GameObjects
 
                                 if (animData->FrameCount != 0)
                                 {
-                                    _animSpeed = animData->FrameInterval != 0 ? animData->FrameInterval * 25 + Constants.ITEM_EFFECT_ANIMATION_DELAY : Constants.ITEM_EFFECT_ANIMATION_DELAY;
+                                    _animSpeed = (animData->FrameInterval + 1) * Constants.ITEM_EFFECT_ANIMATION_DELAY;
                                 }
                             }
                         }

--- a/src/Game/GameObjects/LightningEffect.cs
+++ b/src/Game/GameObjects/LightningEffect.cs
@@ -30,7 +30,7 @@ namespace ClassicUO.Game.GameObjects
             Graphic = 0x4E20;
             Hue = hue;
             IsEnabled = true;
-            Speed = Constants.ITEM_EFFECT_ANIMATION_DELAY;
+            IntervalInMs = Constants.ITEM_EFFECT_ANIMATION_DELAY;
             AnimIndex = 0;
         }
 
@@ -67,10 +67,10 @@ namespace ClassicUO.Game.GameObjects
                 {
                     AnimationGraphic = (ushort) (Graphic + AnimIndex);
 
-                    if (LastChangeFrameTime < totalMS)
+                    if (NextChangeFrameTime < totalMS)
                     {
                         AnimIndex++;
-                        LastChangeFrameTime = (long) totalMS + Speed;
+                        NextChangeFrameTime = (long) totalMS + IntervalInMs;
                     }
 
                     (int x, int y, int z) = GetSource();

--- a/src/Game/GameObjects/Views/MultiView.cs
+++ b/src/Game/GameObjects/Views/MultiView.cs
@@ -103,8 +103,7 @@ namespace ClassicUO.Game.GameObjects
                             if (AnimIndex >= animData->FrameCount)
                                 AnimIndex = 0;
 
-                            _lastAnimationFrameTime = Time.Ticks + (uint)(animData->FrameInterval != 0 ?
-                                                          animData->FrameInterval * Constants.ITEM_EFFECT_ANIMATION_DELAY + 25 : Constants.ITEM_EFFECT_ANIMATION_DELAY);
+                            _lastAnimationFrameTime = Time.Ticks + (uint)((animData->FrameInterval + 1) * Constants.ITEM_EFFECT_ANIMATION_DELAY);
                         }
                     }
                 }

--- a/src/Game/GameObjects/Views/StaticView.cs
+++ b/src/Game/GameObjects/Views/StaticView.cs
@@ -91,8 +91,7 @@ namespace ClassicUO.Game.GameObjects
                             if (AnimIndex >= animData->FrameCount)
                                 AnimIndex = 0;
 
-                            _lastAnimationFrameTime = Time.Ticks + (uint)(animData->FrameInterval !=  0 ?
-                                                          animData->FrameInterval * Constants.ITEM_EFFECT_ANIMATION_DELAY + 25 : Constants.ITEM_EFFECT_ANIMATION_DELAY);
+                            _lastAnimationFrameTime = Time.Ticks + (uint)((animData->FrameInterval + 1) * Constants.ITEM_EFFECT_ANIMATION_DELAY);
                         }
                     }
                 }

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -939,11 +939,11 @@ namespace ClassicUO.Network
 
             if (effect.AnimDataFrame.FrameCount != 0)
             {
-                effect.Speed = effect.AnimDataFrame.FrameInterval * 45;
+                effect.IntervalInMs = effect.AnimDataFrame.FrameInterval * 45;
             }
             else
             {
-                effect.Speed = 13;
+                effect.IntervalInMs = 13;
             }
 
             World.AddEffect(effect);


### PR DESCRIPTION
The OSI client had a fixed frame rate of 12.5 FPS, or 80ms per frame.
Most of the math was done in units of "frames", and what "speed" means
in many of the graphic effect packets is how many of these "frame" units
to go before changing over to the next frame in the animation. These
"frameInterval" values are 0 based, so a value of 0 means every frame
(80ms), a value of 1 means every other frame (160ms), etc.

ClassicUO supports a variable framerate, so it needs to convert all of
these values to clock times. The formula for that is simple:

(frameInterval + 1) * 80