### PR TITLE
Some book fixes

### DIFF
--- a/src/Game/UI/Gumps/BookGump.cs
+++ b/src/Game/UI/Gumps/BookGump.cs
@@ -87,7 +87,8 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     if (_activated > 0)
                     {
-                        for (int i = 0; i < Math.Min(m_Pages.Count, value.Length); i++)
+                        int min = Math.Min(m_Pages.Count, value.Length);
+                        for (int i = 0; i < min; i++)
                         {
                             m_Pages[i].IsEditable = IsEditable;
                             m_Pages[i].Text = value[i];

--- a/src/Network/Packet.cs
+++ b/src/Network/Packet.cs
@@ -136,7 +136,7 @@ namespace ClassicUO.Network
             return _sb.ToString();
         }
 
-        public string ReadASCII(int length, bool exitIfNull = false)
+        public string ReadASCII(int length)
         {
             if (EnsureSize(length))
                 return Empty;

--- a/src/Network/Packet.cs
+++ b/src/Network/Packet.cs
@@ -199,6 +199,41 @@ namespace ClassicUO.Network
             return sb.ToString();
         }
 
+        public string ReadUTF8StringSafe(int length)
+        {
+            if (EnsureSize(length))
+            {
+                return Empty;
+            }
+            if (Position + length > Length)
+            {
+                length = Length - Position - 1;
+            }
+            if (length <= 0)
+            {
+                return Empty;
+            }
+
+            var buffer = new byte[length];
+            for (int i = 0; i < length; i++)
+            {
+                buffer[i] = ReadByte();
+            }
+            string utf8string = Encoding.UTF8.GetString(buffer);
+
+            bool isSafe = true;
+            for (int i = 0; isSafe && i < utf8string.Length; i++) isSafe = StringHelper.IsSafeChar(utf8string[i]);
+            if (isSafe) return utf8string;
+
+            StringBuilder sb = new StringBuilder(utf8string.Length);
+            foreach (var c in utf8string)
+            {
+                if (StringHelper.IsSafeChar(c))
+                    sb.Append(c);
+            }
+            return sb.ToString();
+        }
+
         public string ReadUnicode()
         {
             if (EnsureSize(2))

--- a/src/Network/Packet.cs
+++ b/src/Network/Packet.cs
@@ -217,9 +217,15 @@ namespace ClassicUO.Network
             var buffer = new byte[length];
             for (int i = 0; i < length; i++)
             {
-                buffer[i] = ReadByte();
+                byte b = ReadByte();
+                if (b == 0)
+                {
+                    Skip(length - i - 1);
+                    break;
+                }
+                buffer[i] = b;
             }
-            string utf8string = Encoding.UTF8.GetString(buffer);
+            string utf8string = Encoding.UTF8.GetString(buffer).Trim('\0');
 
             bool isSafe = true;
             for (int i = 0; isSafe && i < utf8string.Length; i++) isSafe = StringHelper.IsSafeChar(utf8string[i]);

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1858,7 +1858,7 @@ namespace ClassicUO.Network
 
                     for (int x = 0; x < lineCnt; x++)
                     {
-                        sb.Append(BookGump.IsNewBookD4 ? p.ReadUTF8StringSafe() : p.ReadASCII());
+                        sb.Append(BookGump.IsNewBook ? p.ReadUTF8StringSafe() : p.ReadASCII());
                         sb.Append('\n');
                     }
 
@@ -2538,7 +2538,7 @@ namespace ClassicUO.Network
                     BookPageCount = p.ReadUShort(),
                     //title allows only 47 dots (. + \0) so 47 is the right number
                     BookTitle =
-                        new MultiLineBox(new MultiLineEntry(BookGump.DefaultFont, 47, 150, 150, BookGump.IsNewBookD4, FontStyle.None, 0), editable)
+                        new MultiLineBox(new MultiLineEntry(BookGump.DefaultFont, 47, 150, 150, BookGump.IsNewBook, FontStyle.None, 0), editable)
                         {
                             X = 40,
                             Y = 60,
@@ -2549,7 +2549,7 @@ namespace ClassicUO.Network
                         },
                     //as the old booktitle supports only 30 characters in AUTHOR and since the new clients only allow 29 dots (. + \0 character at end), we use 29 as a limitation
                     BookAuthor =
-                        new MultiLineBox(new MultiLineEntry(BookGump.DefaultFont, 29, 150, 150, BookGump.IsNewBookD4, FontStyle.None, 0), editable)
+                        new MultiLineBox(new MultiLineEntry(BookGump.DefaultFont, 29, 150, 150, BookGump.IsNewBook, FontStyle.None, 0), editable)
                         {
                             X = 40,
                             Y = 160,
@@ -2558,7 +2558,8 @@ namespace ClassicUO.Network
                             IsEditable = editable,
                             Text = oldpacket ? p.ReadUTF8StringSafe(30).Trim('\0') : p.ReadUTF8StringSafe(p.ReadUShort()).Trim('\0')
                         },
-                    IsEditable = editable
+                    IsEditable = editable,
+                    UseNewHeader = !oldpacket
                 });
                 NetClient.Socket.Send(new PBookPageDataRequest(serial, 1));
             }
@@ -2570,6 +2571,7 @@ namespace ClassicUO.Network
                 bgump.BookTitle.IsEditable = editable;
                 bgump.BookAuthor.Text = oldpacket ? p.ReadASCII(30).Trim('\0') : p.ReadASCII(p.ReadUShort()).Trim('\0');
                 bgump.BookAuthor.IsEditable = editable;
+                bgump.UseNewHeader = !oldpacket;
             }
         }
 

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1839,20 +1839,20 @@ namespace ClassicUO.Network
 
             var serial = p.ReadUInt();
             var pageCnt = p.ReadUShort();
-            var pages = new string[pageCnt];
             var gump = UIManager.GetGump<BookGump>(serial);
-
+           
             if (gump == null) return;
 
+            var pages = gump.BookPages;
+
             StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < pageCnt; i++) pages[i] = string.Empty;
 
             //packets sent from server can contain also an uneven amount of page, not counting that we could receive only part of them, not every page!
             for (int i = 0; i < pageCnt; i++, sb.Clear())
             {
-                var pageNum = p.ReadUShort() - 1;
+                var pageNum = p.ReadUShort();
 
-                if (pageNum < pageCnt)
+                if (pageNum <= pages.Length)
                 {
                     var lineCnt = p.ReadUShort();
 
@@ -1864,7 +1864,7 @@ namespace ClassicUO.Network
 
                     if (sb.Length > 0)
                         sb.Remove(sb.Length - 1, 1); //this removes the last, unwanted, newline
-                    pages[pageNum] = sb.ToString();
+                    pages[pageNum - 1] = sb.ToString();
                 }
                 else
                     Log.Error( "BOOKGUMP: The server is sending a page number GREATER than the allowed number of pages in BOOK!");
@@ -2560,6 +2560,7 @@ namespace ClassicUO.Network
                         },
                     IsEditable = editable
                 });
+                NetClient.Socket.Send(new PBookPageDataRequest(serial, 1));
             }
             else
             {

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -2545,7 +2545,7 @@ namespace ClassicUO.Network
                             Height = 25,
                             Width = 155,
                             IsEditable = editable,
-                            Text = oldpacket ? p.ReadASCII(60).Trim('\0') : p.ReadASCII(p.ReadUShort()).Trim('\0')
+                            Text = oldpacket ? p.ReadUTF8StringSafe(60).Trim('\0') : p.ReadUTF8StringSafe(p.ReadUShort()).Trim('\0')
                         },
                     //as the old booktitle supports only 30 characters in AUTHOR and since the new clients only allow 29 dots (. + \0 character at end), we use 29 as a limitation
                     BookAuthor =
@@ -2556,7 +2556,7 @@ namespace ClassicUO.Network
                             Height = 25,
                             Width = 155,
                             IsEditable = editable,
-                            Text = oldpacket ? p.ReadASCII(30).Trim('\0') : p.ReadASCII(p.ReadUShort()).Trim('\0')
+                            Text = oldpacket ? p.ReadUTF8StringSafe(30).Trim('\0') : p.ReadUTF8StringSafe(p.ReadUShort()).Trim('\0')
                         },
                     IsEditable = editable
                 });

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -2538,7 +2538,7 @@ namespace ClassicUO.Network
                     BookPageCount = p.ReadUShort(),
                     //title allows only 47 dots (. + \0) so 47 is the right number
                     BookTitle =
-                        new MultiLineBox(new MultiLineEntry(BookGump.DefaultFont, 47, 150, 150, BookGump.IsNewBook, FontStyle.None, 0), editable)
+                        new TextBox(new TextEntry(BookGump.DefaultFont, 47, 150, 150, BookGump.IsNewBook, FontStyle.None, 0), editable)
                         {
                             X = 40,
                             Y = 60,
@@ -2549,7 +2549,7 @@ namespace ClassicUO.Network
                         },
                     //as the old booktitle supports only 30 characters in AUTHOR and since the new clients only allow 29 dots (. + \0 character at end), we use 29 as a limitation
                     BookAuthor =
-                        new MultiLineBox(new MultiLineEntry(BookGump.DefaultFont, 29, 150, 150, BookGump.IsNewBook, FontStyle.None, 0), editable)
+                        new TextBox(new TextEntry(BookGump.DefaultFont, 29, 150, 150, BookGump.IsNewBook, FontStyle.None, 0), editable)
                         {
                             X = 40,
                             Y = 160,

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -2545,7 +2545,7 @@ namespace ClassicUO.Network
                             Height = 25,
                             Width = 155,
                             IsEditable = editable,
-                            Text = oldpacket ? p.ReadUTF8StringSafe(60).Trim('\0') : p.ReadUTF8StringSafe(p.ReadUShort()).Trim('\0')
+                            Text = oldpacket ? p.ReadUTF8StringSafe(60) : p.ReadUTF8StringSafe(p.ReadUShort())
                         },
                     //as the old booktitle supports only 30 characters in AUTHOR and since the new clients only allow 29 dots (. + \0 character at end), we use 29 as a limitation
                     BookAuthor =
@@ -2556,7 +2556,7 @@ namespace ClassicUO.Network
                             Height = 25,
                             Width = 155,
                             IsEditable = editable,
-                            Text = oldpacket ? p.ReadUTF8StringSafe(30).Trim('\0') : p.ReadUTF8StringSafe(p.ReadUShort()).Trim('\0')
+                            Text = oldpacket ? p.ReadUTF8StringSafe(30) : p.ReadUTF8StringSafe(p.ReadUShort())
                         },
                     IsEditable = editable,
                     UseNewHeader = !oldpacket
@@ -2567,9 +2567,9 @@ namespace ClassicUO.Network
             {
                 p.Skip(2);
                 bgump.IsEditable = editable;
-                bgump.BookTitle.Text = oldpacket ? p.ReadASCII(60).Trim('\0') : p.ReadASCII(p.ReadUShort()).Trim('\0');
+                bgump.BookTitle.Text = oldpacket ? p.ReadUTF8StringSafe(60) : p.ReadUTF8StringSafe(p.ReadUShort());
                 bgump.BookTitle.IsEditable = editable;
-                bgump.BookAuthor.Text = oldpacket ? p.ReadASCII(30).Trim('\0') : p.ReadASCII(p.ReadUShort()).Trim('\0');
+                bgump.BookAuthor.Text = oldpacket ? p.ReadUTF8StringSafe(30) : p.ReadUTF8StringSafe(p.ReadUShort());
                 bgump.BookAuthor.IsEditable = editable;
                 bgump.UseNewHeader = !oldpacket;
             }


### PR DESCRIPTION
Books (regular text kind) had many bugs. They still have many bugs, but I fixed a couple.

Here's what this fixes:

- Read-only books did not work (they have their page data sent only for the visible pages, instead of all at once like for editable books).
- Editing packets were being sent for read-only books.
- Book titles were not using UTF-8 encoding, but the original client treats them as UTF-8. Left them as ASCII for version 2.x clients which had some special treatment already, but this could be incorrect.
- Book titles were multi-line fields and you could end up with newlines in them when pasting into them etc.
- Book titles were always using the new `0xD4` header packet when saving the book, but some servers (eg. POL) still use the `0x93` packet even with new client versions. This would cause book titles to not save. CUO will use the same type of packet as sent by the server now.
- Reduced amount of unnecessary book opening sounds being played when pressing the enter key. Some unnecessary sounds still play.
- Some refactoring to make the code easier to read.

Many bugs still remain with text books. I'll write them up in a bug report. Frankly I think the book code should be largely rewritten; I found it incredibly difficult to understand and there's probably a dozen different bugs lurking in there. A different design structure would make it much more robust.

Basically, reading books mostly works now. Editing books has many outstanding bugs.