### PR TITLE
Use default music list/index if config.txt doesn't exist

### DIFF
--- a/src/IO/Audio/UOMusic.cs
+++ b/src/IO/Audio/UOMusic.cs
@@ -47,14 +47,15 @@ namespace ClassicUO.IO.Audio
         private MP3Stream m_Stream;
         private readonly byte[] m_WaveBuffer = new byte[NUMBER_OF_PCM_BYTES_TO_READ_PER_CHUNK];
 
-        public UOMusic(int index, string name, bool loop) : base(name, index)
+
+        public UOMusic(int index, string name, bool loop, string basePath) : base(name, index)
         {
             m_Repeat = loop;
             m_Playing = false;
             Channels = AudioChannels.Stereo;
             Delay = 0;
-
-            Path = System.IO.Path.Combine(Settings.GlobalSettings.UltimaOnlineDirectory, Client.Version >= ClientVersion.CV_4011C ? $"Music/Digital/{Name}.mp3" : $"music/{Name}.mp3");
+            
+            Path = System.IO.Path.Combine(Settings.GlobalSettings.UltimaOnlineDirectory, $"{basePath}/{Name}.mp3");
         }
 
         private string Path { get; }

--- a/src/IO/Resources/SoundsLoader.cs
+++ b/src/IO/Resources/SoundsLoader.cs
@@ -55,6 +55,8 @@ namespace ClassicUO.IO.Resources
         private readonly Sound[] _musics = new Sound[Constants.MAX_SOUND_DATA_INDEX_COUNT];
         private readonly Sound[] _sounds = new Sound[Constants.MAX_SOUND_DATA_INDEX_COUNT];
 
+        private bool _useDigitalMusicFolder;
+
         private SoundsLoader()
         {
         }
@@ -161,7 +163,7 @@ namespace ClassicUO.IO.Resources
                             }
                         }
                     }
-                    else if (Client.Version < ClientVersion.CV_4011C)
+                    else
                     {
                         _musicData.Add(0, new Tuple<string, bool>("oldult01", true));
                         _musicData.Add(1, new Tuple<string, bool>("create1", false));
@@ -231,6 +233,8 @@ namespace ClassicUO.IO.Resources
                         _musicData.Add(65, new Tuple<string, bool>("serpentislecombat_u7", true));
                         _musicData.Add(66, new Tuple<string, bool>("valoriaships", true));
                     }
+
+                    _useDigitalMusicFolder = Directory.Exists(Path.Combine(Settings.GlobalSettings.UltimaOnlineDirectory, "Music", "Digital"));
                 }
             );
         }
@@ -383,7 +387,7 @@ namespace ClassicUO.IO.Resources
 
                 if (music == null && TryGetMusicData(index, out string name, out bool loop))
                 {
-                    music = new UOMusic(index, name, loop);
+                    music = _useDigitalMusicFolder ? new UOMusic(index, name, loop, "Music/Digital/") : new UOMusic(index, name, loop, "Music/");
                 }
 
                 return music;


### PR DESCRIPTION
This enables the client to play music regardless if a config.txt file exists in either the `Digital/Music` folder or the `Music` folder.

Removed the version check if CUO can't find a config.txt, it will just load the default music list vs loading nothing.

It also checks if the Digital folder even exists.  If it does, music is played from there, if not, defaults to the standalone music folder.