### PR TITLE
Fix Mac building

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Follow instructions on https://brew.sh/
   - Release version: `msbuild /t:Rebuild /p:Configuration=Release`
 
 7. Run ClassicUO via Mono:
-  - Debug version: `DYLD_LIBRARY_PATH=./bin/Debug/osx/ mono ./bin/Debug/ClassicUO.exe`
-  - Release version: `DYLD_LIBRARY_PATH=./bin/Release/osx/ mono ./bin/Release/ClassicUO.exe`
+  - Debug version: `mono ./bin/Debug/ClassicUO.exe`
+  - Release version: `mono ./bin/Release/ClassicUO.exe`
 
 After the first run, ignore the error message and a new file called `settings.json` will be automatically created in the directory that contains ClassicUO.exe.
 

--- a/external/FNA/FNA.dll.config
+++ b/external/FNA/FNA.dll.config
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<dllmap dll="SDL2" os="windows" target="SDL2.dll"/>
-	<dllmap dll="SDL2" os="osx" target="libSDL2-2.0.0.dylib"/>
-	<dllmap dll="SDL2" os="linux,freebsd,netbsd" target="libSDL2-2.0.so.0"/>
+	<dllmap dll="SDL2" os="windows" target="x64/SDL2.dll"/>
+	<dllmap dll="SDL2" os="osx" target="osx/libSDL2-2.0.0.dylib"/>
+	<dllmap dll="SDL2" os="linux,freebsd,netbsd" target="lib64/libSDL2-2.0.so.0"/>
 
-	<dllmap dll="FNA3D" os="windows" target="FNA3D.dll"/>
-	<dllmap dll="FNA3D" os="osx" target="libFNA3D.0.dylib"/>
-	<dllmap dll="FNA3D" os="linux,freebsd,netbsd" target="libFNA3D.so.0"/>
+	<dllmap dll="FNA3D" os="windows" target="x64/FNA3D.dll"/>
+	<dllmap dll="FNA3D" os="osx" target="osx/libFNA3D.0.dylib"/>
+	<dllmap dll="FNA3D" os="linux,freebsd,netbsd" target="lib64/libFNA3D.so.0"/>
 
-	<dllmap dll="FAudio" os="windows" target="FAudio.dll"/>
-	<dllmap dll="FAudio" os="osx" target="libFAudio.0.dylib"/>
-	<dllmap dll="FAudio" os="linux,freebsd,netbsd" target="libFAudio.so.0"/>
+	<dllmap dll="FAudio" os="windows" target="x64/FAudio.dll"/>
+	<dllmap dll="FAudio" os="osx" target="osx/libFAudio.0.dylib"/>
+	<dllmap dll="FAudio" os="linux,freebsd,netbsd" target="lib64/libFAudio.so.0"/>
 
 	<dllmap dll="SDL2"		os="osx" cpu="armv8" target="__Internal"/>
 	<dllmap dll="FNA3D" 		os="osx" cpu="armv8" target="__Internal"/>

--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -17,7 +17,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>$(SolutionDir)bin\Debug\</OutputPath>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
@@ -96,16 +96,17 @@
       if ! [ -d "$(OutputPath)osx/" ]; then
       mkdir -p "$(OutputPath)osx/"
       fi
- 
+
       if ! [ -d "$(OutputPath)x64/" ]; then
       mkdir -p "$(OutputPath)x64/"
       fi
 
-      cp -Rf "$(SolutionDir)external/lib64/*.*"  "$(OutputPath)lib64/"
-      cp -Rf "$(SolutionDir)external/osx/*.*"    "$(OutputPath)osx/"
-      cp -Rf "$(SolutionDir)external/x64/*.*"    "$(OutputPath)x64/"
+      cd "$(SolutionDir)"
+      cp -Rf external/lib64/*.*  "$(OutputPath)lib64/"
+      cp -Rf external/osx/*.*  "$(OutputPath)osx/"
+      cp -Rf external/x64/*.*  "$(OutputPath)x64/"
     </PostBuildEvent>
-   
+
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
# Mac Building
There was a failure on [the copy commands](https://github.com/andreakarasho/ClassicUO/blob/a870d1ea5217b371ec8b1ade9bfd51e4ce14fc8a/src/ClassicUO.csproj#L104-L106) on Mac OS X, you can't use quotes with `*`, so the copying fails:

```
> ls "*"
ls: *: No such file or directory
```

It works if you remove the quotes around `$(SolutionDir)....` but then it fails if there is a space in the directory. I first tried `pushd` / `popd` which succeeded on Mac but failed on Linux, so now I have a `cd` with no pushing, which I guess is fine.

# Native Libs Import

It appears using the relative paths in the app config works. Built and ran via `msbuild && mono .\bin\Debug\ClassicUO.exe`:

## Linux

<img width="636" alt="dllmap-fix-linux" src="https://user-images.githubusercontent.com/8634912/89316674-b5a50100-d67c-11ea-9689-6b61b050699f.png">

## Mac

<img width="792" alt="dllmap-fix-mac" src="https://user-images.githubusercontent.com/8634912/89316690-ba69b500-d67c-11ea-9936-1c8f7ecbd1e1.png">

## Windows

<img width="756" alt="dllmap-fix-windows" src="https://user-images.githubusercontent.com/8634912/89316696-bb024b80-d67c-11ea-8616-811349cc707b.png">
 
