### PR TITLE
Fix UTF-8 in old book header packet (0x93)

### DIFF
--- a/src/Network/Packets.cs
+++ b/src/Network/Packets.cs
@@ -1266,8 +1266,8 @@ namespace ClassicUO.Network
             WriteByte(0);
             WriteByte(1);
             WriteUShort(0);
-            WriteASCII(title, 60);
-            WriteASCII(author, 30);
+            WriteUTF8(title, 60);
+            WriteUTF8(author, 30);
         }
     }
 


### PR DESCRIPTION
It seems the title and author in this packet are supposed to be UTF-8, at least on the one server I managed to test this on using client 5.0.1j. It's already being read as UTF-8, but when sending the packet we're sending CP1252 (or "ASCII" as we call it) instead which leads to breakage when book title or author contain non-ASCII characters (eg. ä, é).

Technical issues prevented me from testing the behaviour on more servers than one. I'm hoping this doesn't break anything on other servers because if it does then it means the default client is doing some annoying strange things again.