### PR TITLE
Added experimental option to save gumps locations (will restore desktop layout correctly)

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -187,6 +187,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool OverrideContainerLocation { get; set; }
         [JsonProperty] public int OverrideContainerLocationSetting { get; set; } // 0 = container position, 1 = top right of screen, 2 = last dragged position
         [JsonProperty] public Point OverrideContainerLocationPosition { get; set; } = new Point(200, 200);
+        [JsonProperty] public bool SaveContainerLocations { get; set; }
         [JsonProperty] public bool DragSelectHumanoidsOnly { get; set; }
         [JsonProperty] public NameOverheadTypeAllowed NameOverheadTypeAllowed { get; set; } = NameOverheadTypeAllowed.All;
         [JsonProperty] public bool NameOverheadToggled { get; set; } = false;
@@ -197,7 +198,7 @@ namespace ClassicUO.Configuration
 
         [JsonProperty] public bool ShowInfoBar { get; set; }
         [JsonProperty] public int InfoBarHighlightType { get; set; } // 0 = text colour changes, 1 = underline
-      
+
 
         [JsonProperty]
         public InfoBarItem[] InfoBarItems { get; set; }// [FILE_FIX] TODO: REMOVE IT
@@ -371,7 +372,7 @@ namespace ClassicUO.Configuration
                     Log.Error( e.StackTrace);
                 }
 
-               
+
                 SkillsGroupManager.Save();
 
                 try
@@ -588,7 +589,7 @@ namespace ClassicUO.Configuration
                 }
             }
 
-          
+
             // load anchors
             string anchorsPath = Path.Combine(path, "anchors.bin");
 

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -72,8 +72,8 @@ namespace ClassicUO.Game.UI.Gumps
                 c.Dispose();
 
             foreach (Item i in item.Items.Where(s => s != null && s.IsLootable))
-                //FIXME: this should be disabled. Server sends the right position
-                //CheckItemPosition(i);
+            //FIXME: this should be disabled. Server sends the right position
+            //CheckItemPosition(i);
             {
                 var x = new ItemGump(i);
                 Add(x);
@@ -119,7 +119,7 @@ namespace ClassicUO.Game.UI.Gumps
             WantUpdateSize = false;
             _isCorspeContainer = Graphic == 0x0009;
 
-          
+
             Item item = World.Items.Get(LocalSerial);
 
             if (item == null)
@@ -174,7 +174,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (gg == null)
             {
-                if (UIManager.GetGumpCachePosition(LocalSerial, out Point location) && item.Serial == World.Player.Equipment[(int) Layer.Backpack])
+                if (UIManager.GetGumpCachePosition(LocalSerial, out Point location) && (item.Serial == World.Player.Equipment[(int)Layer.Backpack] || ProfileManager.Current.SaveContainerLocations))
                     Location = location;
                 else
                 {
@@ -269,7 +269,7 @@ namespace ClassicUO.Game.UI.Gumps
             IsMinimized = IsMinimized;
             ItemsOnAdded(null, new CollectionChangedEventArgs<uint>(FindControls<ItemGump>().Select(s => s.LocalSerial)));
         }
-        
+
         public override void Save(BinaryWriter writer)
         {
             base.Save(writer);
@@ -316,7 +316,7 @@ namespace ClassicUO.Game.UI.Gumps
             Dispose();
         }
 
-      
+
         private void ItemsOnRemoved(object sender, CollectionChangedEventArgs<uint> e)
         {
             foreach (ItemGump v in Children.OfType<ItemGump>().Where(s => e.Contains(s.LocalSerial)))
@@ -355,7 +355,7 @@ namespace ClassicUO.Game.UI.Gumps
                 Add(itemControl);
             }
         }
-    
+
 
         private void CheckItemControlPosition(ItemGump itemGump, Item item)
         {
@@ -363,7 +363,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             int x = (int) (itemGump.X * scale);
             int y = (int) (itemGump.Y * scale);
-          
+
             ArtTexture texture = ArtLoader.Instance.GetTexture(item.DisplayedGraphic);
 
             int boundX = (int)(_data.Bounds.X * scale);
@@ -486,7 +486,7 @@ namespace ClassicUO.Game.UI.Gumps
                 item.Items.Added -= ItemsOnAdded;
                 item.Items.Removed -= ItemsOnRemoved;
 
-                if (World.Player != null && item == World.Player.Equipment[(int) Layer.Backpack]) UIManager.SavePosition(item, Location);
+                if (World.Player != null && (item == World.Player.Equipment[(int)Layer.Backpack] || (ProfileManager.Current?.SaveContainerLocations ?? false))) UIManager.SavePosition(item, Location);
 
                 foreach (Item child in item.Items)
                 {

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -67,7 +67,7 @@ namespace ClassicUO.Game.UI.Gumps
         private TextBox _rows, _columns, _highlightAmount, _abbreviatedAmount;
 
         //experimental
-        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _skipEmptyCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _disableAutoMove, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG, _saveHealthbars;
+        private Checkbox _enableSelectionArea, _debugGumpIsDisabled, _restoreLastGameSize, _autoOpenDoors, _autoOpenCorpse, _skipEmptyCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _disableAutoMove, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG, _saveHealthbars, _saveContainerLocations;
         private Combobox _overrideContainerLocationSetting;
 
         // sounds
@@ -1279,6 +1279,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             rightArea.Add(_containerGumpLocation);
 
+            _saveContainerLocations = CreateCheckBox(rightArea, "Save container gumps locations", ProfileManager.Current.SaveContainerLocations, 0, 5);
+
             _showTargetRangeIndicator = new Checkbox(0x00D2, 0x00D3, "Show target range indicator", FONT, HUE_FONT, true)
             {
                 IsChecked = ProfileManager.Current.ShowTargetRangeIndicator,
@@ -1599,6 +1601,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _enableDragSelect.IsChecked = false;
                     _overrideContainerLocation.IsChecked = false;
                     _overrideContainerLocationSetting.SelectedIndex = 0;
+                    _saveContainerLocations.IsChecked = false;
                     _dragSelectHumanoidsOnly.IsChecked = false;
                     _showTargetRangeIndicator.IsChecked = false;
                     _customBars.IsChecked = false;
@@ -2029,6 +2032,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             ProfileManager.Current.OverrideContainerLocation = _overrideContainerLocation.IsChecked;
             ProfileManager.Current.OverrideContainerLocationSetting = _overrideContainerLocationSetting.SelectedIndex;
+            ProfileManager.Current.SaveContainerLocations = _saveContainerLocations.IsChecked;
 
             ProfileManager.Current.ShowTargetRangeIndicator = _showTargetRangeIndicator.IsChecked;
 


### PR DESCRIPTION
Makes sure gumps saved in gumps.xml at closing time will get restored at logon. Container gumps locations will be cached on Dispose(), so locations will be remembered within a session, taking precedence over experimental override option. If gump is not cached yet (unknown to the client, i.e. opened for the first time withinin a session), location will be as before (will follow the experimental override setting if enabled -near container, top right or last dragged-, otherwise will use cascade default behaviour).