### PR TITLE
Fix an oopsie in LinkedObject sorting

### DIFF
--- a/src/Game/LinkedObject.cs
+++ b/src/Game/LinkedObject.cs
@@ -275,7 +275,10 @@ namespace ClassicUO.Game
                 }
                 tail.Next = null;
                 if (nmerges <= 1)
+                {
+                    Items = head;
                     return head;
+                }
                 else
                     unitsize *= 2;
             }

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1015,13 +1015,6 @@ namespace ClassicUO.Network
                             first = first.Next;
                         }
                     }
-                    else
-                    {
-                        while (first?.Previous != null)
-                        {
-                            first = first.Previous;
-                        }
-                    }
 
                     while (first != null)
                     {


### PR DESCRIPTION
I forgot to set `Items` to point at the new head when returning, oops.