### PR TITLE
Change `CurrentLoginStep` on packet 0x86

### DIFF
--- a/src/Game/Scenes/LoginScene.cs
+++ b/src/Game/Scenes/LoginScene.cs
@@ -597,6 +597,7 @@ namespace ClassicUO.Game.Scenes
                 case 0x86: // UpdateCharacterList
                     ParseCharacterList(e);
 
+                    CurrentLoginStep = LoginSteps.CharacterSelection;
                     UIManager.GetGump<CharacterSelectionGump>()?.Dispose();
 
                     _currentGump?.Dispose();


### PR DESCRIPTION
When this packet is received, the `CurrentLoginStep` is not updated to `LoginSteps.CharacterSelection` despite navigating there `UIManager.Add(_currentGump = new CharacterSelectionGump());`
This will leave the loading cursor active during character selection.