### PR TITLE
Fixes vendor gump uint to ushort cast leading to integer overflow

### DIFF
--- a/src/Game/UI/Gumps/ShopGump.cs
+++ b/src/Game/UI/Gumps/ShopGump.cs
@@ -223,7 +223,7 @@ namespace ClassicUO.Game.UI.Gumps
             if (_shopItems.TryGetValue(it, out var shopItem)) shopItem.NameFromCliloc = fromcliloc;
         }
 
-        public void AddItem(uint serial, ushort graphic, ushort hue, ushort amount, ushort price, string name, bool fromcliloc)
+        public void AddItem(uint serial, ushort graphic, ushort hue, ushort amount, uint price, string name, bool fromcliloc)
         {
             ShopItem shopItem;
 
@@ -442,7 +442,7 @@ namespace ClassicUO.Game.UI.Gumps
                 return direction;
             }
 
-            public ShopItem(uint serial, ushort graphic, ushort hue, int count, int price, string name)
+            public ShopItem(uint serial, ushort graphic, ushort hue, int count, uint price, string name)
             {
                 LocalSerial = serial;
                 Graphic = graphic;
@@ -552,7 +552,7 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
-            public int Price { get; set; }
+            public uint Price { get; set; }
             public ushort Hue { get; set; }
             public ushort Graphic { get; set; }
             public string Name { get; set; }

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1025,7 +1025,7 @@ namespace ClassicUO.Network
                         list = list.Reverse().ToArray();
 
                     foreach (var i in list) 
-                        gump.AddItem(i.Serial, i.Graphic, i.Hue, i.Amount, (ushort) i.Price, i.Name, false);
+                        gump.AddItem(i.Serial, i.Graphic, i.Hue, i.Amount, i.Price, i.Name, false);
                 }
             }
             else


### PR DESCRIPTION
Vendor gumps would sometimes display incorrect prices because there was an unsafe series of typecasts from uint to int to ushort. Items costing over 0xFFFF would get incorrect prices due to overflow. Presumably items costing over 0x7FFFFFFF would have ended up getting negative prices too.

This converts the price to uint across the board, because the packet the price is from (0x74) is parsed as uint in the first place.

It should be noted that what type the packet actually contains depends on the emulator. RunUO and ServUO seem to use signed int, while POL seems to use unsigned int. What OSI uses I don't know. Unsigned seems like a safe bet because vendors should never sell negative-price items.