### PR TITLE
Fix dropping item.Z while dropping item on desk/etc.

### DIFF
--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -441,7 +441,7 @@ namespace ClassicUO.Game.Scenes
 
                             dropX = obj.X;
                             dropY = obj.Y;
-                            dropZ = obj.Z;
+                            dropZ = (sbyte)(obj.Z + it2.ItemData.Height);
                         }
                     }
                     else


### PR DESCRIPTION
I found a little bug with dropping items on desk. If you put item on desk, it will fall out of desk and appear on the ground.  

Probably it is problem only on old sphere, which isn't fixing Z on item. I Found that if I send item z as ground, sphere doesn't fix it by items on that same spot. 