### PR TITLE
Attempt at fixing bogus speech input from hotkeys on Linux

### DIFF
--- a/src/Game/UI/Controls/StbTextBox.cs
+++ b/src/Game/UI/Controls/StbTextBox.cs
@@ -735,7 +735,7 @@ namespace ClassicUO.Game.UI.Controls
 
         protected override void OnTextInput(string c)
         {
-            if (c == null || !IsEditable)
+            if (c == null || !IsEditable || Keyboard.Alt || Keyboard.Ctrl)
             {
                 return;
             }


### PR DESCRIPTION
Trying to fix #1233 here -- this thing bugs me like hell on Linux since all my HK are on Alt+something.
Somewhat naive I guess, but during some poking around it doesn't seem to mess with the editing/history hotkeys.