### PR TITLE
Fixes blank message on older client if three skills aren't selected

### DIFF
--- a/src/Game/UI/Gumps/CharCreation/CreateCharTradeGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharTradeGump.cs
@@ -28,6 +28,7 @@ using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.IO.Resources;
+using ClassicUO.Resources;
 
 namespace ClassicUO.Game.UI.Gumps.CharCreation
 {
@@ -255,7 +256,7 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
                          ?.ShowMessage
                          (
                              Client.Version <= ClientVersion.CV_5090 ?
-                                 "You must have three unique skills chosen!" :
+                                 ResGumps.YouMustHaveThreeUniqueSkillsChosen :
                                  ClilocLoader.Instance.GetString(1080032)
                          );
 

--- a/src/Game/UI/Gumps/CharCreation/CreateCharTradeGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharTradeGump.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.Linq;
+using ClassicUO.Data;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
@@ -250,7 +251,13 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
             }
             else
             {
-                UIManager.GetGump<CharCreationGump>()?.ShowMessage(ClilocLoader.Instance.GetString(1080032));
+                UIManager.GetGump<CharCreationGump>()
+                         ?.ShowMessage
+                         (
+                             Client.Version <= ClientVersion.CV_5090 ?
+                                 "You must have three unique skills chosen!" :
+                                 ClilocLoader.Instance.GetString(1080032)
+                         );
 
                 return false;
             }

--- a/src/Resources/ResGumps.Designer.cs
+++ b/src/Resources/ResGumps.Designer.cs
@@ -3896,6 +3896,15 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You must have three unique skills chosen!.
+        /// </summary>
+        public static string YouMustHaveThreeUniqueSkillsChosen {
+            get {
+                return ResourceManager.GetString("YouMustHaveThreeUniqueSkillsChosen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Your current channel:.
         /// </summary>
         public static string YourCurrentChannel {

--- a/src/Resources/ResGumps.resx
+++ b/src/Resources/ResGumps.resx
@@ -1405,4 +1405,7 @@ Client version: '{0}'</value>
   <data name="HighlightContainerWhenSelected" xml:space="preserve">
     <value>Highlight container on ground when mouse is over a container gump</value>
   </data>
+  <data name="YouMustHaveThreeUniqueSkillsChosen" xml:space="preserve">
+    <value>You must have three unique skills chosen!</value>
+  </data>
 </root>


### PR DESCRIPTION
CliLoc 1080032 "You must have three unique skills chosen!" only exists on newer clients. At least on 5.0.8.3 the max is 1078060 until it jumps to 3000000 so unless the person selects all 3, they get a blank error message.

To note, on the the 5.0.8.3 OSI client, if you only selected one skill, it will display "You must have three unique skills chosen!", but if you choose 2, it lets you go through so perhaps the validation should only check for 2 out of the 3 instead?

I can't find "You must have three unique skills chosen!" anywhere in the older cliloc file so it must have been hard coded before they moved it to 1080032.

Close out the PR if there is a better way to handle this. 👍 