### PR TITLE
Fix for *nix file system mp3 names

### DIFF
--- a/src/IO/Resources/SoundsLoader.cs
+++ b/src/IO/Resources/SoundsLoader.cs
@@ -33,7 +33,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -318,19 +317,21 @@ namespace ClassicUO.IO.Resources
             // This will list all case variants of the filename even on file systems that
             // are case sensitive.
             Regex  pattern = new Regex($"^{name}.mp3", RegexOptions.IgnoreCase);
-            string[] fileList = Directory.GetFiles(dir, "*.mp3", SearchOption.AllDirectories).Where(path => pattern.IsMatch(Path.GetFileName(path))).ToArray();
+            //string[] fileList = Directory.GetFiles(dir, "*.mp3", SearchOption.AllDirectories).Where(path => pattern.IsMatch(Path.GetFileName(path))).ToArray();
+            string[] fileList = Directory.GetFiles(dir, "*.mp3", SearchOption.AllDirectories);
+            fileList = Array.FindAll(fileList, path => pattern.IsMatch(Path.GetFileName(path)));
 
-            if (fileList.Any())
+            if (fileList != null && fileList.Length != 0)
             {
-                if (fileList.Count() > 1)
+                if (fileList.Length > 1)
                 {
                     // More than one file with the same name but different case spelling found
                     Log.Warn($"Ambiguous File reference for {name}. More than one file found with different spellings.");
                 }
 
-                Log.Debug($"Loading music:\t\t{fileList.First()}");
+                Log.Debug($"Loading music:\t\t{fileList[0]}");
 
-                return Path.GetFileName(fileList.First());
+                return Path.GetFileName(fileList[0]);
             }
             
             // If we've made it this far, there is no file with that name, regardless of case spelling

--- a/src/IO/Resources/SoundsLoader.cs
+++ b/src/IO/Resources/SoundsLoader.cs
@@ -33,11 +33,15 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using ClassicUO.Configuration;
 using ClassicUO.Data;
 using ClassicUO.Game;
 using ClassicUO.IO.Audio;
+using ClassicUO.Utility.Logging;
 
 namespace ClassicUO.IO.Resources
 {
@@ -289,13 +293,50 @@ namespace ClassicUO.IO.Resources
 
             int index = int.Parse(splits[0]);
 
-            string name = splits[1].Trim();
+            // check if name exists as file, ignoring case since UO isn't consistent with file case (necessary for *nix)
+            // also, not every filename in Config.txt has a file extension, so let's strip it out just in case.
+            string name = GetTrueFileName(Path.GetFileNameWithoutExtension(splits[1]));
 
             bool doesLoop = splits.Length == 3 && splits[2] == "loop";
 
             songData = new Tuple<int, string, bool>(index, name, doesLoop);
 
             return true;
+        }
+
+        /// <summary>
+        ///     Returns true filename from name, ignoring case since UO isn't consistent with file case (necessary for *nix)
+        /// </summary>
+        /// <param name="name">The filename from the music Config.txt</param>
+        /// <returns>a string with the true case sensitive filename</returns>
+        private static string GetTrueFileName(string name)
+        {
+            // don't worry about subdirectories, we'll recursively search them all
+            string dir = Settings.GlobalSettings.UltimaOnlineDirectory + $"/Music";
+
+            // Enumerate all files in the directory, using the file name as a pattern
+            // This will list all case variants of the filename even on file systems that
+            // are case sensitive.
+            Regex  pattern = new Regex($"^{name}.mp3", RegexOptions.IgnoreCase);
+            string[] fileList = Directory.GetFiles(dir, "*.mp3", SearchOption.AllDirectories).Where(path => pattern.IsMatch(Path.GetFileName(path))).ToArray();
+
+            if (fileList.Any())
+            {
+                if (fileList.Count() > 1)
+                {
+                    // More than one file with the same name but different case spelling found
+                    Log.Warn($"Ambiguous File reference for {name}. More than one file found with different spellings.");
+                }
+
+                Log.Debug($"Loading music:\t\t{fileList.First()}");
+
+                return Path.GetFileName(fileList.First());
+            }
+            
+            // If we've made it this far, there is no file with that name, regardless of case spelling
+            // return name and GetMusic will fail gracefully (play nothing)
+            Log.Warn($"No File found known as {name}");
+            return name;
         }
 
         private bool TryGetMusicData(int index, out string name, out bool doesLoop)


### PR DESCRIPTION
Closes #1323 

This PR cross references the names in the music `Config.txt` against files in the file system and pulls the proper case-sensitive name to load into the musicData array.

## Changes:
- Creates `GetTrueFileName(string)` method to iterate through `.\Music\*` folders looking for mp3s and cross-check them against the file listed in `Config.txt`, returning the "true" filename.

## Notes
- I don't have a windows machine to test this on. Presumably it works, but should probably still be verified before merge.
- `Config.txt` has an inconsistent schema, sometimes filenames have an extension, sometimes they do not. I'm removing the extension from all names before processing.
- I tested locally on Fedora 32 and it reads the files properly, even if I rename them such as `TrInsICPoS.mp3`