### PR TITLE
Fixes vendor buy/sell gumps having blank names and being reversed under certain conditions

### DIFF
--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -2076,13 +2076,10 @@ namespace ClassicUO.Network
             {
                 byte count = p.ReadByte();
 
-                var list = container.Items /*.OrderBy(s => s.Serial.Value)*/.ToArray();
+                var list = container.Items /*.OrderBy(s => s.Serial.Value)*/.Reverse().ToArray();
 
                 if (list.Length == 0)
                     return;
-
-                if (list[0].X > 1)
-                    list = list.Reverse().ToArray();
 
 
                 foreach (Item it in list.Take(count))
@@ -2096,6 +2093,14 @@ namespace ClassicUO.Network
                     {
                         it.Name = ClilocLoader.Instance.GetString(cliloc);
                         fromcliloc = true;
+                    }
+                    else if (string.IsNullOrEmpty(name))
+                    {
+                        bool success = World.OPL.TryGetNameAndData(it.Serial, out it.Name, out _);
+                        if (!success)
+                        {
+                            it.Name = it.ItemData.Name;
+                        }
                     }
                     else if (string.IsNullOrEmpty(it.Name))
                         it.Name = name;
@@ -2612,6 +2617,14 @@ namespace ClassicUO.Network
                 {
                     name = ClilocLoader.Instance.GetString(clilocnum);
                     fromcliloc = true;
+                }
+                else if (string.IsNullOrEmpty(name))
+                {
+                    bool success = World.OPL.TryGetNameAndData(serial, out name, out _);
+                    if (!success)
+                    {
+                        name = TileDataLoader.Instance.StaticData[graphic].Name;
+                    }
                 }
 
                 //if (string.IsNullOrEmpty(item.Name))

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -2102,7 +2102,7 @@ namespace ClassicUO.Network
                             it.Name = it.ItemData.Name;
                         }
                     }
-                    else if (string.IsNullOrEmpty(it.Name))
+                    if (string.IsNullOrEmpty(it.Name))
                         it.Name = name;
 
                     gump.SetIfNameIsFromCliloc(it, fromcliloc);


### PR DESCRIPTION
Fixes #956 

A server I play on sends names for items vendors sell in `0xD6` MegaCliloc packets right before the `0x3C` and `0x74` packets which open the vendor buy gump, with the item names in the `0x74` packet being blank. Under the original client, the names of items thusly sent would be displayed on the vendor gump. ClassicUO would attempt to instead display the blank names contained in the `0x74` packet.

This PR makes ClassicUO look in `World.OPL` (which is where the data from MegaCliloc packets seem to be stored) for the item's name if the name contained in the `0x74` packet is empty. If that fails, it falls back to the item's base name in `tiledata.mul` (which is also original client behaviour).

Additionally, on servers that sent zeroes for item X coordinates in the `0x74` packet, the contents of the vendor buy gump would not get properly reversed, and the first item on the list would display the price of the last item, the second item the price of the 2nd-to-last one, and so forth. This also fixes that; I am not sure if this issue was deliberate, because as things stood the list was only reversed if the X coordinate of the 1st element was non-zero. However, I tested this on the problematic server, and a freshly installed POL server, and OutlandsUO, and all three of them functioned fine with this change.

