### PR TITLE
World Map settings are stored in the profile vs. gump.xml

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -261,6 +261,23 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool TextFading { get; set; } = true;
 
 
+        [JsonProperty] public int WorldMapWidth { get; set; } = 400;
+        [JsonProperty] public int WorldMapHeight { get; set; } = 400;
+        [JsonProperty] public int WorldMapFont { get; set; } = 3;
+        [JsonProperty] public bool WorldMapFlipMap { get; set; } = true;
+        [JsonProperty] public bool WorldMapTopMost { get; set; }
+        [JsonProperty] public bool WorldMapFreeView { get; set; }
+        [JsonProperty] public bool WorldMapShowParty { get; set; } = true;
+        [JsonProperty] public int WorldMapZoomIndex { get; set; } = 4;
+        [JsonProperty] public bool WorldMapShowCoordinates { get; set; } = true;
+        [JsonProperty] public bool WorldMapShowMobiles { get; set; } = true;
+        [JsonProperty] public bool WorldMapShowPlayerName { get; set; } = true;
+        [JsonProperty] public bool WorldMapShowPlayerBar { get; set; } = true;
+        [JsonProperty] public bool WorldMapShowGroupName { get; set; } = true;
+        [JsonProperty] public bool WorldMapShowGroupBar { get; set; } = true;
+        [JsonProperty] public bool WorldMapShowMarkers { get; set; } = true;
+        [JsonProperty] public bool WorldMapShowMultis { get; set; } = true;
+
         internal static string ProfilePath { get; } = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Profiles");
         internal static string DataPath { get; } = Path.Combine(CUOEnviroment.ExecutablePath, "Data");
 

--- a/src/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/Game/UI/Gumps/WorldMapGump.cs
@@ -29,6 +29,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
@@ -144,65 +145,70 @@ namespace ClassicUO.Game.UI.Gumps
         {
             base.Restore(xml);
 
-            int width = int.Parse(xml.GetAttribute("width"));
-            int height = int.Parse(xml.GetAttribute("height"));
+            LoadSettings();
+            BuildGump();
+        }
 
-            SetFont(int.TryParse(xml.GetAttribute("markerfont"), out int font) ? font : 1);
-            
+        private void LoadSettings()
+        {
+            int width = ProfileManager.Current.WorldMapWidth;
+            int height = ProfileManager.Current.WorldMapHeight;
+
+            SetFont(ProfileManager.Current.WorldMapFont);
+
             ResizeWindow(new Point(width, height));
 
-            _flipMap = ParseBool(xml.GetAttribute("flipmap"));
-            TopMost = ParseBool(xml.GetAttribute("topmost"));
-            FreeView = ParseBool(xml.GetAttribute("freeview"));
-            _showPartyMembers = ParseBool(xml.GetAttribute("showpartymembers"));
+            _flipMap = ProfileManager.Current.WorldMapFlipMap;
+            TopMost = ProfileManager.Current.WorldMapTopMost;
+            FreeView = ProfileManager.Current.WorldMapFreeView;
+            _showPartyMembers = ProfileManager.Current.WorldMapShowParty;
 
             World.WMapManager.SetEnable(_showPartyMembers);
 
-            if (int.TryParse(xml.GetAttribute("zoomindex"), out int value))
-                _zoomIndex = (value >= 0 && value < _zooms.Length) ? value : 4;
+            _zoomIndex = ProfileManager.Current.WorldMapZoomIndex;
 
-            _showCoordinates = ParseBool(xml.GetAttribute("showcoordinates"));
-            _showMobiles = ParseBool(xml.GetAttribute("showmobiles"));
+            _showCoordinates = ProfileManager.Current.WorldMapShowCoordinates;
+            _showMobiles = ProfileManager.Current.WorldMapShowMobiles;
 
-            _showPlayerName = ParseBool(xml.GetAttribute("showplayername"));
-            _showPlayerBar = ParseBool(xml.GetAttribute("showplayerbar"));
-            _showGroupName = ParseBool(xml.GetAttribute("showgroupname"));
-            _showGroupBar = ParseBool(xml.GetAttribute("showgroupbar"));
-            _showMarkers = ParseBool(xml.GetAttribute("showmarkers"));
-            _showMultis = ParseBool(xml.GetAttribute("showmultis"));
+            _showPlayerName = ProfileManager.Current.WorldMapShowPlayerName;
+            _showPlayerBar = ProfileManager.Current.WorldMapShowPlayerBar;
+            _showGroupName = ProfileManager.Current.WorldMapShowGroupName;
+            _showGroupBar = ProfileManager.Current.WorldMapShowGroupBar;
+            _showMarkers = ProfileManager.Current.WorldMapShowMarkers;
+            _showMultis = ProfileManager.Current.WorldMapShowMultis;
+        }
 
-            BuildGump();
+        private void SaveSettings()
+        {
+            ProfileManager.Current.WorldMapWidth = Width;
+            ProfileManager.Current.WorldMapHeight = Height;
+
+            ProfileManager.Current.WorldMapFlipMap = _flipMap;
+            ProfileManager.Current.WorldMapTopMost = TopMost;
+            ProfileManager.Current.WorldMapFreeView = FreeView;
+            ProfileManager.Current.WorldMapShowParty = _showPartyMembers;
+
+            ProfileManager.Current.WorldMapZoomIndex = _zoomIndex;
+
+            ProfileManager.Current.WorldMapShowCoordinates = _showCoordinates;
+            ProfileManager.Current.WorldMapShowMobiles = _showMobiles;
+
+            ProfileManager.Current.WorldMapShowPlayerName = _showPlayerName;
+            ProfileManager.Current.WorldMapShowPlayerBar = _showPlayerBar;
+            ProfileManager.Current.WorldMapShowGroupName = _showGroupName;
+            ProfileManager.Current.WorldMapShowGroupBar = _showGroupBar;
+            ProfileManager.Current.WorldMapShowMarkers = _showMarkers;
+            ProfileManager.Current.WorldMapShowMultis = _showMultis;
+
+            ProfileManager.Current?.Save(UIManager.Gumps.OfType<Gump>().Where(s => s.CanBeSaved).Reverse()
+                .ToList());
         }
 
         private bool ParseBool(string boolStr)
         {
             return bool.TryParse(boolStr, out bool value) && value;
         }
-
-        public override void Save(XmlTextWriter writer)
-        {
-            base.Save(writer);
-
-            writer.WriteAttributeString("width", Width.ToString());
-            writer.WriteAttributeString("height", Height.ToString());
-
-            writer.WriteAttributeString("markerfont", _markerFontIndex.ToString());
-
-            writer.WriteAttributeString("flipmap", _flipMap.ToString());
-            writer.WriteAttributeString("topmost", _isTopMost.ToString());
-            writer.WriteAttributeString("freeview", _freeView.ToString());
-            writer.WriteAttributeString("showpartymembers", _showPartyMembers.ToString());
-            writer.WriteAttributeString("zoomindex", _zoomIndex.ToString());
-            writer.WriteAttributeString("showcoordinates", _showCoordinates.ToString());
-            writer.WriteAttributeString("showmobiles", _showMobiles.ToString());
-            writer.WriteAttributeString("showgroupname", _showPlayerName.ToString());
-            writer.WriteAttributeString("showgroupbar", _showPlayerBar.ToString());
-            writer.WriteAttributeString("showpartyname", _showGroupName.ToString());
-            writer.WriteAttributeString("showpartybar", _showPlayerBar.ToString());
-            writer.WriteAttributeString("showmarkers", _showMarkers.ToString());
-            writer.WriteAttributeString("showmultis", _showMultis.ToString());
-        }
-
+        
         private void BuildGump()
         {
             BuildContextMenu();
@@ -238,6 +244,12 @@ namespace ClassicUO.Game.UI.Gumps
             _options["show_party_name"] = new ContextMenuItemEntry("Show group name", () => { _showGroupName = !_showGroupName; }, true, _showGroupName);
             _options["show_party_healthbar"] = new ContextMenuItemEntry("Show group healthbar", () => { _showGroupBar = !_showGroupBar; }, true, _showGroupBar);
             _options["show_coordinates"] = new ContextMenuItemEntry("Show your coordinates", () => { _showCoordinates = !_showCoordinates; }, true, _showCoordinates);
+
+            _options["saveclose"] = new ContextMenuItemEntry("Save & Close", () =>
+            {
+                SaveSettings();
+                Dispose();
+            });
         }
 
         private void BuildContextMenu()
@@ -300,7 +312,7 @@ namespace ClassicUO.Game.UI.Gumps
             ContextMenu.Add(_options["show_multis"]);
             ContextMenu.Add(_options["show_coordinates"]);
             ContextMenu.Add("", null);
-            ContextMenu.Add("Close", Dispose);
+            ContextMenu.Add(_options["saveclose"]);
         }
 
 
@@ -450,6 +462,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                     _mapTexture = new UOTexture32(realWidth, realHeight);
                     _mapTexture.SetData(buffer);
+
+                    LoadSettings();
 
                     GameActions.Print("WorldMap loaded!", 0x48);
                 }


### PR DESCRIPTION
If the World Map is closed, and you saved your profile, since the gump wasn't active you'd lose your settings.  This will save those settings the current profile so they can be restored.

Updated the Close menu to save Save & Close, which will save the actual settings in the profile.