### PR TITLE
Properly restore UseAbilityButtonGump on login

### DIFF
--- a/src/Game/UI/Gumps/CombatBookGump.cs
+++ b/src/Game/UI/Gumps/CombatBookGump.cs
@@ -289,7 +289,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             GetSpellFloatingButton(def.Index)?.Dispose();
 
-            UseAbilityButtonGump gump = new UseAbilityButtonGump(def.Index, true)
+            UseAbilityButtonGump gump = new UseAbilityButtonGump(true)
             {
                 X = Mouse.LClickPosition.X - 22,
                 Y = Mouse.LClickPosition.Y - 22
@@ -310,7 +310,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             GetSpellFloatingButton(def.Index)?.Dispose();
 
-            UseAbilityButtonGump gump = new UseAbilityButtonGump(def.Index, false)
+            UseAbilityButtonGump gump = new UseAbilityButtonGump(false)
             {
                 X = Mouse.LClickPosition.X - 22,
                 Y = Mouse.LClickPosition.Y - 22

--- a/src/Game/UI/Gumps/UseAbilityButtonGump.cs
+++ b/src/Game/UI/Gumps/UseAbilityButtonGump.cs
@@ -50,25 +50,23 @@ namespace ClassicUO.Game.UI.Gumps
             CanCloseWithRightClick = true;
         }
 
-        public UseAbilityButtonGump(int index, bool primary) : this()
+        public UseAbilityButtonGump(bool primary) : this()
         {
             IsPrimary = primary;
-            Index = index;
             BuildGump();
         }
 
         public override GumpType GumpType => GumpType.AbilityButton;
 
-        public int Index { get; }
+        public int Index { get; private set; }
         public bool IsPrimary { get; private set; }
 
         private void BuildGump()
         {
             Clear();
+            Index = ((byte)World.Player.Abilities[IsPrimary ? 0 : 1] & 0x7F);
 
-            int index = ((byte) World.Player.Abilities[IsPrimary ? 0 : 1] & 0x7F) - 1;
-
-            ref readonly AbilityDefinition def = ref AbilityData.Abilities[index];
+            ref readonly AbilityDefinition def = ref AbilityData.Abilities[Index - 1];
 
             _button = new GumpPic(0, 0, def.Icon, 0)
             {
@@ -77,7 +75,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             Add(_button);
 
-            SetTooltip(ClilocLoader.Instance.GetString(1028838 + index), 80);
+            SetTooltip(ClilocLoader.Instance.GetString(1028838 + (Index - 1)), 80);
 
             WantUpdateSize = true;
             AcceptMouseInput = true;
@@ -119,7 +117,7 @@ namespace ClassicUO.Game.UI.Gumps
                 return false;
             }
 
-            byte index = (byte) World.Player.Abilities[IsPrimary ? 0 : 1];
+            byte index = (byte)World.Player.Abilities[IsPrimary ? 0 : 1];
 
             if ((index & 0x80) != 0)
             {

--- a/src/Game/UI/Gumps/UseAbilityButtonGump.cs
+++ b/src/Game/UI/Gumps/UseAbilityButtonGump.cs
@@ -117,7 +117,7 @@ namespace ClassicUO.Game.UI.Gumps
                 return false;
             }
 
-            byte index = (byte)World.Player.Abilities[IsPrimary ? 0 : 1];
+            byte index = (byte) World.Player.Abilities[IsPrimary ? 0 : 1];
 
             if ((index & 0x80) != 0)
             {

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -6227,6 +6227,8 @@ namespace ClassicUO.Network
 
                 World.Player.UpdateScreenPosition();
                 World.Player.AddToTile();
+
+                World.Player.UpdateAbilities();
             }
         }
 


### PR DESCRIPTION
Problem:
- Ability Button Gump does not restore at all after entering world. Gump data is stored properly upon logout but is never restored afterwards. This example shows 2 gumps with type 14 - one for the primary and another for the secondary ability.

```
       <anchored_group_gump matrix_w="2" matrix_h="1">
		<gump type="14" x="1351" y="695" serial="0" isprimary="True" matrix_x="0" matrix_y="0" />
		<gump type="14" x="1395" y="695" serial="0" isprimary="False" matrix_x="1" matrix_y="0" />
	</anchored_group_gump>
```

Cause(s):
(1) At the moment when user enters world and client tries to restore the gump from gumps.xml: World.Player.Abilities returns Ability.Invalid and, thus, fails to identify the ability for the previously stored gump. The first attempt to fix this involved a call to World.Player.UpdateAbilities() before this point.

(2) The first fix caused a second problem. Moving a new ability gump (taken directly from the combat book) would not remove the old one because the index would not match. I fixed this problem by setting the gump Index while it is being built, instead of setting passing it directly to the constructor.