### PR TITLE
Update build/run instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Follow instructions on https://brew.sh/
 After the first run, ignore the error message and a new file called `settings.json` will be automatically created in the directory that contains ClassicUO.exe.
 
 Other useful commands:
-- `msbuild /t:Clean`
+- `msbuild /t:Clean /p:Configuration=Debug`
 - `msbuild /t:Clean /p:Configuration=Release`
 
 # Contribute

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ Follow instructions on https://brew.sh/
 `nuget restore`
 
 6. Build:
-  - Debug version: `msbuild /t:Rebuild`
+  - Debug version: `msbuild /t:Rebuild /p:Configuration=Debug`
   - Release version: `msbuild /t:Rebuild /p:Configuration=Release`
 
 7. Run ClassicUO via Mono:
-  - Debug version: `mono ./bin/Debug/ClassicUO.exe`
-  - Release version: `mono ./bin/Release/ClassicUO.exe`
+  - Debug version: `DYLD_LIBRARY_PATH=./bin/Debug/osx/ mono ./bin/Debug/ClassicUO.exe`
+  - Release version: `DYLD_LIBRARY_PATH=./bin/Release/osx/ mono ./bin/Release/ClassicUO.exe`
 
-After the first run, ignore the error message and a new file named `settings.json` will be automatically created in the directory with ClassicUO.exe.
+After the first run, ignore the error message and a new file called `settings.json` will be automatically created in the directory that contains ClassicUO.exe.
 
 Other useful commands:
 - `msbuild /t:Clean`


### PR DESCRIPTION
To force mono to use supplied with ClassicUO libraries (no need to install system-wide SDL libraries) the `DYLD_LIBRARY_PATH` runtime environment variable should be used in front of the `mono` command. This allows seamless build and run experience on macOS 10.12+.