### PR TITLE
Fix some item desync issues

### DIFF
--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -4593,9 +4593,7 @@ namespace ClassicUO.Network
 
                     if (SerialHelper.IsValid(item.Container))
                     {
-                        Console.WriteLine("======= UpdateObject function: item: {0:X8}, container: {1:X8}", item.Serial, item.Container);
-                        //RemoveItemFromContainer(item);
-                        //item.Container = 0xFFFF_FFFF;
+                        RemoveItemFromContainer(item);
                     }
                 }
                 else if (SerialHelper.IsMobile(serial))
@@ -4820,7 +4818,7 @@ namespace ClassicUO.Network
 
                 obj.Next = null;
                 obj.Previous = null;
-                obj.Container = 0xFFFF_FFFF;
+                obj.Container = 0;
             }
 
             obj.RemoveFromTile();


### PR DESCRIPTION
I don't know if this code was commented out for a specific reason, but it being commented out causes items to not appear when the server forcibly moves them out of a container.

I can't think of a generic example where this happens, but on the server I'm playing on it would happen when a corpse is skinned twice; on the second skinning the corpse is deleted and whatever was on it is dropped into the tile it was on. With the commented-out code the items would be invisible, as the client wouldn't move them out of the (now deleted) corpse container.

Also, in all my testing items dropped onto the ground had their `Container` set to 0, but for some reason the code here was setting it to 0xFFFFFFFF. I changed that to 0 for consistency's sake, and it didn't seem to have any ill effects.