### PR TITLE
Add -no_server_ping param to not ping on server selection scene

### DIFF
--- a/src/CUOEnviroment.cs
+++ b/src/CUOEnviroment.cs
@@ -51,6 +51,7 @@ namespace ClassicUO
         public static bool SkipLoginScreen;
         public static bool IsOutlands;
         public static bool PacketLog;
+        public static bool NoServerPing;
 
         public static readonly bool IsUnix = Environment.OSVersion.Platform != PlatformID.Win32NT && Environment.OSVersion.Platform != PlatformID.Win32Windows && Environment.OSVersion.Platform != PlatformID.Win32S && Environment.OSVersion.Platform != PlatformID.WinCE;
 

--- a/src/Game/Scenes/LoginScene.cs
+++ b/src/Game/Scenes/LoginScene.cs
@@ -199,7 +199,7 @@ namespace ClassicUO.Game.Scenes
                 }
             }
 
-            if (CurrentLoginStep == LoginSteps.CharacterCreation && Time.Ticks > _pingTime)
+            if (CUOEnviroment.NoServerPing == false && CurrentLoginStep == LoginSteps.CharacterCreation && Time.Ticks > _pingTime)
             {
                 if (NetClient.Socket != null && NetClient.Socket.IsConnected)
                 {

--- a/src/Game/UI/Gumps/Login/ServerSelectionGump.cs
+++ b/src/Game/UI/Gumps/Login/ServerSelectionGump.cs
@@ -82,21 +82,24 @@ namespace ClassicUO.Game.UI.Gumps.Login
                     }
                 ); // "Select which shard to play on:"
 
-                Add
-                (
-                    new Label(ClilocLoader.Instance.GetString(1044577), true, textColor, font: 1)
-                    {
-                        X = 400, Y = 70
-                    }
-                ); // "Latency:"
+                if (CUOEnviroment.NoServerPing == false)
+                {
+                    Add
+                    (
+                        new Label(ClilocLoader.Instance.GetString(1044577), true, textColor, font: 1)
+                        {
+                            X = 400, Y = 70
+                        }
+                    ); // "Latency:"
 
-                Add
-                (
-                    new Label(ClilocLoader.Instance.GetString(1044578), true, textColor, font: 1)
-                    {
-                        X = 470, Y = 70
-                    }
-                ); // "Packet Loss:"
+                    Add
+                    (
+                        new Label(ClilocLoader.Instance.GetString(1044578), true, textColor, font: 1)
+                        {
+                            X = 470, Y = 70
+                        }
+                    ); // "Packet Loss:"
+                }
 
                 Add
                 (
@@ -328,7 +331,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 (
                     _server_ping = new HoveredLabel
                     (
-                        "-",
+                        CUOEnviroment.NoServerPing ? string.Empty : "-",
                         false,
                         normal_hue,
                         selected_hue,
@@ -345,7 +348,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 (
                     _server_packet_loss = new HoveredLabel
                     (
-                        "-",
+                        CUOEnviroment.NoServerPing ? string.Empty : "-",
                         false,
                         normal_hue,
                         selected_hue,
@@ -396,7 +399,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
             {
                 base.Update(totalTime, frameTime);
 
-                if (_pingCheckTime < Time.Ticks)
+                if (CUOEnviroment.NoServerPing == false && _pingCheckTime < Time.Ticks)
                 {
                     _pingCheckTime = Time.Ticks + 2000;
                     _entry.DoPing();

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -516,6 +516,12 @@ namespace ClassicUO
                         }
 
                         break;
+
+                    case "no_server_ping":
+
+                        CUOEnviroment.NoServerPing = true;
+
+                        break;
                 }
             }
         }


### PR DESCRIPTION
Some shards don't allow you to directly ping them and so 100% time out message could be a little misleading.

This adds `-no_server_ping` to tell ClassicUO not to even try to ping the server and hides a few of the ping labels as well.