### PR TITLE
Only ignore LeftAlt

### DIFF
--- a/src/GameController.cs
+++ b/src/GameController.cs
@@ -622,7 +622,7 @@ namespace ClassicUO
                     }
 
                     // Fix for linux OS: https://github.com/andreakarasho/ClassicUO/pull/1263
-                    if (Keyboard.Alt || Keyboard.Ctrl)
+                    if (Keyboard.LeftAlt || Keyboard.Ctrl)
                     {
                         break;
                     }

--- a/src/Input/Keyboard.cs
+++ b/src/Input/Keyboard.cs
@@ -42,6 +42,7 @@ namespace ClassicUO.Input
         public static SDL.SDL_Keymod IgnoreKeyMod { get; } = SDL.SDL_Keymod.KMOD_CAPS | SDL.SDL_Keymod.KMOD_NUM | SDL.SDL_Keymod.KMOD_MODE | SDL.SDL_Keymod.KMOD_RESERVED;
 
         public static bool Alt { get; private set; }
+        public static bool LeftAlt { get; private set; }
         public static bool Shift { get; private set; }
         public static bool Ctrl { get; private set; }
 


### PR DESCRIPTION
On German keyboard layouts the right Alt key is required for input of brackets, etc.

Only left alt, so  #1263 doesn't resurface.