### PR TITLE
Implement character creation feature flag restrictions

### DIFF
--- a/src/Game/UI/Controls/Button.cs
+++ b/src/Game/UI/Controls/Button.cs
@@ -223,7 +223,9 @@ namespace ClassicUO.Game.UI.Controls
         {
             UOTexture texture = GetTextureByState();
 
-            ResetHueVector();
+            int hue = IsEnabled ? 0 : 944;
+            
+            ShaderHueTranslator.GetHueVector(ref HueVector, hue, false, Alpha, true);
 
             HueVector.Z = Alpha;
 

--- a/src/Game/UI/Controls/Button.cs
+++ b/src/Game/UI/Controls/Button.cs
@@ -181,6 +181,7 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
+        public int Hue { get; set; }
         public ushort FontHue { get; }
 
         public ushort HueHover { get; }
@@ -223,9 +224,7 @@ namespace ClassicUO.Game.UI.Controls
         {
             UOTexture texture = GetTextureByState();
 
-            int hue = IsEnabled ? 0 : 944;
-            
-            ShaderHueTranslator.GetHueVector(ref HueVector, hue, false, Alpha, true);
+            ShaderHueTranslator.GetHueVector(ref HueVector, Hue, false, Alpha, true);
 
             HueVector.Z = Alpha;
 

--- a/src/Game/UI/Gumps/CharCreation/CreateCharAppearanceGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharAppearanceGump.cs
@@ -358,14 +358,17 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
             if (race == RaceType.ELF && !allowElf)
             {
                 _nextButton.IsEnabled = false;
+                _nextButton.Hue = 944;
             }
             else if (race == RaceType.GARGOYLE && !allowGarg)
             {
                 _nextButton.IsEnabled = false;
+                _nextButton.Hue = 944;
             }
             else
             {
                 _nextButton.IsEnabled = true;
+                _nextButton.Hue = 0;
             }
         }
 

--- a/src/Game/UI/Gumps/CharCreation/CreateCharAppearanceGump.cs
+++ b/src/Game/UI/Gumps/CharCreation/CreateCharAppearanceGump.cs
@@ -47,6 +47,7 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         private readonly RadioButton _maleRadio;
         private readonly StbTextBox _nameTextBox;
         private PaperDollInteractable _paperDoll;
+        private readonly Button _nextButton;
         private readonly Dictionary<Layer, Tuple<int, ushort>> CurrentColorOption =
             new Dictionary<Layer, Tuple<int, ushort>>();
         private readonly Dictionary<Layer, int> CurrentOption = new Dictionary<Layer, int>
@@ -198,7 +199,7 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
 
             Add
             (
-                new Button((int) Buttons.Next, 0x15A4, 0x15A6, 0x15A5)
+                _nextButton = new Button((int) Buttons.Next, 0x15A4, 0x15A6, 0x15A5)
                 {
                     X = 610, Y = 445, ButtonAction = ButtonAction.Activate
                 }, 1
@@ -345,6 +346,27 @@ namespace ClassicUO.Game.UI.Gumps.CharCreation
         {
             CurrentColorOption.Clear();
             HandleGenreChange();
+            RaceType race = GetSelectedRace();
+            CharacterListFlags flags = World.ClientFeatures.Flags;
+            LockedFeatureFlags locks = World.ClientLockedFeatures.Flags;
+
+            bool allowElf = (flags & CharacterListFlags.CLF_ELVEN_RACE) != 0 &&
+                            (locks & LockedFeatureFlags.MondainsLegacy) != 0;
+
+            bool allowGarg = (locks & LockedFeatureFlags.StygianAbyss) != 0;
+            
+            if (race == RaceType.ELF && !allowElf)
+            {
+                _nextButton.IsEnabled = false;
+            }
+            else if (race == RaceType.GARGOYLE && !allowGarg)
+            {
+                _nextButton.IsEnabled = false;
+            }
+            else
+            {
+                _nextButton.IsEnabled = true;
+            }
         }
 
         private void Genre_ValueChanged(object sender, EventArgs e)


### PR DESCRIPTION
Disables the "Next" button if you're trying to create an elf or a gargoyle when the server has disabled those in feature flags.

Right now the effect is a bit ugly, the button should grey out but it seems there's no easy way to change the hue after the button is created.