### PR TITLE
Add a macro action to allow item use by graphic ID

### DIFF
--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -1364,6 +1364,26 @@ namespace ClassicUO.Game.Managers
                         }
                     }
                     break;
+
+                case MacroType.UseItemByGraphicId:
+                    string itemGraphicIdStr = ((MacroObjectString)macro).Text;
+
+                    try
+                    {
+                        ushort itemGraphicId = Convert.ToUInt16(itemGraphicIdStr);
+                        Item item = World.Player.FindItemByGraphic(itemGraphicId);
+
+                        if (item != null)
+                            GameActions.DoubleClick(item.Serial);
+                        else
+                            GameActions.Print("Item not found (try to open a bag that contains the item)");
+                    }
+                    catch (FormatException)
+                    {
+                        GameActions.Print("Invalid item graphic ID");
+                    }
+
+                    break;
             }
 
 
@@ -1565,6 +1585,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.SetUpdateRange:
                 case MacroType.ModifyUpdateRange:
                 case MacroType.RazorMacro:
+                case MacroType.UseItemByGraphicId:
                     obj = new MacroObjectString(code, MacroSubType.MSC_NONE);
 
                     break;
@@ -1699,6 +1720,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.SetUpdateRange:
                 case MacroType.ModifyUpdateRange:
                 case MacroType.RazorMacro:
+                case MacroType.UseItemByGraphicId:
                     SubMenuType = 2;
 
                     break;
@@ -1813,6 +1835,7 @@ namespace ClassicUO.Game.Managers
         UsePotion,
         CloseAllHealthBars,
         RazorMacro,
+        UseItemByGraphicId,
     }
 
     internal enum MacroSubType


### PR DESCRIPTION
This is an essential macro action for those who play without an assistant (Razor). Since macOS users can't use Razor, this action should help significantly. To find a graphic ID you can use `-info` command. Then just use found graphic ID (usually something like 5119) in the macro.