### PR TITLE
Vendor buy gump ordering... again

### DIFF
--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1034,7 +1034,11 @@ namespace ClassicUO.Network
                         continue;
                     }
 
-                    IEnumerable<Item> list = first.X > 1 ? item.Items.Reverse() : item.Items;
+                    IEnumerable<Item> list = item.Items.Reverse();
+                    if (first.Y <= 1)
+                    {
+                        list = list.OrderBy(o => o.X);
+                    }
 
                     foreach (var i in list) 
                         gump.AddItem(i.Serial, i.Graphic, i.Hue, i.Amount, i.Price, i.Name, false);
@@ -2117,7 +2121,11 @@ namespace ClassicUO.Network
                 if (first == null)
                     return;
 
-                IEnumerable<Item> list = first.X > 1 ? container.Items.Reverse() : container.Items;
+                IEnumerable<Item> list = container.Items.Reverse();
+                if (first.Y <= 1)
+                {
+                    list = list.OrderBy(o => o.X);
+                }
                 
                 foreach (Item it in list.Take(count))
                 {


### PR DESCRIPTION
The way this works has proven to be a bit strange, but I think this is getting close to the way it should be.

Through lots of testing, it seems that the order the items are supposed to be in the buy gump is:

1. Reverse the order of the item list from the `0x3C` packet.
2. **If Y coordinate of the items <= 1:** sort the items by their X coordinate in ascending order. (coordinates are also included in the `0x3C` packet)

[ServUO says that the client sorts these by their X/Y](https://github.com/ServUO/ServUO/blob/master/Server/Network/Packets.cs#L335), but that doesn't seem to always be the case. POL100 servers send the X/Y coordinates as random values > 1, and the original client doesn't use them for sorting when this is the case.

The solution here looks to work on all servers tested, including:
- ServUO 5.7
- POL100 (Modern distro)
- OutlandsUO
- UO Renaissance
- a POL98 server that sends X/Y coordinates as (0,0) for all items (item order compared to item prices used to be reversed on this server)
- an unknown emulator server that sends the `0x3C` packet in reverse order compared to all other servers and expects items to be sorted by the X coordinate (item order compared to prices was reversed on this server after #958)

