### PR TITLE
More SpriteFont sanity

### DIFF
--- a/src/Renderer/SpriteFont.cs
+++ b/src/Renderer/SpriteFont.cs
@@ -96,14 +96,17 @@ namespace ClassicUO.Renderer
                 {
                     if (!DefaultCharacter.HasValue)
                     {
-                        throw new ArgumentException(
-                                                    "Text contains characters that cannot be" +
-                                                    " resolved by this SpriteFont.",
-                                                    "text"
-                                                   );
+                        index = CharacterMap.IndexOf('?');
+                        //throw new ArgumentException(
+                        //                            "Text contains characters that cannot be" +
+                        //                            " resolved by this SpriteFont.",
+                        //                            "text"
+                        //                           );
                     }
-
-                    index = CharacterMap.IndexOf(DefaultCharacter.Value);
+                    else
+                    {
+                        index = CharacterMap.IndexOf(DefaultCharacter.Value);
+                    }
                 }
 
                 /* For the first character in a line, always push the width


### PR DESCRIPTION
#980 

@andreakarasho fixed one crash, but there was another. This should fix that one. Tested on the server the bug was on, and it didn't crash anymore. Hard to test locally because most servers don't support unicode characters in names by default.