### PR TITLE
Fix map freeview and topmost selections being reversed

### DIFF
--- a/src/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/Game/UI/Gumps/WorldMapGump.cs
@@ -120,8 +120,6 @@ namespace ClassicUO.Game.UI.Gumps
                 ShowBorder = !_isTopMost;
 
                 ControlInfo.Layer = _isTopMost ? UILayer.Over : UILayer.Default;
-
-                SetOptionValue("top_most", value);
             }
         }
 
@@ -137,8 +135,6 @@ namespace ClassicUO.Game.UI.Gumps
                     _isScrolling = false;
                     CanMove = true;
                 }
-
-                SetOptionValue("free_view", value);
             }
         }
 


### PR DESCRIPTION
These selections were getting set by an explicit call, and then the ContextMenu control's OnMouseUp handler would also toggle the selection. This resulted in the context menu displaying the selection backwards; when the map was in Free View, the control displayed as unselected, and when it was in locked view the control displayed as selected. The same applied to the Topmost selection.