### PR TITLE
Book fix part seven

### DIFF
--- a/src/Game/UI/Gumps/ModernBookGump.cs
+++ b/src/Game/UI/Gumps/ModernBookGump.cs
@@ -69,13 +69,23 @@ namespace ClassicUO.Game.UI.Gumps
 
             for (int i = 0, l = BookLines.Length; i < l; i++)
             {
+                if (BookLines[i] != null && BookLines[i].Contains("\n"))
+                {
+                    BookLines[i] = BookLines[i].Replace("\n", "");
+                }
+            }
+
+            for (int i = 0, l = BookLines.Length; i < l; i++)
+            {
                 int w = IsNewBook ?
                     FontsLoader.Instance.GetWidthUnicode(_bookPage.renderedText.Font, BookLines[i]) :
                     FontsLoader.Instance.GetWidthASCII(_bookPage.renderedText.Font, BookLines[i]);
 
                 sb.Append(BookLines[i]);
 
-                if (i + 1 < l && (string.IsNullOrWhiteSpace(BookLines[i]) || w + sw < _bookPage.renderedText.MaxWidth))
+                if (BookLines[i] == null) continue;
+
+                if (i + 1 < l && (string.IsNullOrWhiteSpace(BookLines[i]) && !BookLines[i].Contains("\n") || w + sw < _bookPage.renderedText.MaxWidth))
                 {
                     sb.Append('\n');
                     BookLines[i] += '\n';

--- a/src/Game/UI/Gumps/ModernBookGump.cs
+++ b/src/Game/UI/Gumps/ModernBookGump.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using ClassicUO.Data;
 using ClassicUO.Game.Managers;
@@ -50,6 +51,7 @@ namespace ClassicUO.Game.UI.Gumps
 
 
         public ushort BookPageCount { get; internal set; }
+        public HashSet<int> KnownPages { get; internal set; } = new HashSet<int>();
         public static bool IsNewBook => Client.Version > ClientVersion.CV_200;
         public bool UseNewHeader { get; set; } = true;
         public static byte DefaultFont => (byte) (IsNewBook ? 1 : 4);
@@ -266,18 +268,19 @@ namespace ClassicUO.Game.UI.Gumps
                 Client.Game.Scene.Audio.PlaySound(0x0055);
             }
 
-            //Non-editable books only have page data sent for currently viewed pages
+            //Non-editable books may only have data for the currently displayed pages,
+            //but some servers send their entire contents in one go so we need to keep track of which pages we know
             if (!IsEditable)
             {
                 int leftPage = (page - 1) << 1;
                 int rightPage = leftPage + 1;
 
-                if (leftPage > 0)
+                if (leftPage > 0 && !KnownPages.Contains(leftPage))
                 {
                     NetClient.Socket.Send(new PBookPageDataRequest(LocalSerial, (ushort) leftPage));
                 }
 
-                if (leftPage + 1 < MaxPage * 2)
+                if (rightPage < MaxPage * 2 && !KnownPages.Contains(rightPage))
                 {
                     NetClient.Socket.Send(new PBookPageDataRequest(LocalSerial, (ushort) rightPage));
                 }

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -2142,7 +2142,7 @@ namespace ClassicUO.Network
                     {
                         for (int n = 0; n < gump.BookLines.Length; n++)
                         {
-                            if (n < startline - 8 && n >= startline + 8)
+                            if (n < startline - 8 || n >= startline + 8)
                             {
                                 gump.BookLines[n] = string.Empty;
                             }
@@ -2152,7 +2152,7 @@ namespace ClassicUO.Network
                     {
                         for (int n = 0; n < gump.BookLines.Length; n++)
                         {
-                            if (n >= startline + 16 && n < startline)
+                            if (n >= startline + 16 || n < startline)
                             {
                                 gump.BookLines[n] = string.Empty;
                             }
@@ -2160,7 +2160,7 @@ namespace ClassicUO.Network
                     }
                 }
 
-                if (pageNum < pageCnt && pageNum >= 0)
+                if (pageNum < gump.BookPageCount && pageNum >= 0)
                 {
                     ushort lineCnt = p.ReadUShort();
 

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -2133,32 +2133,7 @@ namespace ClassicUO.Network
             for (int i = 0; i < pageCnt; i++)
             {
                 int pageNum = p.ReadUShort() - 1;
-
-                if (!gump.IsEditable) //other pages are blank
-                {
-                    int startline = pageNum * ModernBookGump.MAX_BOOK_LINES;
-
-                    if (pageNum % 2 == 0)
-                    {
-                        for (int n = 0; n < gump.BookLines.Length; n++)
-                        {
-                            if (n < startline - 8 || n >= startline + 8)
-                            {
-                                gump.BookLines[n] = string.Empty;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        for (int n = 0; n < gump.BookLines.Length; n++)
-                        {
-                            if (n >= startline + 16 || n < startline)
-                            {
-                                gump.BookLines[n] = string.Empty;
-                            }
-                        }
-                    }
-                }
+                gump.KnownPages.Add(pageNum);
 
                 if (pageNum < gump.BookPageCount && pageNum >= 0)
                 {


### PR DESCRIPTION
There were a couple of issues with books... again:

1. Books were crashing the client, possibly depending on the renderer.

2. Read-only books only displayed the first page

Tested this on POL and ServUO servers and seemed to work well enough on both of those. It turns out ServUO handles read-only books differently so some changes were necessary to accommodate that.

It seems the `pageCnt` in the `BookData` packet is the number of pages contained *in that packet*, not the total number of pages in the book.

~~Gonna test this on the Linux client in a bit, had similar issues there but instead of crashing the client the books just rendered black (probably because of opengl renderer instead of directx).~~ Fixes the black book pages issue I was complaining about on Linux too, so I guess that was just how the Windows crash issue manifested on the OpenGL renderer.

Hopefully fixes #1258 fixes #1137