### PR TITLE
Fix journal emotes having double asterisks

### DIFF
--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -243,7 +243,7 @@ namespace ClassicUO.Game.Scenes
 
                 case MessageType.Emote:
                     name = e.Name;
-                    text = $"*{e.Text}*";
+                    text = $"{e.Text}";
 
                     if (e.Hue == 0)
                         hue = ProfileManager.Current.EmoteHue;


### PR DESCRIPTION
This slipped past me in #961, causing emotes in the journal to still have double asterisks around them.