### PR TITLE
WorldMap will save show/hide for each marker file

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -279,8 +279,7 @@ namespace ClassicUO.Configuration
         [JsonProperty] public bool WorldMapShowMarkers { get; set; } = true;
         [JsonProperty] public bool WorldMapShowMarkersNames { get; set; } = true;
         [JsonProperty] public bool WorldMapShowMultis { get; set; } = true;
-
-
+        [JsonProperty] public string WorldMapHiddenMarkerFiles { get; set; } = string.Empty;
 
 
         internal static string ProfilePath { get; } = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Profiles");


### PR DESCRIPTION
Default WorldMap behavior is to show all markers by default.  Now, markers you have hidden will be saved in your profile and hidden when you reload the world map.

(Sorry Kar, realized I didn't branch off dev for this PR)