### PR TITLE
Mac users can use 'cmd' key as macro modifier 

### DIFF
--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -253,13 +253,13 @@ namespace ClassicUO.Game.Managers
         }
 
 
-        public Macro FindMacro(SDL.SDL_Keycode key, bool alt, bool ctrl, bool shift)
+        public Macro FindMacro(SDL.SDL_Keycode key, bool alt, bool ctrl, bool shift, bool cmd = false)
         {
             Macro obj = (Macro) Items;
 
             while (obj != null)
             {
-                if (obj.Key == key && obj.Alt == alt && obj.Ctrl == ctrl && obj.Shift == shift)
+                if (obj.Key == key && obj.Alt == alt && obj.Ctrl == ctrl && obj.Shift == shift && obj.Cmd == cmd)
                 {
                     break;
                 }
@@ -1548,12 +1548,13 @@ namespace ClassicUO.Game.Managers
 
     internal class Macro : LinkedObject, IEquatable<Macro>
     {
-        public Macro(string name, SDL.SDL_Keycode key, bool alt, bool ctrl, bool shift) : this(name)
+        public Macro(string name, SDL.SDL_Keycode key, bool alt, bool ctrl, bool shift, bool cmd = false) : this(name)
         {
             Key = key;
             Alt = alt;
             Ctrl = ctrl;
             Shift = shift;
+            Cmd = cmd;
         }
 
         public Macro(string name)
@@ -1567,6 +1568,7 @@ namespace ClassicUO.Game.Managers
         public bool Alt { get; set; }
         public bool Ctrl { get; set; }
         public bool Shift { get; set; }
+        public bool Cmd { get; set; }
 
         public bool Equals(Macro other)
         {
@@ -1575,7 +1577,7 @@ namespace ClassicUO.Game.Managers
                 return false;
             }
 
-            return Key == other.Key && Alt == other.Alt && Ctrl == other.Ctrl && Shift == other.Shift &&
+            return Key == other.Key && Alt == other.Alt && Ctrl == other.Ctrl && Shift == other.Shift && Cmd == other.Cmd &&
                    Name == other.Name;
         }
 
@@ -1611,6 +1613,7 @@ namespace ClassicUO.Game.Managers
             writer.WriteAttributeString("alt", Alt.ToString());
             writer.WriteAttributeString("ctrl", Ctrl.ToString());
             writer.WriteAttributeString("shift", Shift.ToString());
+            writer.WriteAttributeString("cmd", Cmd.ToString());
 
             writer.WriteStartElement("actions");
 
@@ -1642,9 +1645,10 @@ namespace ClassicUO.Game.Managers
             }
 
             Key = (SDL.SDL_Keycode) int.Parse(xml.GetAttribute("key"));
-            Alt = bool.Parse(xml.GetAttribute("alt"));
-            Ctrl = bool.Parse(xml.GetAttribute("ctrl"));
-            Shift = bool.Parse(xml.GetAttribute("shift"));
+            Alt = xml.GetAttribute("alt") == String.Empty ? false : bool.Parse(xml.GetAttribute("alt"));
+            Ctrl = xml.GetAttribute("ctrl") == String.Empty ? false : bool.Parse(xml.GetAttribute("ctrl"));
+            Shift = xml.GetAttribute("shift") == String.Empty ? false : bool.Parse(xml.GetAttribute("shift"));
+            Cmd = xml.GetAttribute("cmd") == String.Empty ? false : bool.Parse(xml.GetAttribute("cmd"));
 
             XmlElement actions = xml["actions"];
 

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -1043,7 +1043,7 @@ namespace ClassicUO.Game.Scenes
 
             if (canExecuteMacro)
             {
-                Macro macro = Macros.FindMacro(e.keysym.sym, Keyboard.Alt, Keyboard.Ctrl, Keyboard.Shift);
+                Macro macro = Macros.FindMacro(e.keysym.sym, Keyboard.Alt, Keyboard.Ctrl, Keyboard.Shift, Keyboard.Cmd);
 
                 if (macro != null && e.keysym.sym != SDL.SDL_Keycode.SDLK_UNKNOWN)
                 {

--- a/src/Game/UI/Controls/MacroControl.cs
+++ b/src/Game/UI/Controls/MacroControl.cs
@@ -30,6 +30,7 @@ using ClassicUO.Input;
 using ClassicUO.IO.Resources;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
+using ClassicUO.Utility.Platforms;
 using SDL2;
 
 namespace ClassicUO.Game.UI.Controls
@@ -200,6 +201,11 @@ namespace ClassicUO.Game.UI.Controls
                     mod |= SDL.SDL_Keymod.KMOD_CTRL;
                 }
 
+                if (Macro.Cmd)
+                {
+                    mod |= SDL.SDL_Keymod.KMOD_GUI;
+                }
+
                 _hotkeyBox.SetKey(Macro.Key, mod);
             }
         }
@@ -209,10 +215,11 @@ namespace ClassicUO.Game.UI.Controls
             bool shift = (_hotkeyBox.Mod & SDL.SDL_Keymod.KMOD_SHIFT) != SDL.SDL_Keymod.KMOD_NONE;
             bool alt = (_hotkeyBox.Mod & SDL.SDL_Keymod.KMOD_ALT) != SDL.SDL_Keymod.KMOD_NONE;
             bool ctrl = (_hotkeyBox.Mod & SDL.SDL_Keymod.KMOD_CTRL) != SDL.SDL_Keymod.KMOD_NONE;
+            bool cmd = (_hotkeyBox.Mod & SDL.SDL_Keymod.KMOD_GUI) != SDL.SDL_Keymod.KMOD_NONE && PlatformHelper.IsOSX;
 
             if (_hotkeyBox.Key != SDL.SDL_Keycode.SDLK_UNKNOWN)
             {
-                Macro macro = Client.Game.GetScene<GameScene>().Macros.FindMacro(_hotkeyBox.Key, alt, ctrl, shift);
+                Macro macro = Client.Game.GetScene<GameScene>().Macros.FindMacro(_hotkeyBox.Key, alt, ctrl, shift, cmd);
 
                 if (macro != null)
                 {
@@ -237,12 +244,13 @@ namespace ClassicUO.Game.UI.Controls
             m.Shift = shift;
             m.Alt = alt;
             m.Ctrl = ctrl;
+            m.Cmd = cmd;
         }
 
         private void BoxOnHotkeyCancelled(object sender, EventArgs e)
         {
             Macro m = Macro;
-            m.Alt = m.Ctrl = m.Shift = false;
+            m.Alt = m.Ctrl = m.Shift = m.Cmd = false;
             m.Key = SDL.SDL_Keycode.SDLK_UNKNOWN;
         }
 

--- a/src/Input/Keyboard.cs
+++ b/src/Input/Keyboard.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using SDL2;
+using ClassicUO.Utility.Platforms;
 
 namespace ClassicUO.Input
 {
@@ -36,6 +37,7 @@ namespace ClassicUO.Input
         public static bool Alt { get; private set; }
         public static bool Shift { get; private set; }
         public static bool Ctrl { get; private set; }
+        public static bool Cmd { get; private set; }
 
 
         //public static bool IsKeyPressed(SDL.SDL_Keycode code)
@@ -64,6 +66,7 @@ namespace ClassicUO.Input
             Shift = (e.keysym.mod & SDL.SDL_Keymod.KMOD_SHIFT) != SDL.SDL_Keymod.KMOD_NONE;
             Alt = (e.keysym.mod & SDL.SDL_Keymod.KMOD_ALT) != SDL.SDL_Keymod.KMOD_NONE;
             Ctrl = (e.keysym.mod & SDL.SDL_Keymod.KMOD_CTRL) != SDL.SDL_Keymod.KMOD_NONE;
+            Cmd = (e.keysym.mod & SDL.SDL_Keymod.KMOD_GUI) != SDL.SDL_Keymod.KMOD_NONE && PlatformHelper.IsOSX;
 
             _code = SDL.SDL_Keycode.SDLK_UNKNOWN;
         }
@@ -82,6 +85,7 @@ namespace ClassicUO.Input
             Shift = (e.keysym.mod & SDL.SDL_Keymod.KMOD_SHIFT) != SDL.SDL_Keymod.KMOD_NONE;
             Alt = (e.keysym.mod & SDL.SDL_Keymod.KMOD_ALT) != SDL.SDL_Keymod.KMOD_NONE;
             Ctrl = (e.keysym.mod & SDL.SDL_Keymod.KMOD_CTRL) != SDL.SDL_Keymod.KMOD_NONE;
+            Cmd = (e.keysym.mod & SDL.SDL_Keymod.KMOD_GUI) != SDL.SDL_Keymod.KMOD_NONE && PlatformHelper.IsOSX;
 
             if (e.keysym.sym != SDL.SDL_Keycode.SDLK_UNKNOWN)
             {

--- a/src/Utility/KeysTranslator.cs
+++ b/src/Utility/KeysTranslator.cs
@@ -24,6 +24,7 @@
 using System.Collections.Generic;
 using System.Text;
 using SDL2;
+using ClassicUO.Utility.Platforms;
 
 namespace ClassicUO.Utility
 {
@@ -291,7 +292,7 @@ namespace ClassicUO.Utility
                 bool isshift = (mod & SDL.SDL_Keymod.KMOD_SHIFT) != SDL.SDL_Keymod.KMOD_NONE;
                 bool isctrl = (mod & SDL.SDL_Keymod.KMOD_CTRL) != SDL.SDL_Keymod.KMOD_NONE;
                 bool isalt = (mod & SDL.SDL_Keymod.KMOD_ALT) != SDL.SDL_Keymod.KMOD_NONE;
-
+                bool iscmd = (mod & SDL.SDL_Keymod.KMOD_GUI) != SDL.SDL_Keymod.KMOD_NONE && PlatformHelper.IsOSX;
 
                 if (isshift)
                 {
@@ -308,6 +309,10 @@ namespace ClassicUO.Utility
                     sb.Append("Alt ");
                 }
 
+                if(iscmd)
+                {
+                    sb.Append("Cmd ");
+                }
 
                 sb.Append(value);
 

--- a/src/Utility/Platforms/PlatformHelper.cs
+++ b/src/Utility/Platforms/PlatformHelper.cs
@@ -32,6 +32,10 @@ namespace ClassicUO.Utility.Platforms
     {
         public static readonly bool IsMonoRuntime = Type.GetType("Mono.Runtime") != null;
 
+        public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        public static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        public static readonly bool IsOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
         public static void LaunchBrowser(string url)
         {
             try


### PR DESCRIPTION
# Feature

On mac system it is common to use 'command' key to be a modifier of hotkeys. This PR does OS checking and allows Mac users to create macro with 'command' key.

# Changes of file `macros.xml`

## Mac

A new property `cmd` will be added into `Macro` tag when users run ClassicUO at MacOS.

## Windows

There is no change on Windows.
**A corner case:** If users copy&replace a mac copy. `cmd` properties are remained, however macros using 'cmd' key won't work. **Users have to re-assigned them to make them work again.**

This is a arguable implementation. **The reason I don't remove `cmd` property:** I don't want to break user's data without any notification. I think a better solution is that to pop out a notification, suggesting users to reassign hotkeys for those effectted macros. Another solution could be popping out the macro editing GUI to force users to re-assign hotkeys. Please advice me.

# Test

I have tested on Mac and Windows 10. 

**Please backup the `macros.xml` file before test.** Although I don't think there is any risk, just in case any bug to destory your macros.

**Off-topic:** I find that the parse error will cause recreation of `macros.xml`. It is an issue in my optionion, as users will lost all of defined macros without any notification. According to my experience, users will copy macros time to time. There is chance of tag missing during copy&parse. Maybe we could create a backup before recreation? I will submit a issue later for discussion.

# OS checking variables
Three OS checking variables under namespace `Utility.Platforms.PlatformHelper` for MacOS detection.
I find that there are two usage of `SDL.SDL_GetPlatform()` and one usage of `RuntimeInformation.IsOSPlatform()` in this project. I think it is better to use uniform OS checking. So that I will commit a PR later to apply those OS checking variables globally. Please advice me if it is a good practice.