### PR TITLE
Fix Limit3Spell MessageTypes not displaying overhead text.

### DIFF
--- a/src/Game/Managers/MessageManager.cs
+++ b/src/Game/Managers/MessageManager.cs
@@ -115,6 +115,7 @@ namespace ClassicUO.Game.Managers
                 case MessageType.Yell:
                 case MessageType.Regular:
                 case MessageType.Label:
+                case MessageType.Limit3Spell:
 
                     if (parent == null)
                         break;

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -225,6 +225,7 @@ namespace ClassicUO.Game.Scenes
             switch (e.Type)
             {
                 case MessageType.Regular:
+                case MessageType.Limit3Spell:
 
                     if (e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial))
                         name = "System";


### PR DESCRIPTION
Fixes #957 

Some Sphere (and in this case, POL) shards use MessageType 3 for some overhead text. This has no handling in GameScene.cs, so currently this text only appears in the journal.

MessageType.cs has the following comment attached to the type:

`// Sphere style shards use this to limit to 3 of these message types showing overhead.`

This suggests that only 3 of these messages are supposed to be visible at any one time. However, in my testing with the original client, an arbitrary number of these messages could be visible so long as they came from different sources (eg. on different items in your backpack). For any single given item only 3 of these messages could ever be visible at a time, but that seems to apply to *all* overhead text in the old client.

In other words, I did not observe any special behaviour for this MessageType on the original client. For that reason I'm submitting this bandaid fix of simply treating this MessageType the same as the regular text MessageType (`0x00`).