### PR TITLE
Fix ommiting some unicode characters

### DIFF
--- a/src/IO/Resources/FontsLoader.cs
+++ b/src/IO/Resources/FontsLoader.cs
@@ -1651,9 +1651,9 @@ namespace ClassicUO.IO.Resources
                 char si = htmlData[i].Char;
                 uint* table = (uint*) _unicodeFontAddress[htmlData[i].Font];
 
-                if ((byte) si == 0x000D || si == '\n')
+                if (si == 0x000D || si == '\n')
                 {
-                    if ((byte) si == 0x000D || isFixed || isCropped)
+                    if (si == 0x000D || isFixed || isCropped)
                         si = (char) 0;
                     else
                         si = '\n';


### PR DESCRIPTION
Some unicode characters like have value with lower byte 0x0D.
Converting `si` to byte left only 0x0D and then wrongly assumed
it's a carriage return.

For example letter č has value 269 or 0x010D.