### PR TITLE
Update music pathfinding.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.1.6.{build}
+version: 0.1.7.{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ build_script:
 - cmd: >-
     nuget restore
 
-    dotnet build "%APPVEYOR_BUILD_FOLDER%" -c release /p:DefineConstants="DEV_BUILD" -p:IS_DEV_BUILD=true
+    dotnet build "%APPVEYOR_BUILD_FOLDER%" -c release /p:DefineConstants="DEV_BUILD;NETFRAMEWORK" -p:IS_DEV_BUILD=true
 
 
     xcopy "%APPVEYOR_BUILD_FOLDER%\tools\monokickstart\*.*" "%APPVEYOR_BUILD_FOLDER%\bin\Release" /Y

--- a/src/Game/Data/ClientVersion.cs
+++ b/src/Game/Data/ClientVersion.cs
@@ -51,7 +51,8 @@ namespace ClassicUO.Data
         CV_308Z = (3 << 24) | (0 << 16) | (8 << 8) | ('z' & 0xFF),   // Age of Shadows. Adds paladin, necromancer, custom housing, resists, profession selection window, removes save password checkbox
         CV_400B = (4 << 24) | (0 << 16) | (0 << 8) | ('b' & 0xFF),   // Deletes tooltips
         CV_405A = (4 << 24) | (0 << 16) | (5 << 8) | ('a' & 0xFF),   // Adds ninja, samurai
-        CV_4011D = (4 << 24) | (0 << 16) | (11 << 8) | ('d' & 0xFF), // Adds elven race
+        CV_4011C = (4 << 24) | (0 << 16) | (11 << 8) | ('c' & 0xFF), // Music/* vs Music/Digital/* switchover
+		CV_4011D = (4 << 24) | (0 << 16) | (11 << 8) | ('d' & 0xFF), // Adds elven race
         CV_500A = (5 << 24) | (0 << 16) | (0 << 8) | ('a' & 0xFF),   // Paperdoll buttons journal becomes quests, chat becomes guild. Use mega FileManager.Cliloc. Removes verdata.mul.
         CV_5020 = (5 << 24) | (0 << 16) | (2 << 8) | 0,              // Adds buff bar
         CV_5090 = (5 << 24) | (0 << 16) | (9 << 8) | 0,              //

--- a/src/IO/Audio/UOMusic.cs
+++ b/src/IO/Audio/UOMusic.cs
@@ -54,7 +54,7 @@ namespace ClassicUO.IO.Audio
             Channels = AudioChannels.Stereo;
             Delay = 0;
 
-            Path = System.IO.Path.Combine(Settings.GlobalSettings.UltimaOnlineDirectory, Client.Version > ClientVersion.CV_5090 ? $"Music/Digital/{Name}.mp3" : $"music/{Name}.mp3");
+            Path = System.IO.Path.Combine(Settings.GlobalSettings.UltimaOnlineDirectory, Client.Version >= ClientVersion.CV_4011C ? $"Music/Digital/{Name}.mp3" : $"music/{Name}.mp3");
         }
 
         private string Path { get; }

--- a/src/IO/Resources/SoundsLoader.cs
+++ b/src/IO/Resources/SoundsLoader.cs
@@ -141,7 +141,7 @@ namespace ClassicUO.IO.Resources
                         }
                     }
 
-                    path = UOFileManager.GetUOFilePath(@"Music/Digital/Config.txt");
+					path = UOFileManager.GetUOFilePath(Client.Version >= ClientVersion.CV_4011C ?  @"Music/Digital/Config.txt" : @"Music/Config.txt");
 
                     if (File.Exists(path))
                     {
@@ -158,7 +158,7 @@ namespace ClassicUO.IO.Resources
                             }
                         }
                     }
-                    else if (Client.Version <= ClientVersion.CV_5090)
+                    else if (Client.Version < ClientVersion.CV_4011C)
                     {
                         _musicData.Add(0, new Tuple<string, bool>("oldult01", true));
                         _musicData.Add(1, new Tuple<string, bool>("create1", false));


### PR DESCRIPTION
In src/IO/Audio/UOMusic.cs, the path to the game music is determined with this line:
`Path = System.IO.Path.Combine(Settings.GlobalSettings.UltimaOnlineDirectory, Client.Version > ClientVersion.CV_5090 ? $"Music/Digital/{Name}.mp3" : $"music/{Name}.mp3");`

I believe client version 5.0.9.0 to be an incorrect cut-off for the Music/* - Music/Digital/* switchover.

The initial Mondain's Legacy client was v4.0.11c ([A legal and free copy of which appears to be available here](https://download.cnet.com/Ultima-Online-Mondain-s-Legacy-client/3000-7540_4-10432237.html)), and it installs with all music in the Music/Digital/ subfolder. Using ClassicUO with this client results in no music being played at all, unless the mp3 files are manually moved up one level to Music/.

This pull requests corrects this.