### PR TITLE
add behavior to filter display of unlootable items on Outlands

### DIFF
--- a/src/Game/GameObjects/Item.cs
+++ b/src/Game/GameObjects/Item.cs
@@ -229,10 +229,16 @@ namespace ClassicUO.Game.GameObjects
 
         public ref readonly StaticTiles ItemData => ref TileDataLoader.Instance.StaticData[IsMulti ? MultiGraphic : Graphic];
 
-        public bool IsLootable =>
-            ItemData.Layer != (int) Layer.Hair &&
-            ItemData.Layer != (int) Layer.Beard &&
-            ItemData.Layer != (int) Layer.Face;
+        public bool IsLootable
+        {
+            get
+            {
+                return ItemData.Layer != (int)Layer.Hair &&
+                ItemData.Layer != (int)Layer.Beard &&
+                ItemData.Layer != (int)Layer.Face &&
+                !(X == 0 && Y == 0);
+            }
+        }
 
         private static readonly DataReader _reader = new DataReader();
 


### PR DESCRIPTION
On UO Outlands many mobs spawn with custom hued items, rare items, or rare weapons in their inventory.  These items appear in corpses at position `(0, 0, 0)` with their `Frozen` property set to `True`.  In practice, the `Z` value of an `Item` in a container is always `0`, and it's unlikely (perhaps impossible, haven't checked) that an item will spawn at `(0, 0, 0)` naturally.  

In this PR I modified `Item.IsLootable` to include a check on the item's `X` and `Y` values both equaling `0`.  This effectively removes the items from both grid loot and the container.  I don't think this solution should have any side effects with other uses of `Item.IsLootable`, but that needs confirmation from someone with more context.

Thanks!