### PR TITLE
Allows Prof.txt to support skills with spaces in it

### DIFF
--- a/src/IO/Resources/ProfessionLoader.cs
+++ b/src/IO/Resources/ProfessionLoader.cs
@@ -248,7 +248,7 @@ namespace ClassicUO.IO.Resources
                             {
                                 SkillEntry skill = SkillsLoader.Instance.Skills[j];
 
-                                if (strings[1] == skill.Name)
+                                if (strings[1].Replace('_', ' ') == skill.Name)
                                 {
                                     skillIndex[idx, 0] = j;
                                     int.TryParse(strings[2], out skillIndex[idx, 1]);


### PR DESCRIPTION
Prof.txt is used to define the templates during character creation. Skills like "Animal Taming" are not parsed correctly and the character is created without skills.

This fix adds support so if the template has "Animal_Taming" it will correctly load based on the name in SkillsLoader (in this case, "Animal Taming" but will apply to any skill with a space)