### PR TITLE
Update client version check for music pathfinding.

### DIFF
--- a/src/Game/Data/ClientVersion.cs
+++ b/src/Game/Data/ClientVersion.cs
@@ -51,6 +51,7 @@ namespace ClassicUO.Data
         CV_308Z = (3 << 24) | (0 << 16) | (8 << 8) | ('z' & 0xFF),   // Age of Shadows. Adds paladin, necromancer, custom housing, resists, profession selection window, removes save password checkbox
         CV_400B = (4 << 24) | (0 << 16) | (0 << 8) | ('b' & 0xFF),   // Deletes tooltips
         CV_405A = (4 << 24) | (0 << 16) | (5 << 8) | ('a' & 0xFF),   // Adds ninja, samurai
+        CV_4011C = (4 << 24) | (0 << 16) | (11 << 8) | ('c' & 0xFF), // Music/* vs Music/Digital/* switchover
         CV_4011D = (4 << 24) | (0 << 16) | (11 << 8) | ('d' & 0xFF), // Adds elven race
         CV_500A = (5 << 24) | (0 << 16) | (0 << 8) | ('a' & 0xFF),   // Paperdoll buttons journal becomes quests, chat becomes guild. Use mega FileManager.Cliloc. Removes verdata.mul.
         CV_5020 = (5 << 24) | (0 << 16) | (2 << 8) | 0,              // Adds buff bar

--- a/src/IO/Audio/UOMusic.cs
+++ b/src/IO/Audio/UOMusic.cs
@@ -54,7 +54,7 @@ namespace ClassicUO.IO.Audio
             Channels = AudioChannels.Stereo;
             Delay = 0;
 
-            Path = System.IO.Path.Combine(Settings.GlobalSettings.UltimaOnlineDirectory, Client.Version > ClientVersion.CV_5090 ? $"Music/Digital/{Name}.mp3" : $"music/{Name}.mp3");
+            Path = System.IO.Path.Combine(Settings.GlobalSettings.UltimaOnlineDirectory, Client.Version >= ClientVersion.CV_4011C ? $"Music/Digital/{Name}.mp3" : $"music/{Name}.mp3");
         }
 
         private string Path { get; }

--- a/src/IO/Resources/SoundsLoader.cs
+++ b/src/IO/Resources/SoundsLoader.cs
@@ -141,7 +141,7 @@ namespace ClassicUO.IO.Resources
                         }
                     }
 
-                    path = UOFileManager.GetUOFilePath(@"Music/Digital/Config.txt");
+                    path = UOFileManager.GetUOFilePath(Client.Version >= ClientVersion.CV_4011C ?  @"Music/Digital/Config.txt" : @"Music/Config.txt");
 
                     if (File.Exists(path))
                     {
@@ -158,7 +158,7 @@ namespace ClassicUO.IO.Resources
                             }
                         }
                     }
-                    else if (Client.Version <= ClientVersion.CV_5090)
+                    else if (Client.Version < ClientVersion.CV_4011C)
                     {
                         _musicData.Add(0, new Tuple<string, bool>("oldult01", true));
                         _musicData.Add(1, new Tuple<string, bool>("create1", false));


### PR DESCRIPTION
In src/IO/Audio/UOMusic.cs, the path to the game music is determined with this line:
`Path = System.IO.Path.Combine(Settings.GlobalSettings.UltimaOnlineDirectory, Client.Version > ClientVersion.CV_5090 ? $"Music/Digital/{Name}.mp3" : $"music/{Name}.mp3");`

I believe client version 5.0.9.0 to be an incorrect cut-off for the Music/* - Music/Digital/* switchover.

The initial Mondain's Legacy client was v4.0.11c ([A legal and free copy of which appears to be available here](https://download.cnet.com/Ultima-Online-Mondain-s-Legacy-client/3000-7540_4-10432237.html)), and it installs with all music in the Music/Digital/ subfolder. Using ClassicUO with this client results in no music being played at all, unless the mp3 files are manually moved up one level to Music/.

This pull requests corrects this.

Updated PR using dev branches instead of master, as advised.