### PR TITLE
Use UTF-8 in 0xD4

### DIFF
--- a/src/Network/Packets.cs
+++ b/src/Network/Packets.cs
@@ -1279,10 +1279,12 @@ namespace ClassicUO.Network
             WriteByte(0);
             WriteByte(0);
             WriteUShort(0);
-            WriteUShort((ushort) (title.Length + 1));
-            WriteASCII(title);
-            WriteUShort((ushort) (author.Length + 1));
-            WriteASCII(author);
+            int titleLength = Encoding.UTF8.GetByteCount(title);
+            WriteUShort((ushort) titleLength);
+            WriteUTF8(title, titleLength);
+            int authorLength = Encoding.UTF8.GetByteCount(author);
+            WriteUShort((ushort) authorLength);
+            WriteUTF8(author, authorLength);
         }
     }
 


### PR DESCRIPTION
Fixes #1277

This makes the behaviour match [the ServUO source code](https://github.com/ServUO/ServUO/blob/d8670d7150ea0c6586d46df0f90b1abcc9fa6aaa/Scripts/Items/Books/BaseBook.cs#L480). It obviously works on ServUO, and other emulators don't even seem to be using this packet (they use the old `0x93` packet instead) so I think it's fine.