### PR TITLE
Fix emote message asterisks

### DIFF
--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -357,17 +357,17 @@ namespace ClassicUO.Game.Managers
                 case MacroType.Yell:
                 case MacroType.RazorMacro:
 
-                    MacroObjectString mos = (MacroObjectString) macro;
+                    string text = ((MacroObjectString)macro).Text;
 
-                    if (!string.IsNullOrEmpty(mos.Text))
+                    if (!string.IsNullOrEmpty(text))
                     {
                         MessageType type = MessageType.Regular;
                         ushort hue = ProfileManager.Current.SpeechHue;
-                        string prefix = null;
 
                         switch (macro.Code)
                         {
                             case MacroType.Emote:
+                                text = "*" + text + "*";
                                 type = MessageType.Emote;
                                 hue = ProfileManager.Current.EmoteHue;
 
@@ -385,12 +385,12 @@ namespace ClassicUO.Game.Managers
                                 break;
 
                             case MacroType.RazorMacro:
-                                prefix = ">macro ";
+                                text = ">macro " + text;
 
                                 break;
                         }
 
-                        GameActions.Say(prefix + mos.Text, hue, type);
+                        GameActions.Say(text, hue, type);
                     }
 
                     break;

--- a/src/Game/Managers/MessageManager.cs
+++ b/src/Game/Managers/MessageManager.cs
@@ -179,7 +179,7 @@ namespace ClassicUO.Game.Managers
                     if (parent == null)
                         break;
 
-                    msg = CreateMessage($"*{text}*", hue, font, unicode, type);
+                    msg = CreateMessage($"{text}", hue, font, unicode, type);
 
                     parent.AddMessage(msg);
 

--- a/src/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/Game/UI/Gumps/SystemChatControl.cs
@@ -521,6 +521,7 @@ namespace ClassicUO.Game.UI.Gumps
                         break;
 
                     case ChatMode.Emote:
+                        text = "*" + text + "*";    
                         GameActions.Say(text, ProfileManager.Current.EmoteHue, MessageType.Emote);
                         break;
 


### PR DESCRIPTION
Emote messages (prefixing a line in chat with `: `) sent from CUO to official clients would not have \*asterisks\* around them. Emote messages sent from official clients to CUO would have \*\*two asterisks\*\* around them.

Sending from CUO:

![1583084462831](https://user-images.githubusercontent.com/5822375/75630811-69015980-5bf6-11ea-8c90-ac80c80e5a42.png)

Receiving in official client:

![1583084476424](https://user-images.githubusercontent.com/5822375/75630813-71599480-5bf6-11ea-8414-a28510dcfea3.png)

------

Sending in official client:

![1583084482448](https://user-images.githubusercontent.com/5822375/75630820-7ae2fc80-5bf6-11ea-9e47-e5a6f273b21a.png)

Receiving in CUO:

![1583084486454](https://user-images.githubusercontent.com/5822375/75630824-80d8dd80-5bf6-11ea-894b-9f7157c55958.png)

