### PR TITLE
HealthBarGump LT-Highlight

### DIFF
--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -530,7 +530,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _bars[0].IsVisible = true;
                 }
 
-                if (TargetManager.LastTarget != World.Player && !_outOfRange && !mobile != null)
+                if (TargetManager.LastTarget != World.Player && !_outOfRange && mobile != null)
                 {
                     if (mobile == TargetManager.LastTarget)
                     {

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -530,7 +530,27 @@ namespace ClassicUO.Game.UI.Gumps
                     _bars[0].IsVisible = true;
                 }
 
+                if (TargetManager.LastTarget != World.Player && !_outOfRange)
+                {
+                    if (mobile == TargetManager.LastTarget)
+                    {
+                        _border[0].LineColor = HPB_COLOR_RED;
 
+                        if (_border.Length >= 3)
+                        {
+                            _border[1].LineColor = _border[2].LineColor = _border[3].LineColor = HPB_COLOR_RED;
+                        }
+                    }
+                    else if (mobile != TargetManager.LastTarget)
+                    {
+                        _border[0].LineColor = HPB_COLOR_BLACK;
+
+                        if (_border.Length >= 3)
+                        {
+                            _border[1].LineColor = _border[2].LineColor = _border[3].LineColor = HPB_COLOR_BLACK;
+                        }
+                    }
+                }
 
                 if (mobile != null)
                 {

--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -530,7 +530,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _bars[0].IsVisible = true;
                 }
 
-                if (TargetManager.LastTarget != World.Player && !_outOfRange)
+                if (TargetManager.LastTarget != World.Player && !_outOfRange && !mobile != null)
                 {
                     if (mobile == TargetManager.LastTarget)
                     {


### PR DESCRIPTION
ClassicUO - LastTarget Highlight (Red Border)
![Syrupz-UO-LastTargetHighlight](https://user-images.githubusercontent.com/53979689/76257711-979bb780-6228-11ea-9dc8-89137e9da600.gif)

Was a small feature request by Merrit. Sounded like a proper request so I dusted off the cobwebs. This simply highlights the custom bar with a RED border(similar to tabbing into war-mode for your personal health bar). Once a mobile is set to last target, their health bar (if opened, in range, and not your own) will now have a red border around it to make identifying last target selected easier for players.