### PR TITLE
Last characters are saved per account and server

### DIFF
--- a/src/Configuration/Settings.cs
+++ b/src/Configuration/Settings.cs
@@ -57,9 +57,7 @@ namespace ClassicUO.Configuration
         [JsonProperty("profilespath")] public string ProfilesPath { get; set; } = string.Empty;
 
         [JsonProperty("clientversion")] public string ClientVersion { get; set; } = string.Empty;
-
-        [JsonProperty("lastcharactername")] public string LastCharacterName { get; set; } = string.Empty;
-
+        
         [JsonProperty("lang")] public string Language { get; set; } = "";
 
         [JsonProperty("lastservernum")] public ushort LastServerNum { get; set; } = 1;

--- a/src/Game/Managers/LastCharacterManager.cs
+++ b/src/Game/Managers/LastCharacterManager.cs
@@ -48,7 +48,9 @@ namespace ClassicUO.Game.Managers
         private static readonly string _lastCharacterFilePath = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Profiles");
         private static readonly string _lastCharacterFile = Path.Combine(_lastCharacterFilePath, "lastcharacter.json");
 
-        public static List<LastCharacterInfo> LastCharacters { get; set; }
+        private static List<LastCharacterInfo> LastCharacters { get; set; }
+
+        private static string LastCharacterNameOverride { get; set; }
 
         public static void Load()
         {
@@ -65,6 +67,12 @@ namespace ClassicUO.Game.Managers
         public static void Save(string account, string server, string name)
         {
             LastCharacterInfo lastChar = LastCharacters.FirstOrDefault(c => c.AccountName.Equals(account) && c.ServerName == server);
+
+            // Check to see if they passed in -lastcharactername but picked another character, clear override then
+            if (!string.IsNullOrEmpty(LastCharacterNameOverride) && !LastCharacterNameOverride.Equals(name))
+            {
+                LastCharacterNameOverride = string.Empty;
+            }
 
             if (lastChar != null)
             {
@@ -90,9 +98,20 @@ namespace ClassicUO.Game.Managers
                 Load();
             }
 
+            // If they passed in a -lastcharactername param, ignore json value, use that value instead
+            if (!string.IsNullOrEmpty(LastCharacterNameOverride))
+            {
+                return LastCharacterNameOverride;
+            }
+
             LastCharacterInfo lastChar = LastCharacters.FirstOrDefault(c => c.AccountName.Equals(account) && c.ServerName == server);
 
             return lastChar != null ? lastChar.LastCharacterName : string.Empty;
+        }
+        
+        public static void OverrideLastCharacter(string name)
+        {
+            LastCharacterNameOverride = name;
         }
     }
 

--- a/src/Game/Managers/LastCharacterManager.cs
+++ b/src/Game/Managers/LastCharacterManager.cs
@@ -1,0 +1,105 @@
+﻿#region license
+
+// Copyright (c) 2021, andreakarasho
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. All advertising materials mentioning features or use of this software
+//    must display the following acknowledgement:
+//    This product includes software developed by andreakarasho - https://github.com/andreakarasho
+// 4. Neither the name of the copyright holder nor the
+//    names of its contributors may be used to endorse or promote products
+//    derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Scenes;
+using ClassicUO.Resources;
+using ClassicUO.Utility.Logging;
+
+namespace ClassicUO.Game.Managers
+{
+    public static class LastCharacterManager
+    {
+        private static readonly string _lastCharacterFilePath = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Profiles");
+        private static readonly string _lastCharacterFile = Path.Combine(_lastCharacterFilePath, "lastcharacter.json");
+
+        public static List<LastCharacterInfo> LastCharacters { get; set; }
+
+        public static void Load()
+        {
+            LastCharacters = new List<LastCharacterInfo>();
+
+            if (!File.Exists(_lastCharacterFile))
+            {
+                ConfigurationResolver.Save(LastCharacters, _lastCharacterFile);
+            }
+
+            LastCharacters = ConfigurationResolver.Load<List<LastCharacterInfo>>(_lastCharacterFile);
+        }
+
+        public static void Save(string account, string server, string name)
+        {
+            LastCharacterInfo lastChar = LastCharacters.FirstOrDefault(c => c.AccountName.Equals(account) && c.ServerName == server);
+
+            if (lastChar != null)
+            {
+                lastChar.LastCharacterName = name;
+            }
+            else
+            {
+                LastCharacters.Add(new LastCharacterInfo
+                {
+                    ServerName = server,
+                    LastCharacterName = name,
+                    AccountName = account
+                });
+            }
+
+            ConfigurationResolver.Save(LastCharacters, _lastCharacterFile);
+        }
+
+        public static string GetLastCharacter(string account, string server)
+        {
+            if (LastCharacters == null)
+            {
+                Load();
+            }
+
+            LastCharacterInfo lastChar = LastCharacters.FirstOrDefault(c => c.AccountName.Equals(account) && c.ServerName == server);
+
+            return lastChar != null ? lastChar.LastCharacterName : string.Empty;
+        }
+    }
+
+    public class LastCharacterInfo
+    {
+        public string AccountName { get; set; }
+        public string ServerName { get; set; }
+        public string LastCharacterName { get; set; }
+    }
+}

--- a/src/Game/Scenes/LoginScene.cs
+++ b/src/Game/Scenes/LoginScene.cs
@@ -79,7 +79,6 @@ namespace ClassicUO.Game.Scenes
         private int _reconnectTryCounter = 1;
         private bool _autoLogin;
 
-
         public LoginScene() : base((int) SceneType.Login, false, false, true)
         {
         }
@@ -104,7 +103,7 @@ namespace ClassicUO.Game.Scenes
         public string Password { get; private set; }
 
         public bool CanAutologin => _autoLogin || Reconnect;
-
+        
 
         public override void Load()
         {
@@ -418,8 +417,8 @@ namespace ClassicUO.Game.Scenes
         {
             if (CurrentLoginStep == LoginSteps.CharacterSelection)
             {
-                Settings.GlobalSettings.LastCharacterName = Characters[index];
-                Settings.GlobalSettings.Save();
+                LastCharacterManager.Save(Account, World.ServerName, Characters[index]);
+
                 CurrentLoginStep = LoginSteps.EnteringBritania;
                 NetClient.Socket.Send_SelectCharacter(index, Characters[index], NetClient.Socket.LocalIP);
             }
@@ -445,7 +444,7 @@ namespace ClassicUO.Game.Scenes
                 }
             }
 
-            Settings.GlobalSettings.LastCharacterName = character.Name;
+            LastCharacterManager.Save(Account, World.ServerName, character.Name);
 
             NetClient.Socket.Send_CreateCharacter(character,
                                                   cityIndex,
@@ -656,13 +655,15 @@ namespace ClassicUO.Game.Scenes
                 _autoLogin = false;
             }
 
+            string lastCharName = LastCharacterManager.GetLastCharacter(Account, World.ServerName);
+
             for (byte i = 0; i < Characters.Length; i++)
             {
                 if (Characters[i].Length > 0)
                 {
                     haveAnyCharacter = true;
 
-                    if (Characters[i] == Settings.GlobalSettings.LastCharacterName)
+                    if (Characters[i] == lastCharName)
                     {
                         charToSelect = i;
 

--- a/src/Game/UI/Gumps/Login/CharacterSelectionGump.cs
+++ b/src/Game/UI/Gumps/Login/CharacterSelectionGump.cs
@@ -35,6 +35,7 @@ using System.Linq;
 using ClassicUO.Configuration;
 using ClassicUO.Data;
 using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
@@ -60,8 +61,9 @@ namespace ClassicUO.Game.UI.Gumps.Login
             int listTitleY = 106;
 
             LoginScene loginScene = Client.Game.GetScene<LoginScene>();
-
-            string lastSelected = loginScene.Characters.FirstOrDefault(o => o == Settings.GlobalSettings.LastCharacterName);
+            
+            string lastCharName = LastCharacterManager.GetLastCharacter(LoginScene.Account, World.ServerName);
+            string lastSelected = loginScene.Characters.FirstOrDefault(o => o == lastCharName);
 
             LockedFeatureFlags f = World.ClientLockedFeatures.Flags;
             CharacterListFlags ff = World.ClientFeatures.Flags;

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -39,6 +39,7 @@ using System.Threading;
 using ClassicUO.Configuration;
 using ClassicUO.Data;
 using ClassicUO.Game;
+using ClassicUO.Game.Managers;
 using ClassicUO.IO;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
@@ -333,6 +334,12 @@ namespace ClassicUO
 
                     case "clientversion":
                         Settings.GlobalSettings.ClientVersion = value;
+
+                        break;
+
+                    case "lastcharactername":
+                    case "lastcharname": 
+                        LastCharacterManager.OverrideLastCharacter(value);
 
                         break;
 

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -336,12 +336,6 @@ namespace ClassicUO
 
                         break;
 
-                    case "lastcharactername":
-                    case "lastcharname":
-                        Settings.GlobalSettings.LastCharacterName = value;
-
-                        break;
-
                     case "lastservernum":
                         Settings.GlobalSettings.LastServerNum = ushort.Parse(value);
 

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -748,7 +748,8 @@ namespace ClassicUO.Network
         {
             if (ProfileManager.CurrentProfile == null)
             {
-                ProfileManager.Load(World.ServerName, LoginScene.Account, Settings.GlobalSettings.LastCharacterName.Trim());
+                string lastChar = LastCharacterManager.GetLastCharacter(LoginScene.Account, World.ServerName);
+                ProfileManager.Load(World.ServerName, LoginScene.Account, lastChar);
             }
 
             if (World.Player != null)


### PR DESCRIPTION
Instead of the last character being a global setting either via `settings.json` or a `-param`, this change makes it per server, per account and saves the list in `Data/Profiles/lastcharacter.json`

```json
[
	{
		"AccountName" : "quick",
		"ServerName" : "UOServerA",
		"LastCharacterName" : "Quick"
	},
	{
		"AccountName" : "quick1",
		"ServerName" : "UOServerB",
		"LastCharacterName" : "TestUser"
	},
	{
		"AccountName" : "quick2",
		"ServerName" : "UOServerB",
		"LastCharacterName" : "TestTwo"
	}
]
```
