### PR TITLE
container gumps now better match override option

### DIFF
--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -337,6 +337,11 @@ namespace ClassicUO.Game.Managers
             _gumpPositionCache[serverSerial] = point;
         }
 
+        public static bool RemovePosition(uint serverSerial)
+        {
+            return _gumpPositionCache.Remove(serverSerial);
+        }
+
         public static bool GetGumpCachePosition(uint id, out Point pos)
         {
             return _gumpPositionCache.TryGetValue(id, out pos);

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -512,5 +512,11 @@ namespace ClassicUO.Game.UI.Gumps
 
             base.OnDragEnd(x, y);
         }
+        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        {            
+            UIManager.RemovePosition(LocalSerial);
+            return IsVisible && base.Draw(batcher, x, y);
+        }
+
     }
 }


### PR DESCRIPTION
container gumps locations will be loaded from gumps.xml on login, but gumps location will no longer be remembered after gumps are closed when "remember every gump" is not selected