### PR TITLE
Re-enable all names packet

### DIFF
--- a/src/Game/GameObjects/Entity.cs
+++ b/src/Game/GameObjects/Entity.cs
@@ -107,11 +107,12 @@ namespace ClassicUO.Game.GameObjects
 
             if (UseObjectHandles && !ObjectHandlesOpened)
             {
-                // TODO: this is not sent by client. There is a particular situation when standard client sends it. Disabled for the moment
-                //if (SerialHelper.IsMobile(Serial) && string.IsNullOrEmpty(Name))
-                //{
-                //    Socket.Send(new PNameRequest(Serial));
-                //}
+                // TODO: Some servers may not want to receive this (causing original client to not send it),
+                //but all servers tested (latest POL, old POL, ServUO, Outlands) do.
+                if (SerialHelper.IsMobile(Serial))
+                {
+                    Socket.Send(new PNameRequest(Serial));
+                }
 
                 UIManager.Add(new NameOverheadGump(this));
 


### PR DESCRIPTION
I tested this behaviour on local latest ServUO, local latest POL, an old POL98 server, UO Renaissance and OutlandsUO. On all of these servers this packet is being sent by the original client and the server replies appropriately.

Because not sending this packet will cause incorrect names to display under certain circumstances (eg. when a pet, or a player for that matter, is renamed while it is in your view), it needs to be re-enabled. If there is some server wherein the original client does *not* send this packet, let me know and I'll take a look.

The only thing I'm not sure about is if this is the right place for this code. This packet needs to be sent every time Ctrl+Shift is pressed to display entity name plates. This implementation seems to do the job and doesn't send extra packets so far as I can tell.