### PR TITLE
RE: Added "rem" command for Party System

### DIFF
--- a/src/Game/GameActions.cs
+++ b/src/Game/GameActions.cs
@@ -428,6 +428,11 @@ namespace ClassicUO.Game
             UIManager.GetGump<PartyInviteGump>()?.Dispose();
         }
 
+        public static void RequestPartyRemoveMemberByTarget()
+        {
+            Socket.Send_PartyRemoveRequest(0x00);
+        }
+
         public static void RequestPartyRemoveMember(uint serial)
         {
             Socket.Send_PartyRemoveRequest(serial);

--- a/src/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/Game/UI/Gumps/SystemChatControl.cs
@@ -783,6 +783,29 @@ namespace ClassicUO.Game.UI.Gumps
 
                                 break;
 
+                            case "rem":
+
+                                if (World.Party.Leader != 0 && World.Party.Leader == World.Player)
+                                {
+                                    GameActions.RequestPartyRemoveMemberByTarget();
+                                }
+                                else
+                                {
+                                    MessageManager.HandleMessage
+                                    (
+                                        null,
+                                        ResGumps.YouAreNotPartyLeader,
+                                        "System",
+                                        0xFFFF,
+                                        MessageType.Regular,
+                                        3,
+                                        TextType.SYSTEM
+                                    );
+                                }
+
+
+                                break;
+
                             default:
 
                                 if (World.Party.Leader != 0)


### PR DESCRIPTION
Fix #1421 

- Added rem command that give a target popup to target to player to kick out.
- Force serial to 0x00 to make the Target to appear in this case

Should be okay like this, sorry for the other PR 😅.

Thanks!