### PR TITLE
Fix PUnicodeSpeechRequest packets having too many null bytes

### DIFF
--- a/src/Network/Packets.cs
+++ b/src/Network/Packets.cs
@@ -453,7 +453,7 @@ namespace ClassicUO.Network
             }
             else
             {
-                WriteUnicode(text, 14 + text.Length * 2);
+                WriteUnicode(text);
             }
         }
     }


### PR DESCRIPTION
I do not know why this was written this way. Maybe there was a reason.

However, it's causing speech packets to have lots of null bytes at the end for seemingly no reason. Saying the line `Hep` should result in a 20-byte packet like this:

```
13:45:45.8473: Client -> Server 0xAD (Length: 20)
        0  1  2  3  4  5  6  7   8  9  A  B  C  D  E  F
       -- -- -- -- -- -- -- --  -- -- -- -- -- -- -- --
0000   AD 00 14 00 00 34 00 03  45 4E 47 00 00 48 00 65   .....4..ENG..H.e
0010   00 70 00 00                                        .p..
```

but on CUO it would instead result in a ~56 (can't remember exact length) byte packet with lots of null padding at the end.

Changing this line solves the issue and does not seem to cause any problems, though I have not tested everything.