### PR TITLE
Highlight Gameobject fix

### DIFF
--- a/src/Game/GameObjects/Views/MobileView.cs
+++ b/src/Game/GameObjects/Views/MobileView.cs
@@ -82,8 +82,15 @@ namespace ClassicUO.Game.GameObjects
 
             if (ProfileManager.Current.HighlightGameObjects && SelectedObject.LastObject == this)
             {
-                _viewHue = Constants.HIGHLIGHT_CURRENT_OBJECT_HUE;
-                HueVector.Y = 1;
+                Item item = World.Items.Get(Serial);
+
+                if (this == item)
+                {
+                	_viewHue = Constants.HIGHLIGHT_CURRENT_OBJECT_HUE;
+                	HueVector.Y = 1;
+                }
+                else
+                	_viewHue = Notoriety.GetHue(NotorietyFlag);
             }
             else if (SelectedObject.HealthbarObject == this)
             {


### PR DESCRIPTION
Fixes the bug where HighLightGameObjects(on) would override notoriety colors & by state (IsPoisoned, IsParalyzed, Invul)