### PR TITLE
Protocol Extensions behind settings

### DIFF
--- a/src/Configuration/Settings.cs
+++ b/src/Configuration/Settings.cs
@@ -103,7 +103,8 @@ namespace ClassicUO.Configuration
         [JsonProperty(PropertyName = "plugins")]
         public string[] Plugins { get; set; } = {@"./Assistant/Razor.dll"};
 
-
+        [JsonProperty(PropertyName = "ProtocolExtensions")]
+        public bool ProtocolExtensions { get; set; } = true;
 
 
         public const string SETTINGS_FILENAME = "settings.json";

--- a/src/Configuration/Settings.cs
+++ b/src/Configuration/Settings.cs
@@ -103,7 +103,7 @@ namespace ClassicUO.Configuration
         [JsonProperty(PropertyName = "plugins")]
         public string[] Plugins { get; set; } = {@"./Assistant/Razor.dll"};
 
-        [JsonProperty(PropertyName = "ProtocolExtensions")]
+        [JsonProperty(PropertyName = "protocol_extensions")]
         public bool ProtocolExtensions { get; set; } = true;
 
 

--- a/src/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/Game/UI/Gumps/WorldMapGump.cs
@@ -20,8 +20,10 @@
 #endregion
 
 using System;
+using System.Net;
 using System.Threading.Tasks;
 using System.Xml;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
@@ -233,7 +235,7 @@ namespace ClassicUO.Game.UI.Gumps
                 Load();
             }
 
-            if (World.InGame && _nextQueryPacket < Time.Ticks)
+            if (World.InGame && _nextQueryPacket < Time.Ticks  && Settings.GlobalSettings.ProtocolExtensions)
             {
                 _nextQueryPacket = Time.Ticks + 250;
 
@@ -249,6 +251,7 @@ namespace ClassicUO.Game.UI.Gumps
                 //        }
                 //    }
                 //}
+
 
                 NetClient.Socket.Send(new PQueryGuildPosition());
 


### PR DESCRIPTION
Moves the use of these server specific custom packets behind a Settings.json, to allow Sphere/POL players to play without flooding their server consoles with unhanded packets.
