### PR TITLE
Fix ReadASCII/WriteASCII using ASCII instead of cp-1252/iso-8859-1

### DIFF
--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -125,6 +125,10 @@
     <DataFiles_vulkan Include="$(ProjectDir)..\external\vulkan\icd.d\*.*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+  </ItemGroup>
+
   <Target Name="CopyExternalDeps_build" AfterTargets="Build">
     <Copy SourceFiles="@(DataFiles_x64)" DestinationFolder="$(TargetDir)\x64\" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(DataFiles_lib64)" DestinationFolder="$(TargetDir)\lib64\" SkipUnchangedFiles="true" />

--- a/src/IO/StackDataReader.cs
+++ b/src/IO/StackDataReader.cs
@@ -276,12 +276,12 @@ namespace ClassicUO.IO
 
         public string ReadASCII(bool safe = false)
         {
-            return ReadString(Encoding.ASCII, -1, 1, safe);
+            return ReadString(Encoding.GetEncoding("iso-8859-1"), -1, 1, safe);
         }
 
         public string ReadASCII(int length, bool safe = false)
         {
-            return ReadString(Encoding.ASCII, length, 1, safe);
+            return ReadString(Encoding.GetEncoding("iso-8859-1"), length, 1, safe);
         }
 
         public string ReadUnicodeBE(bool safe = false)

--- a/src/IO/StackDataReader.cs
+++ b/src/IO/StackDataReader.cs
@@ -276,12 +276,12 @@ namespace ClassicUO.IO
 
         public string ReadASCII(bool safe = false)
         {
-            return ReadString(Encoding.GetEncoding("iso-8859-1"), -1, 1, safe);
+            return ReadString(Encoding.GetEncoding(1252), -1, 1, safe);
         }
 
         public string ReadASCII(int length, bool safe = false)
         {
-            return ReadString(Encoding.GetEncoding("iso-8859-1"), length, 1, safe);
+            return ReadString(Encoding.GetEncoding(1252), length, 1, safe);
         }
 
         public string ReadUnicodeBE(bool safe = false)

--- a/src/IO/StackDataWriter.cs
+++ b/src/IO/StackDataWriter.cs
@@ -284,14 +284,14 @@ namespace ClassicUO.IO
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str)
         {
-            WriteString<byte>(Encoding.GetEncoding("iso-8859-1"), str, -1);
+            WriteString<byte>(Encoding.GetEncoding(1252), str, -1);
             WriteUInt8(0x00);
         }
 
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str, int length)
         {
-            WriteString<byte>(Encoding.GetEncoding("iso-8859-1"), str, length);
+            WriteString<byte>(Encoding.GetEncoding(1252), str, length);
         }
 
 

--- a/src/IO/StackDataWriter.cs
+++ b/src/IO/StackDataWriter.cs
@@ -284,14 +284,14 @@ namespace ClassicUO.IO
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str)
         {
-            WriteString<byte>(Encoding.ASCII, str, -1);
+            WriteString<byte>(Encoding.GetEncoding("iso-8859-1"), str, -1);
             WriteUInt8(0x00);
         }
 
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str, int length)
         {
-            WriteString<byte>(Encoding.ASCII, str, length);
+            WriteString<byte>(Encoding.GetEncoding("iso-8859-1"), str, length);
         }
 
 

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -35,6 +35,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using ClassicUO.Configuration;
 using ClassicUO.Data;
@@ -154,6 +155,9 @@ namespace ClassicUO
                 SetDllDirectory(libsPath);
             }
 
+            // Register the encoding provider that provides CP-1252, a text encoding used by UO.
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            
             if (string.IsNullOrWhiteSpace(Settings.GlobalSettings.Language))
             {
                 Log.Trace("language is not set. Trying to get the OS language.");


### PR DESCRIPTION
ReadASCII was reading (and WriteASCII was writing) text as actual ASCII, but Ultima Online actually uses [CP-1252](https://en.wikipedia.org/wiki/Windows-1252) (at least on English locale -- I do not know about other locales, but presumably those would not use ASCII either). This would cause non-ASCII characters such as Ä or é to appear as question marks in some contexts (eg. in the journal when included in the `name` field of the 0x1C packet).

This PR makes ReadASCII and WriteASCII use the [ISO 8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1) / Latin-1 encoding, which is *not* the same thing as CP-1252, but is the closest thing supported by the `Encoding` class on .NET Core and .NET 5. A better solution would require using a custom Encoding type, but that seems annoying and I don't feel like doing it right now. Take a look at the [ISO 8859-1 encoding class source](https://referencesource.microsoft.com/#mscorlib/system/text/latin1encoding.cs) to get an idea of what this would entail.

Note the difference below -- Latin-1 is missing some of the special characters included in CP-1252. These characters will appear blank, as far as I know. This is still better than current behaviour, where any character past 0x7F will appear as a question mark.

## CP-1252

![Windows-1252-infobox](https://user-images.githubusercontent.com/5822375/133947272-17b1b9b0-2b57-44de-9915-e8e005212db1.png)


## ISO 8859-1 / Latin-1

![Latin-1-infobox](https://user-images.githubusercontent.com/5822375/133947277-070d3dc2-3bad-4e75-8b32-39d311426317.png)
