### PR TITLE
Implement UpdateName/NameRequest packet 0x98

### DIFF
--- a/src/Game/GameObjects/Entity.cs
+++ b/src/Game/GameObjects/Entity.cs
@@ -24,6 +24,8 @@ using System;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Network;
+using static ClassicUO.Network.NetClient;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -108,7 +110,9 @@ namespace ClassicUO.Game.GameObjects
 
                 //if (gump == null)
                 {
+                    Socket.Send(new PNameRequest(Serial));
                     UIManager.Add(new NameOverheadGump(this));
+
                     ObjectHandlesOpened = true;
                 }
             }

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -67,7 +67,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public Entity Entity { get; }
 
-        private bool SetName()
+        public bool SetName()
         {
             if (string.IsNullOrEmpty(_renderedText.Text))
             {

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -138,6 +138,7 @@ namespace ClassicUO.Network
             Handlers.Add(0x93, OpenBook);
             Handlers.Add(0x95, DyeData);
             Handlers.Add(0x97, MovePlayer);
+            Handlers.Add(0x98, UpdateName);
             Handlers.Add(0x99, MultiPlacement);
             Handlers.Add(0x9A, ASCIIPrompt);
             Handlers.Add(0x9E, SellList);
@@ -2548,6 +2549,25 @@ namespace ClassicUO.Network
 
             Direction direction = (Direction) p.ReadByte();
             World.Player.Walk(direction & Direction.Mask, (direction & Direction.Running) != 0);
+        }
+
+        private static void UpdateName(Packet p)
+        {
+            if (!World.InGame)
+                return;
+
+            uint serial = p.ReadUInt();
+            string name = p.ReadASCII();
+
+            Entity entity = World.Get(serial);
+            if (entity == null)
+                return;
+            entity.Name = name;
+
+            NameOverheadGump gump = UIManager.GetGump<NameOverheadGump>(serial);
+            if (gump == null)
+                return;
+            gump.SetName();
         }
 
         private static void MultiPlacement(Packet p)


### PR DESCRIPTION
https://docs.polserver.com/packets/index.php?Packet=0x98

This packet is sent when the "Show all names" shortcut, Ctrl+Shift, is pressed. It's sent by the client for each entity whose nameplate (`NameOverheadGump`) is displayed. The server will respond with the serial of the entity, followed by its null-terminated name.

(Note: in the above docs it says the name is 30 bytes long; in practice through packetlogging it looks to be null-terminated)

This functionality was not implemented in CUO, so if you were standing next to a creature that got renamed, Ctrl+Shift would display their old name (even if you repeatedly press it). The outgoing packet was already implemented as `PNameRequest` but it was not being sent.

I don't know how robust this implementation is, since I'm unfamiliar with the network and interface code. Please review carefully.