### PR TITLE
fix PlaySoundWithDistance muted

### DIFF
--- a/src/Game/Managers/AudioManager.cs
+++ b/src/Game/Managers/AudioManager.cs
@@ -139,12 +139,18 @@ namespace ClassicUO.Game.Managers
             {
                 return;
             }
+            
+            Profile currentProfile = ProfileManager.CurrentProfile;
+
+            if (currentProfile.SoundVolume == 0)
+            {
+                return;
+            }
 
             int distX = Math.Abs(x - World.Player.X);
             int distY = Math.Abs(y - World.Player.Y);
             int distance = Math.Max(distX, distY);
-
-            Profile currentProfile = ProfileManager.CurrentProfile;
+            
             float volume = currentProfile.SoundVolume / Constants.SOUND_DELTA;
             float distanceFactor = 0.0f;
 


### PR DESCRIPTION
Why would we go through all this trouble if sound is already muted? It's still fetching the sound and trying to play it muted.

For me playing sounds with distance crashes, maybe my sound.mul is corrupted. But this should be avoided with the sound set to 0 in the settings.