### PR TITLE
More accurate mouse-over hover when displaying marker icons

### DIFF
--- a/src/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/Game/UI/Gumps/WorldMapGump.cs
@@ -975,8 +975,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (!showMarkerName)
                 {
-                    if (Mouse.Position.X >= rotX && Mouse.Position.X <= rotX + marker.MarkerIcon.Width &&
-                        Mouse.Position.Y >= rotY && Mouse.Position.Y <= rotY + marker.MarkerIcon.Height)
+                    if (Mouse.Position.X >= rotX - (marker.MarkerIcon.Width / 2) && Mouse.Position.X <= rotX + (marker.MarkerIcon.Width / 2) &&
+                        Mouse.Position.Y >= rotY - (marker.MarkerIcon.Height / 2) && Mouse.Position.Y <= rotY + (marker.MarkerIcon.Height / 2))
                     {
                         _hueVector.X = 0;
                         _hueVector.Y = 1;


### PR DESCRIPTION
When you would hover over an icon, you have to be slightly off it for the hover to work (especially when zoomed out)  This corrects that.