### PR TITLE
add Party members to map update

### DIFF
--- a/src/Game/World.cs
+++ b/src/Game/World.cs
@@ -197,14 +197,14 @@ namespace ClassicUO.Game
 
                     if (mob.IsDestroyed)
                         _toRemove.Add(mob);
-                    else if (mob.NotorietyFlag == NotorietyFlag.Ally)
+                    else if (mob.NotorietyFlag == NotorietyFlag.Ally || (World.Party != null && World.Party.Contains(mob.Serial)))
                         WMapManager.AddOrUpdate(
                             mob.Serial,
                             mob.X, 
                             mob.Y, 
                             Utility.MathHelper.PercetangeOf(mob.Hits, mob.HitsMax),
-                            MapIndex, 
-                            true,
+                            MapIndex,
+                            mob.NotorietyFlag == NotorietyFlag.Ally,
                             mob.Name);
                 }
 


### PR DESCRIPTION
When a party member comes within view range, [the client will no longer request location data](https://github.com/andreakarasho/ClassicUO/blob/4305a4f0c355dacb25f99fabe17c1c86eba0415f/src/Game/UI/Gumps/WorldMapGump.cs#L263) for them. This PR updates the World Map Manager's cache with party members, so they won't be removed in the subsequent call to `WMapManager.RemoveUnupdatedWEntity`.