### PR TITLE
Fixes issue with last char highlight after delete

### DIFF
--- a/src/Game/UI/Gumps/Login/CharacterSelectionGump.cs
+++ b/src/Game/UI/Gumps/Login/CharacterSelectionGump.cs
@@ -109,7 +109,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 },
                 1
             );
-           
+            
             for (int i = 0, valid = 0; i < loginScene.Characters.Length; i++)
             {
                 string character = loginScene.Characters[i];
@@ -130,14 +130,14 @@ namespace ClassicUO.Game.UI.Gumps.Login
                             break;
                         }
                     }
-
+                    
                     Add
                     (
                         new CharacterEntryGump((uint) i, character, SelectCharacter, LoginCharacter)
                         {
                             X = 224,
                             Y = yOffset + posInList * 40,
-                            Hue = posInList == _selectedCharacter ? SELECTED_COLOR : NORMAL_COLOR
+                            Hue = i == _selectedCharacter ? SELECTED_COLOR : NORMAL_COLOR
                         },
                         1
                     );


### PR DESCRIPTION
To replicate the issue:

Put 5 chars on an account, delete char 3, and then log in to char 3, log out, log in. Char 3 will not be the character that is highlighted, but rather char 4.  

RunUO sends an array of characters like this after you delete character 3 in a list of 5.

![image](https://user-images.githubusercontent.com/577652/128606285-19da7667-1e30-478f-9ce5-3462a99247ac.png)

In this example, `"Hello"` is the last character in `lastcharacter.json` and correctly gets the value here:

```csharp
string lastCharName = LastCharacterManager.GetLastCharacter(LoginScene.Account, World.ServerName);
string lastSelected = loginScene.Characters.FirstOrDefault(o => o == lastCharName);
_selectedCharacter = (uint) Array.IndexOf(loginScene.Characters, lastSelected);
```

`_selectedCharacter` is set to 3 but `posInList` gets out of sync when the `character` name is null or empty, so while `_selectedCharacter` is 3, `posInList` is now 2.  This results in the highlight being one off (in this case JohnDoe is highlighted)

