### PR TITLE
Fix Body.def and Corpse.def file override conflict resolution

### DIFF
--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -614,9 +614,13 @@ namespace ClassicUO.IO.Resources
                                 if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                                     continue;
 
+                                if (DataIndex[index].ReadFromBodyDef)
+                                    break;
+
                                 DataIndex[index].Graphic = (ushort)checkIndex;
                                 DataIndex[index].Color = (ushort)color;
                                 DataIndex[index].IsValidMUL = true;
+                                DataIndex[index].ReadFromBodyDef = true;
 
                                 break;
                             }
@@ -651,9 +655,13 @@ namespace ClassicUO.IO.Resources
                                 if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                                     continue;
 
+                                if (DataIndex[index].ReadFromCorpseDef)
+                                    break;
+
                                 DataIndex[index].CorpseGraphic = (ushort)checkIndex;
                                 DataIndex[index].CorpseColor = color;
                                 DataIndex[index].IsValidMUL = true;
+                                DataIndex[index].ReadFromCorpseDef = true;
 
                                 break;
                             }
@@ -1894,6 +1902,8 @@ namespace ClassicUO.IO.Resources
         public AnimationGroup[] Groups;
 
         public bool IsValidMUL;
+        public bool ReadFromBodyDef;
+        public bool ReadFromCorpseDef;
         public sbyte MountedHeightOffset;
 
         public ANIMATION_GROUPS_TYPE Type = ANIMATION_GROUPS_TYPE.UNKNOWN;

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -607,23 +607,34 @@ namespace ClassicUO.IO.Resources
                                 continue;
                             int color = defReader.ReadInt();
 
-                            for (int i = 0; i < group.Length; i++)
-                            {
-                                int checkIndex = group[i];
+                            int checkIndex;
+                            if (group.Length >= 3)
+                                checkIndex = group[2];
+                            else
+                                checkIndex = group[0];
 
-                                if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
-                                    continue;
+                            DataIndex[index].Graphic = (ushort)checkIndex;
+                            DataIndex[index].Color = (ushort)color;
+                            DataIndex[index].IsValidMUL = true;
+                            DataIndex[index].ReadFromBodyDef = true;
 
-                                if (DataIndex[index].ReadFromBodyDef)
-                                    break;
+                            //for (int i = 0; i < group.Length; i++)
+                            //{
+                            //    int checkIndex = group[i];
 
-                                DataIndex[index].Graphic = (ushort)checkIndex;
-                                DataIndex[index].Color = (ushort)color;
-                                DataIndex[index].IsValidMUL = true;
-                                DataIndex[index].ReadFromBodyDef = true;
+                            //    if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                            //        continue;
 
-                                break;
-                            }
+                            //    if (DataIndex[index].ReadFromBodyDef)
+                            //        break;
+
+                            //    DataIndex[index].Graphic = (ushort)checkIndex;
+                            //    DataIndex[index].Color = (ushort)color;
+                            //    DataIndex[index].IsValidMUL = true;
+                            //    DataIndex[index].ReadFromBodyDef = true;
+
+                            //    break;
+                            //}
                         }
                     }
                 }

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -610,7 +610,7 @@ namespace ClassicUO.IO.Resources
                             int color = defReader.ReadInt();
 
 
-                            //TODO: Placeholder logic to match perceived original client behaviour.
+                            //Yes, this is actually how this is supposed to work.
                             int checkIndex;
                             if (group.Length >= 3)
                                 checkIndex = group[2];
@@ -621,24 +621,6 @@ namespace ClassicUO.IO.Resources
                             DataIndex[index].Color = (ushort)color;
                             DataIndex[index].IsValidMUL = true;
                             DataIndex[index].ReadFromBodyDef = true;
-
-                            //for (int i = 0; i < group.Length; i++)
-                            //{
-                            //    int checkIndex = group[i];
-
-                            //    if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
-                            //        continue;
-
-                            //    if (DataIndex[index].ReadFromBodyDef)
-                            //        break;
-
-                            //    DataIndex[index].Graphic = (ushort)checkIndex;
-                            //    DataIndex[index].Color = (ushort)color;
-                            //    DataIndex[index].IsValidMUL = true;
-                            //    DataIndex[index].ReadFromBodyDef = true;
-
-                            //    break;
-                            //}
                         }
                     }
                 }
@@ -665,7 +647,7 @@ namespace ClassicUO.IO.Resources
                             int color = defReader.ReadInt();
 
 
-                            //TODO: Placeholder logic to match perceived original client behaviour.
+                            //Yes, this is actually how this is supposed to work.
                             int checkIndex;
                             if (group.Length >= 3)
                                 checkIndex = group[2];
@@ -676,24 +658,6 @@ namespace ClassicUO.IO.Resources
                             DataIndex[index].CorpseColor = (ushort)color;
                             DataIndex[index].IsValidMUL = true;
                             DataIndex[index].ReadFromCorpseDef = true;
-
-                            //for (int i = 0; i < group.Length; i++)
-                            //{
-                            //    int checkIndex = group[i];
-
-                            //    if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
-                            //        continue;
-
-                            //    if (DataIndex[index].ReadFromCorpseDef)
-                            //        break;
-
-                            //    DataIndex[index].CorpseGraphic = (ushort)checkIndex;
-                            //    DataIndex[index].CorpseColor = (ushort)color;
-                            //    DataIndex[index].IsValidMUL = true;
-                            //    DataIndex[index].ReadFromCorpseDef = true;
-
-                            //    break;
-                            //}
                         }
                     }
                 }

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -600,6 +600,8 @@ namespace ClassicUO.IO.Resources
 
                             if (index >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                                 continue;
+                            if (DataIndex[index].ReadFromBodyDef)
+                                continue;
 
                             int[] group = defReader.ReadGroup();
 
@@ -607,6 +609,8 @@ namespace ClassicUO.IO.Resources
                                 continue;
                             int color = defReader.ReadInt();
 
+
+                            //TODO: Placeholder logic to match perceived original client behaviour.
                             int checkIndex;
                             if (group.Length >= 3)
                                 checkIndex = group[2];
@@ -647,35 +651,49 @@ namespace ClassicUO.IO.Resources
                     {
                         while (defReader.Next())
                         {
-                            ushort index = (ushort)defReader.ReadInt();
+                            int index = defReader.ReadInt();
 
                             if (index >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                                continue;
+                            if (DataIndex[index].ReadFromCorpseDef)
                                 continue;
 
                             int[] group = defReader.ReadGroup();
 
                             if (group == null)
                                 continue;
+                            int color = defReader.ReadInt();
 
-                            ushort color = (ushort)defReader.ReadInt();
 
-                            for (int i = 0; i < group.Length; i++)
-                            {
-                                int checkIndex = group[i];
+                            //TODO: Placeholder logic to match perceived original client behaviour.
+                            int checkIndex;
+                            if (group.Length >= 3)
+                                checkIndex = group[2];
+                            else
+                                checkIndex = group[0];
 
-                                if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
-                                    continue;
+                            DataIndex[index].CorpseGraphic = (ushort)checkIndex;
+                            DataIndex[index].CorpseColor = (ushort)color;
+                            DataIndex[index].IsValidMUL = true;
+                            DataIndex[index].ReadFromCorpseDef = true;
 
-                                if (DataIndex[index].ReadFromCorpseDef)
-                                    break;
+                            //for (int i = 0; i < group.Length; i++)
+                            //{
+                            //    int checkIndex = group[i];
 
-                                DataIndex[index].CorpseGraphic = (ushort)checkIndex;
-                                DataIndex[index].CorpseColor = color;
-                                DataIndex[index].IsValidMUL = true;
-                                DataIndex[index].ReadFromCorpseDef = true;
+                            //    if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                            //        continue;
 
-                                break;
-                            }
+                            //    if (DataIndex[index].ReadFromCorpseDef)
+                            //        break;
+
+                            //    DataIndex[index].CorpseGraphic = (ushort)checkIndex;
+                            //    DataIndex[index].CorpseColor = (ushort)color;
+                            //    DataIndex[index].IsValidMUL = true;
+                            //    DataIndex[index].ReadFromCorpseDef = true;
+
+                            //    break;
+                            //}
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #1061

If these .def files contain multiple conflicting overrides for the same thing, the original client seems to pick the **first** override and use that. ClassicUO would process them all, in effect picking the **last** override.

I don't know if this is the most elegant solution to the problem, but processing files backwards is non-trivial so this is probably better.