### PR TITLE
Fix random ArgumentOutOfRangeException in journal on login

### DIFF
--- a/src/Game/UI/Gumps/JournalGump.cs
+++ b/src/Game/UI/Gumps/JournalGump.cs
@@ -509,7 +509,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 for (int i = 0; i < _entries.Count; i++)
                 {
-                    if (CanBeDrawn(_text_types[i]))
+                    if (i < _text_types.Count && CanBeDrawn(_text_types[i]))
                     {
                         height += _entries[i].Height;
                     }


### PR DESCRIPTION
I've had this crash pop up occasionally for ages. Finally bothered to fix it.

Relevant stacktrace:
```
Unhandled Exception:
System.ArgumentOutOfRangeException: Invalid existing index 8 for source length 8
Parameter name: index
  at ClassicUO.Utility.Collections.Deque`1[T].CheckExistingIndexArgument (System.Int32 sourceLength, System.Int32 index) [0x00036] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Utility.Collections.Deque`1[T].get_Item (System.Int32 index) [0x00007] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Gumps.JournalGump+RenderedTextList.CalculateScrollBarMaxValue () [0x00021] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Gumps.JournalGump+RenderedTextList.Update (System.Double totalTime, System.Double frameTime) [0x00059] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Controls.Control.Update (System.Double totalTime, System.Double frameTime) [0x00070] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Gumps.Gump.Update (System.Double totalTime, System.Double frameTime) [0x00033] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Gumps.JournalGump.Update (System.Double totalTime, System.Double frameTime) [0x00001] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.Managers.UIManager.Update (System.Double totalTime, System.Double frameTime) [0x00023] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.GameController.Update (Microsoft.Xna.Framework.GameTime gameTime) [0x000e5] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at Microsoft.Xna.Framework.Game.Tick () [0x0025a] in <cc42580f95b84799a7f8b78492ba1089>:0 
  at Microsoft.Xna.Framework.Game.RunLoop () [0x00044] in <cc42580f95b84799a7f8b78492ba1089>:0 
  at Microsoft.Xna.Framework.Game.Run () [0x0003e] in <cc42580f95b84799a7f8b78492ba1089>:0 
  at ClassicUO.Client.Run () [0x000a7] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Bootstrap.Main (System.String[] args) [0x003d1] in <d82670b897324f4893b21bdfb4e5508c>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentOutOfRangeException: Invalid existing index 8 for source length 8
Parameter name: index
  at ClassicUO.Utility.Collections.Deque`1[T].CheckExistingIndexArgument (System.Int32 sourceLength, System.Int32 index) [0x00036] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Utility.Collections.Deque`1[T].get_Item (System.Int32 index) [0x00007] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Gumps.JournalGump+RenderedTextList.CalculateScrollBarMaxValue () [0x00021] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Gumps.JournalGump+RenderedTextList.Update (System.Double totalTime, System.Double frameTime) [0x00059] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Controls.Control.Update (System.Double totalTime, System.Double frameTime) [0x00070] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Gumps.Gump.Update (System.Double totalTime, System.Double frameTime) [0x00033] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.UI.Gumps.JournalGump.Update (System.Double totalTime, System.Double frameTime) [0x00001] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Game.Managers.UIManager.Update (System.Double totalTime, System.Double frameTime) [0x00023] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.GameController.Update (Microsoft.Xna.Framework.GameTime gameTime) [0x000e5] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at Microsoft.Xna.Framework.Game.Tick () [0x0025a] in <cc42580f95b84799a7f8b78492ba1089>:0 
  at Microsoft.Xna.Framework.Game.RunLoop () [0x00044] in <cc42580f95b84799a7f8b78492ba1089>:0 
  at Microsoft.Xna.Framework.Game.Run () [0x0003e] in <cc42580f95b84799a7f8b78492ba1089>:0 
  at ClassicUO.Client.Run () [0x000a7] in <d82670b897324f4893b21bdfb4e5508c>:0 
  at ClassicUO.Bootstrap.Main (System.String[] args) [0x003d1] in <d82670b897324f4893b21bdfb4e5508c>:0 
```