### PR TITLE
Unicode response fixes

### DIFF
--- a/src/Network/PacketBase.cs
+++ b/src/Network/PacketBase.cs
@@ -192,6 +192,47 @@ namespace ClassicUO.Network
             }
         }
 
+        public void WriteUnicodeLE(string value)
+        {
+            EnsureSize((value.Length + 1) * 2);
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+
+                if (c != '\0')
+                {
+                    WriteByte((byte)(c & 0xFF));
+                    WriteByte((byte)(c >> 8));
+                }
+            }
+
+            WriteUShort(0);
+        }
+
+        public void WriteUnicodeLE(string value, int length)
+        {
+            EnsureSize(length);
+
+            for (int i = 0; i < length && i < value.Length; i++)
+            {
+                char c = value[i];
+
+                if (c != '\0')
+                {
+                    WriteByte((byte)(c & 0xFF));
+                    WriteByte((byte)(c >> 8));
+                }
+            }
+
+
+            if (value.Length < length)
+            {
+                WriteUShort(0);
+                Position += (length - value.Length - 1) * 2;
+            }
+        }
+
 
         public void WriteUTF8(string value)
         {

--- a/src/Network/Packets.cs
+++ b/src/Network/Packets.cs
@@ -828,11 +828,8 @@ namespace ClassicUO.Network
         {
             WriteBytes(MessageManager.PromptData.Data, 0, 8);
             WriteUInt((uint) (cancel ? 0 : 1));
-            WriteASCII(lang, 3);
-            WriteUnicode(text, text.Length);
-            //This must be terminated with EXACTLY one null byte, unlike most unicode-containing packets which are terminated with two.
-            //Some servers are fussy about this and will reject the packet otherwise!
-            WriteByte(0x00);
+            WriteASCII(lang);
+            WriteUnicodeLE(text, text.Length);
         }
     }
 


### PR DESCRIPTION
This version now produces exactly the same output in every case as the
original client. The language is a null terminated ASCII string
containing the language code (which is usually 3 characters). The
description is a little endian unicode string with no null terminator.

Before, it wasn't null terminating the language and starting the
description immediately. But it was sending big endian encoded unicode
and then tacking on an extra null byte. This works if all of the
characters being sent happen to only require 1 byte of unicode, but as
soon as you send something with data in the upper byte of a character it
falls apart.