### PR TITLE
Remove _fontIndex to allow all characters from fonts.mul

### DIFF
--- a/src/IO/Resources/FontsLoader.cs
+++ b/src/IO/Resources/FontsLoader.cs
@@ -48,11 +48,8 @@ namespace ClassicUO.IO.Resources
         private const int UOFONT_CROPTEXTURE = 0x0200;
         private const int UNICODE_SPACE_WIDTH = 8;
         private const int MAX_HTML_TEXT_HEIGHT = 18;
+        private const byte NOPRINT_CHARS = 32;
         private const float ITALIC_FONT_KOEFFICIENT = 3.3f;
-        private readonly byte[] _fontIndex =
-        {
-            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 136, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 152, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223
-        };
         private readonly IntPtr[] _unicodeFontAddress = new IntPtr[20];
         private readonly long[] _unicodeFontSize = new long[20];
         private readonly Dictionary<ushort, WebLink> _webLinks = new Dictionary<ushort, WebLink>();
@@ -194,12 +191,6 @@ namespace ClassicUO.IO.Resources
                     _unicodeFontAddress[1] = _unicodeFontAddress[0];
                     _unicodeFontSize[1] = _unicodeFontSize[0];
                 }
-
-                for (int i = 0; i < 256; i++)
-                {
-                    if (_fontIndex[i] >= 0xE0)
-                        _fontIndex[i] = _fontIndex[' '];
-                }
             });
         }
 
@@ -250,7 +241,12 @@ namespace ClassicUO.IO.Resources
             int textLength = 0;
 
             foreach (char c in str)
-                textLength += _font[font][_fontIndex[(byte) c]].Width;
+            {
+                if(c < NOPRINT_CHARS)
+                    textLength += _font[font][0].Width;
+                else
+                    textLength += _font[font][c - NOPRINT_CHARS].Width;
+            }
 
             return textLength;
         }
@@ -377,12 +373,16 @@ namespace ClassicUO.IO.Resources
             }
 
             if (isCropped)
-                width -= fd[_fontIndex[(byte) '.']].Width * 3;
+                width -= fd['.' - NOPRINT_CHARS].Width * 3;
             int textLength = 0;
 
             foreach (char c in str)
             {
-                textLength += fd[_fontIndex[(byte) c]].Width;
+
+                if (c < NOPRINT_CHARS)
+                    textLength += _font[font][0].Width;
+                else
+                    textLength += _font[font][c - NOPRINT_CHARS].Width;
 
                 if (textLength > width)
                     break;
@@ -489,7 +489,11 @@ namespace ClassicUO.IO.Resources
                 {
                     byte index = (byte) ptr.Data[i].Item;
                     int offsY = GetFontOffsetY(font, index);
-                    ref readonly FontCharacterData fcd = ref fd[_fontIndex[index]];
+                    if (index < NOPRINT_CHARS)
+                        index = 0;
+                    else
+                        index -= NOPRINT_CHARS;
+                    ref readonly FontCharacterData fcd = ref fd[index];
                     int dw = fcd.Width;
                     int dh = fcd.Height;
                     ushort charColor = color;
@@ -603,7 +607,13 @@ namespace ClassicUO.IO.Resources
                     charCount = 0;
                 }
 
-                ref readonly FontCharacterData fcd = ref fd[_fontIndex[(byte) si]];
+                byte index;
+                if (si < NOPRINT_CHARS)
+                    index = 0;
+                else
+                    index = (byte)(si - NOPRINT_CHARS);
+
+                ref readonly FontCharacterData fcd = ref fd[index];
 
                 if (si == '\n' || ptr.Width + readWidth + fcd.Width > width)
                 {
@@ -2943,7 +2953,12 @@ namespace ClassicUO.IO.Resources
 
                         for (int i = 0; i < len && i < info.Data.Count; i++)
                         {
-                            byte index = _fontIndex[info.Data[i].Item];
+                            byte index;
+                            if (info.Data[i].Item < NOPRINT_CHARS)
+                                index = 0;
+                            else
+                                index = (byte) (info.Data[i].Item - NOPRINT_CHARS);
+
                             width += fd[index].Width;
 
                             if (width > x)
@@ -3026,7 +3041,12 @@ namespace ClassicUO.IO.Resources
                 {
                     for (int i = 0; i < len; i++)
                     {
-                        byte index = _fontIndex[info.Data[i].Item];
+
+                        byte index;
+                        if (info.Data[i].Item < NOPRINT_CHARS)
+                            index = 0;
+                        else
+                            index = (byte)(info.Data[i].Item - NOPRINT_CHARS);
                         x += fd[index].Width;
 
                         if (info.CharStart + i + 1 == pos)


### PR DESCRIPTION
The _fontIndex mapped non-ASCII characters to different position
in fonts.mul. Instead of hardcoding character mapping in the
client, shards should fix their fonts.mul if they use non-ASCII
characters.