### PR TITLE
Fix PUnicodePromptResponse null-termination

### DIFF
--- a/src/Network/Packets.cs
+++ b/src/Network/Packets.cs
@@ -726,7 +726,10 @@ namespace ClassicUO.Network
             WriteBytes(MessageManager.PromptData.Data, 0, 8);
             WriteUInt((uint) (cancel ? 0 : 1));
             WriteASCII(lang, 3);
-            WriteUnicode(text);
+            WriteUnicode(text, text.Length);
+            //This must be terminated with EXACTLY one null byte, unlike most unicode-containing packets which are terminated with two.
+            //Some servers are fussy about this and will reject the packet otherwise!
+            WriteByte(0x00);
         }
     }
 


### PR DESCRIPTION
PUnicodePromptResponse (packet `0xC2`) was terminated with two null-bytes (ie. one null unicode char). However, the official client terminates it with only one null-byte, unlike most other packets containing unicode. Some servers (old ones, mostly) are fussy about this and will reject the packet if it contains two null-bytes at the end instead of only one.


What official client sends:

```
01:47:05.3187: Client -> Server 0xC2 (Length: 37)
        0  1  2  3  4  5  6  7   8  9  A  B  C  D  E  F
       -- -- -- -- -- -- -- --  -- -- -- -- -- -- -- --
0000   C2 00 25 71 37 30 19 71  37 30 19 00 00 00 01 45   ..%q70.q70.....E
0010   4E 47 00 50 00 61 00 61  00 74 00 74 00 69 00 20   NG.P.a.a.t.t.i. 
0020   00 56 00 49 00                                     .V.I.
```

What CUO was sending:

```
01:54:02.1543: Client -> Server 0xC2 (Length: 38)
        0  1  2  3  4  5  6  7   8  9  A  B  C  D  E  F
       -- -- -- -- -- -- -- --  -- -- -- -- -- -- -- --
0000   C2 00 26 71 37 30 19 71  37 30 19 00 00 00 01 45   ..%q70.q70.....E
0010   4E 47 00 50 00 61 00 61  00 74 00 74 00 69 00 20   NG.P.a.a.t.t.i. 
0020   00 56 00 49 00 00                                  .V.I..
```