### PR TITLE
Remove newlines from book pages when sending the packet

### DIFF
--- a/src/Network/Packets.cs
+++ b/src/Network/Packets.cs
@@ -1338,7 +1338,7 @@ namespace ClassicUO.Network
             {
                 if (text[i] != null && text[i].Length > 0)
                 {
-                    WriteBytes(Encoding.UTF8.GetBytes(text[i]));
+                    WriteBytes(Encoding.UTF8.GetBytes(text[i].Replace("\n", "")));
                 }
 
                 WriteByte(0);


### PR DESCRIPTION
The original client doesn't send these (empty lines are just a single null character there) and it seems some servers might be fussy about this.