### PR TITLE
Consolidate project targets to net472 and let it compile on Linux without error MSB3644

### DIFF
--- a/PackageReferences.targets
+++ b/PackageReferences.targets
@@ -1,8 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-</Project>

--- a/PackageReferences.targets
+++ b/PackageReferences.targets
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
@@ -52,33 +51,39 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="cuologo.png" />
-    <EmbeddedResource Include="Renderer\fonts\bold_font.xnb" />
-    <EmbeddedResource Include="Renderer\fonts\map1_font.xnb" />
-    <EmbeddedResource Include="Renderer\fonts\map2_font.xnb" />
-    <EmbeddedResource Include="Renderer\fonts\map3_font.xnb" />
-    <EmbeddedResource Include="Renderer\fonts\map4_font.xnb" />
-    <EmbeddedResource Include="Renderer\fonts\map5_font.xnb" />
-    <EmbeddedResource Include="Renderer\fonts\map6_font.xnb" />
-    <EmbeddedResource Include="Renderer\fonts\regular_font.xnb" />
-    <EmbeddedResource Include="shaders\IsometricWorld.fxc" />
-    <EmbeddedResource Include="shaders\xBR.fxc" />
+    <EmbeddedResource Include="cuologo.png"/>
+    <EmbeddedResource Include="Renderer\fonts\bold_font.xnb"/>
+    <EmbeddedResource Include="Renderer\fonts\map1_font.xnb"/>
+    <EmbeddedResource Include="Renderer\fonts\map2_font.xnb"/>
+    <EmbeddedResource Include="Renderer\fonts\map3_font.xnb"/>
+    <EmbeddedResource Include="Renderer\fonts\map4_font.xnb"/>
+    <EmbeddedResource Include="Renderer\fonts\map5_font.xnb"/>
+    <EmbeddedResource Include="Renderer\fonts\map6_font.xnb"/>
+    <EmbeddedResource Include="Renderer\fonts\regular_font.xnb"/>
+    <EmbeddedResource Include="shaders\IsometricWorld.fxc"/>
+    <EmbeddedResource Include="shaders\xBR.fxc"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="cuoapi">
       <HintPath>..\external\api\cuoapi.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression"/>
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Properties\" />
+    <Folder Include="Properties\"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\external\FNA\FNA.Core.csproj" />
+    <ProjectReference Include="..\external\FNA\FNA.Core.csproj"/>
   </ItemGroup>
 
   <ItemGroup>
@@ -116,31 +121,31 @@
 
 
   <ItemGroup>
-    <DataFiles_x64 Include="$(ProjectDir)..\external\x64\*.*" />
-    <DataFiles_lib64 Include="$(ProjectDir)..\external\lib64\*.*" />
-    <DataFiles_osx Include="$(ProjectDir)..\external\osx\*.*" />
-    <DataFiles_vulkan Include="$(ProjectDir)..\external\vulkan\icd.d\*.*" />
+    <DataFiles_x64 Include="$(ProjectDir)..\external\x64\*.*"/>
+    <DataFiles_lib64 Include="$(ProjectDir)..\external\lib64\*.*"/>
+    <DataFiles_osx Include="$(ProjectDir)..\external\osx\*.*"/>
+    <DataFiles_vulkan Include="$(ProjectDir)..\external\vulkan\icd.d\*.*"/>
   </ItemGroup>
 
 
   <Target Name="CopyExternalDeps_build" AfterTargets="Build">
-    <Copy SourceFiles="@(DataFiles_x64)" DestinationFolder="$(TargetDir)\x64\" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(DataFiles_lib64)" DestinationFolder="$(TargetDir)\lib64\" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(DataFiles_osx)" DestinationFolder="$(TargetDir)\osx\" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(DataFiles_vulkan)" DestinationFolder="$(TargetDir)\vulkan\icd.d\" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(DataFiles_x64)" DestinationFolder="$(TargetDir)\x64\" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(DataFiles_lib64)" DestinationFolder="$(TargetDir)\lib64\" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(DataFiles_osx)" DestinationFolder="$(TargetDir)\osx\" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(DataFiles_vulkan)" DestinationFolder="$(TargetDir)\vulkan\icd.d\" SkipUnchangedFiles="true"/>
   </Target>
 
   <Target Name="CopyExternalDeps_publish" AfterTargets="Publish">
     <ItemGroup>
-      <MonockickstartPath Include="$(ProjectDir)..\tools\monokickstart\*.*" />
+      <MonockickstartPath Include="$(ProjectDir)..\tools\monokickstart\*.*"/>
     </ItemGroup>
 
-    <Copy SourceFiles="@(DataFiles_x64)" DestinationFolder="$(PublishDir)\x64\" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(DataFiles_lib64)" DestinationFolder="$(PublishDir)\lib64\" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(DataFiles_osx)" DestinationFolder="$(PublishDir)\osx\" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(DataFiles_vulkan)" DestinationFolder="$(PublishDir)\vulkan\icd.d\" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(DataFiles_x64)" DestinationFolder="$(PublishDir)\x64\" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(DataFiles_lib64)" DestinationFolder="$(PublishDir)\lib64\" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(DataFiles_osx)" DestinationFolder="$(PublishDir)\osx\" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(DataFiles_vulkan)" DestinationFolder="$(PublishDir)\vulkan\icd.d\" SkipUnchangedFiles="true"/>
 
-    <Copy SourceFiles="@(MonockickstartPath)" DestinationFolder="$(PublishDir)\" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(MonockickstartPath)" DestinationFolder="$(PublishDir)\" SkipUnchangedFiles="true"/>
 
   </Target>
 

--- a/tests/ClassicUO.UnitTests/ClassicUO.UnitTests.csproj
+++ b/tests/ClassicUO.UnitTests/ClassicUO.UnitTests.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="../../PackageReferences.targets" Condition="'$(OS)' != 'Windows'"/>
-
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
 
@@ -23,6 +20,13 @@
     <PackageReference Include="xunit" Version="2.4.0"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0"/>
     <PackageReference Include="coverlet.collector" Version="1.2.0"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ClassicUO.UnitTests/ClassicUO.UnitTests.csproj
+++ b/tests/ClassicUO.UnitTests/ClassicUO.UnitTests.csproj
@@ -1,35 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net472</TargetFramework>
+  <Import Project="../../PackageReferences.targets" Condition="'$(OS)' != 'Windows'"/>
 
-        <IsPackable>false</IsPackable>
-        <DebugType>Full</DebugType>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
 
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <PlatformTarget>x64</PlatformTarget>
-    </PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <PlatformTarget>x64</PlatformTarget>
-    </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-        <PackageReference Include="xunit" Version="2.4.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-        <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <Folder Include="Game" />
-      <Folder Include="Utility" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
+    <PackageReference Include="xunit" Version="2.4.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0"/>
+    <PackageReference Include="coverlet.collector" Version="1.2.0"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\ClassicUO.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Game"/>
+    <Folder Include="Utility"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ClassicUO.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/tools/ManifestCreator/ManifestCreator.csproj
+++ b/tools/ManifestCreator/ManifestCreator.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../../PackageReferences.targets" Condition="'$(OS)' != 'Windows'"/>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/tools/ManifestCreator/ManifestCreator.csproj
+++ b/tools/ManifestCreator/ManifestCreator.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="../../PackageReferences.targets" Condition="'$(OS)' != 'Windows'"/>
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
@@ -14,5 +11,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
make sure ReferenceAssemblies are pulled in for non windows platforms to eradicate

```
...Microsoft.Common.CurrentVersion.targets(1175,5): 
error MSB3644: The reference assemblies for framework ".NETFramework,Version=v4.7" 
were not found. To resolve this, install the SDK or Targeting Pack for this framework 
version or retarget your application to a version of the framework for which you have 
the SDK or Targeting Pack installed. Note that assemblies will be resolved from the 
Global Assembly Cache (GAC) and will be used in place of reference assemblies. 
Therefore your assembly may not be correctly targeted for the framework you intend.
```

and I also retargeted all projects to `net472`, not sure if `net48` will run/exist on win7