### PR TITLE
Fix libs copying commands in PostBuildEvent

### DIFF
--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -108,9 +108,9 @@
       mkdir -p "$(OutputPath)x64/"
       fi
 
-      cp -ru $(SolutionDir)external/lib64/*.*   $(OutputPath)lib64/
-      cp -ru $(SolutionDir)external/osx/*.*     $(OutputPath)osx/ 
-      cp -ru $(SolutionDir)external/x64/*.*     $(OutputPath)x64/
+      cp -Rf $(SolutionDir)external/lib64/*.*   $(OutputPath)lib64/
+      cp -Rf $(SolutionDir)external/osx/*.*     $(OutputPath)osx/ 
+      cp -Rf $(SolutionDir)external/x64/*.*     $(OutputPath)x64/
     </PostBuildEvent>
    
   </PropertyGroup>


### PR DESCRIPTION
This fix replaces non-macOS-compatible `-ru` options with `-Rf` that work on both macOS and Linux.