### PR TITLE
Fix reopening container gumps in correct order

### DIFF
--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -63,6 +63,8 @@ namespace ClassicUO.Game.UI.Gumps
                 return;
             }
 
+            ParentSerial = item.Container;
+
             Graphic = gumpid;
 
             BuildGump();
@@ -88,6 +90,8 @@ namespace ClassicUO.Game.UI.Gumps
         }
 
         public ushort Graphic { get; }
+
+        public uint ParentSerial { get; set; }
 
         public override GumpType GumpType => GumpType.Container;
 

--- a/src/Game/UI/Gumps/ContainerGump.cs
+++ b/src/Game/UI/Gumps/ContainerGump.cs
@@ -91,7 +91,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public ushort Graphic { get; }
 
-        public uint ParentSerial { get; set; }
+        public uint ParentSerial { get; }
 
         public override GumpType GumpType => GumpType.Container;
 


### PR DESCRIPTION
Fixed issue with reopening gumps after login where containers would open after their child container causing child gump to close.

Added functionality to sort ContainerGumps by their new ParentSerial property to reopen in correct order.