### PR TITLE
Bug/world map on top

### DIFF
--- a/src/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/Game/UI/Gumps/WorldMapGump.cs
@@ -115,7 +115,6 @@ namespace ClassicUO.Game.UI.Gumps
             Y = _last_position.Y;
 
             _dumyLabel = new Label("", false, 0);
-
             Add(_dumyLabel);
 
             LoadSettings();

--- a/src/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/Game/UI/Gumps/WorldMapGump.cs
@@ -70,7 +70,8 @@ namespace ClassicUO.Game.UI.Gumps
         private int _mapIndex;
         private bool _mapMarkersLoaded;
         private UOTexture _mapTexture;
-
+        // Dummy label to make MakeTopMostGump possible (method take Control as parameter and inside take Parent of it)
+        private readonly Label _dumyLabel;
 
         private readonly List<WMapMarkerFile> _markerFiles = new List<WMapMarkerFile>();
 
@@ -113,6 +114,10 @@ namespace ClassicUO.Game.UI.Gumps
             X = _last_position.X;
             Y = _last_position.Y;
 
+            _dumyLabel = new Label("", false, 0);
+
+            Add(_dumyLabel);
+
             LoadSettings();
 
             GameActions.Print(ResGumps.WorldMapLoading, 0x35);
@@ -139,6 +144,8 @@ namespace ClassicUO.Game.UI.Gumps
                 ShowBorder = !_isTopMost;
 
                 LayerOrder = _isTopMost ? UILayer.Over : UILayer.Under;
+                if(_isTopMost)
+                    UIManager.MakeTopMostGump(_dumyLabel);
             }
         }
 


### PR DESCRIPTION
Fix issue when user set `Keep on Top` World map and it's don't work

Steps to reproduce:
- Select form Context Menu at World Map Keep on Top
- Map stay behind
- User have to reload GameScene to draw it properly

