### PR TITLE
Cross platform way to launch a browser with .net core and .net 5

### DIFF
--- a/src/Game/UI/Controls/HtmlControl.cs
+++ b/src/Game/UI/Controls/HtmlControl.cs
@@ -29,6 +29,7 @@ using ClassicUO.IO.Resources;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
+using ClassicUO.Utility.Platforms;
 using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Game.UI.Controls
@@ -296,14 +297,7 @@ namespace ClassicUO.Game.UI.Controls
                         {
                             Log.Info("LINK CLICKED: " + result.Link);
 
-                            try
-                            {
-                                Process.Start(result.Link);
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Error(ex.ToString());
-                            }
+                            PlatformHelper.LaunchBrowser(result.Link);
 
                             break;
                         }

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -34,6 +34,7 @@ using ClassicUO.IO;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
+using ClassicUO.Utility.Platforms;
 using SDL2;
 
 namespace ClassicUO
@@ -218,13 +219,7 @@ namespace ClassicUO
                     Client.ShowErrorMessage(ResGeneral.YourUOClientVersionIsInvalid);
                 }
 
-                try
-                {
-                    Process.Start(ResGeneral.ClassicUOLink);
-                }
-                catch
-                {
-                }
+                PlatformHelper.LaunchBrowser(ResGeneral.ClassicUOLink);
             }
             else
             {

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -3211,14 +3211,7 @@ namespace ClassicUO.Network
 
             if (!string.IsNullOrEmpty(url))
             {
-                try
-                {
-                    Process.Start(url);
-                }
-                catch (Exception)
-                {
-                    Log.Warn("Failed to open url: " + url);
-                }
+                PlatformHelper.LaunchBrowser(url);
             }
         }
 

--- a/src/Utility/Platforms/PlatformHelper.cs
+++ b/src/Utility/Platforms/PlatformHelper.cs
@@ -21,12 +21,43 @@
 
 #endregion
 
+using ClassicUO.Utility.Logging;
 using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace ClassicUO.Utility.Platforms
 {
     internal static class PlatformHelper
     {
         public static readonly bool IsMonoRuntime = Type.GetType("Mono.Runtime") != null;
+
+        public static void LaunchBrowser(string url)
+        {
+            try
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    ProcessStartInfo psi = new ProcessStartInfo
+                    {
+                        FileName = url,
+                        UseShellExecute = true
+                    };
+                    Process.Start(psi);
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    Process.Start("open", url);
+                }
+                else
+                {
+                    Process.Start("xdg-open", url);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
In .net core, launching a browser in a cross-platform way is a bit more
complicated. Add a helper function and use that everywhere.

This also happens to work on .net framework, even though just
Process.Start is sufficient there.