### PR TITLE
Fixes issue with bulletin items being cut off

### DIFF
--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -2376,7 +2376,7 @@ namespace ClassicUO.Network
 
                             if (lineLen > 0)
                             {
-                                string putta = p.ReadUTF8StringSafe();
+                                string putta = p.ReadUTF8StringSafe(lineLen);
                                 sb.Append(putta);
                                 sb.Append('\n');
                             }

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -2376,7 +2376,7 @@ namespace ClassicUO.Network
 
                             if (lineLen > 0)
                             {
-                                string putta = p.ReadUTF8StringSafe(len);
+                                string putta = p.ReadUTF8StringSafe();
                                 sb.Append(putta);
                                 sb.Append('\n');
                             }


### PR DESCRIPTION
It's using the length of the date to read each line of text resulting in cut off text, I don't believe `len` is supposed to be there per the packet spec.  Please close out if this fix isn't needed.

See https://github.com/andreakarasho/ClassicUO/issues/1225