### PR TITLE
Fixed output of empty cliloc messages.

### DIFF
--- a/src/IO/Resources/ClilocLoader.cs
+++ b/src/IO/Resources/ClilocLoader.cs
@@ -30,6 +30,7 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -90,7 +91,7 @@ namespace ClassicUO.IO.Resources
                         return;
                     }
 
-                    if (_cliloc != "Cliloc.enu")
+                    if (string.Compare(_cliloc, "cliloc.enu", StringComparison.InvariantCultureIgnoreCase) == 0)
                     { 
                         string enupath = UOFileManager.GetUOFilePath("Cliloc.enu");
 

--- a/src/IO/Resources/ClilocLoader.cs
+++ b/src/IO/Resources/ClilocLoader.cs
@@ -90,6 +90,35 @@ namespace ClassicUO.IO.Resources
                         return;
                     }
 
+                    if (_cliloc != "Cliloc.enu")
+                    { 
+                        string enupath = UOFileManager.GetUOFilePath("Cliloc.enu");
+
+                        using (BinaryReader reader = new BinaryReader(new FileStream(enupath, FileMode.Open, FileAccess.Read)))
+                        {
+                            reader.ReadInt32();
+                            reader.ReadInt16();
+                            byte[] buffer = new byte[1024];
+
+                            while (reader.BaseStream.Length != reader.BaseStream.Position)
+                            {
+                                int number = reader.ReadInt32();
+                                byte flag = reader.ReadByte();
+                                int length = reader.ReadInt16();
+
+                                if (length > buffer.Length)
+                                {
+                                    buffer = new byte[(length + 1023) & ~1023];
+                                }
+
+                                reader.Read(buffer, 0, length);
+                                string text = string.Intern(Encoding.UTF8.GetString(buffer, 0, length));
+
+                                _entries[number] = text;
+                            }
+                        }
+                    }
+
                     using (BinaryReader reader = new BinaryReader(new FileStream(path, FileMode.Open, FileAccess.Read)))
                     {
                         reader.ReadInt32();

--- a/src/IO/Resources/ClilocLoader.cs
+++ b/src/IO/Resources/ClilocLoader.cs
@@ -91,7 +91,7 @@ namespace ClassicUO.IO.Resources
                         return;
                     }
 
-                    if (string.Compare(_cliloc, "cliloc.enu", StringComparison.InvariantCultureIgnoreCase) == 0)
+                    if (string.Compare(_cliloc, "cliloc.enu", StringComparison.InvariantCultureIgnoreCase) != 0)
                     { 
                         string enupath = UOFileManager.GetUOFilePath("Cliloc.enu");
 


### PR DESCRIPTION
If the Localization message is empty, the cliloc.enu message of the corresponding number should be displayed.