### PR TITLE
Fix crash when rendering nonASCII character as ASCII

### DIFF
--- a/src/IO/Resources/FontsLoader.cs
+++ b/src/IO/Resources/FontsLoader.cs
@@ -232,6 +232,15 @@ namespace ClassicUO.IO.Resources
             return (width, height);
         }
 
+        /// <summary> Get the index in ASCII fonts of a character. </summary>
+        private int GetASCIIIndex(char c)
+        {
+            byte ch = (byte) c; // ASCII fonts cover only 256 characters
+            if (ch < NOPRINT_CHARS)
+                return 0;
+            else
+                return ch - NOPRINT_CHARS;
+        }
 
         public int GetWidthASCII(byte font, string str)
         {
@@ -242,10 +251,7 @@ namespace ClassicUO.IO.Resources
 
             foreach (char c in str)
             {
-                if(c < NOPRINT_CHARS)
-                    textLength += _font[font][0].Width;
-                else
-                    textLength += _font[font][c - NOPRINT_CHARS].Width;
+                textLength += _font[font][GetASCIIIndex(c)].Width;
             }
 
             return textLength;
@@ -271,6 +277,8 @@ namespace ClassicUO.IO.Resources
 
             return textWidth;
         }
+
+
 
         private int GetHeightASCII(MultilinesFontInfo info)
         {
@@ -378,11 +386,7 @@ namespace ClassicUO.IO.Resources
 
             foreach (char c in str)
             {
-
-                if (c < NOPRINT_CHARS)
-                    textLength += _font[font][0].Width;
-                else
-                    textLength += _font[font][c - NOPRINT_CHARS].Width;
+                textLength += _font[font][GetASCIIIndex(c)].Width;
 
                 if (textLength > width)
                     break;
@@ -489,11 +493,7 @@ namespace ClassicUO.IO.Resources
                 {
                     byte index = (byte) ptr.Data[i].Item;
                     int offsY = GetFontOffsetY(font, index);
-                    if (index < NOPRINT_CHARS)
-                        index = 0;
-                    else
-                        index -= NOPRINT_CHARS;
-                    ref FontCharacterData fcd = ref fd[index];
+                    ref FontCharacterData fcd = ref fd[GetASCIIIndex(ptr.Data[i].Item)];
                     int dw = fcd.Width;
                     int dh = fcd.Height;
                     ushort charColor = color;
@@ -607,13 +607,7 @@ namespace ClassicUO.IO.Resources
                     charCount = 0;
                 }
 
-                byte index;
-                if (si < NOPRINT_CHARS)
-                    index = 0;
-                else
-                    index = (byte)(si - NOPRINT_CHARS);
-
-                ref FontCharacterData fcd = ref fd[index];
+                ref FontCharacterData fcd = ref fd[GetASCIIIndex(si)];
 
                 if (si == '\n' || ptr.Width + readWidth + fcd.Width > width)
                 {
@@ -2953,13 +2947,7 @@ namespace ClassicUO.IO.Resources
 
                         for (int i = 0; i < len && i < info.Data.Count; i++)
                         {
-                            byte index;
-                            if (info.Data[i].Item < NOPRINT_CHARS)
-                                index = 0;
-                            else
-                                index = (byte) (info.Data[i].Item - NOPRINT_CHARS);
-
-                            width += fd[index].Width;
+                            width += fd[GetASCIIIndex(info.Data[i].Item)].Width;
 
                             if (width > x)
                                 break;
@@ -3041,13 +3029,7 @@ namespace ClassicUO.IO.Resources
                 {
                     for (int i = 0; i < len; i++)
                     {
-
-                        byte index;
-                        if (info.Data[i].Item < NOPRINT_CHARS)
-                            index = 0;
-                        else
-                            index = (byte)(info.Data[i].Item - NOPRINT_CHARS);
-                        x += fd[index].Width;
+                        x += fd[GetASCIIIndex(info.Data[i].Item)].Width;
 
                         if (info.CharStart + i + 1 == pos)
                             return (x, y);


### PR DESCRIPTION
When character > 255 was being printed using ASCII fonts it caused
IndexOutOfRangeException to be thrown. This will prevent the crash
by casting the char to byte (like it did before) before calculating
font index.