### PR TITLE
Fix ReadASCII/WriteASCII using ASCII instead of cp-1252

### DIFF
--- a/src/ClassicUO.csproj
+++ b/src/ClassicUO.csproj
@@ -125,6 +125,10 @@
     <DataFiles_vulkan Include="$(ProjectDir)..\external\vulkan\icd.d\*.*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+  </ItemGroup>
+
   <Target Name="CopyExternalDeps_build" AfterTargets="Build">
     <Copy SourceFiles="@(DataFiles_x64)" DestinationFolder="$(TargetDir)\x64\" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(DataFiles_lib64)" DestinationFolder="$(TargetDir)\lib64\" SkipUnchangedFiles="true" />

--- a/src/IO/StackDataReader.cs
+++ b/src/IO/StackDataReader.cs
@@ -276,12 +276,12 @@ namespace ClassicUO.IO
 
         public string ReadASCII(bool safe = false)
         {
-            return ReadString(Encoding.ASCII, -1, 1, safe);
+            return ReadString(Encoding.GetEncoding("iso-8859-1"), -1, 1, safe);
         }
 
         public string ReadASCII(int length, bool safe = false)
         {
-            return ReadString(Encoding.ASCII, length, 1, safe);
+            return ReadString(Encoding.GetEncoding("iso-8859-1"), length, 1, safe);
         }
 
         public string ReadUnicodeBE(bool safe = false)

--- a/src/IO/StackDataReader.cs
+++ b/src/IO/StackDataReader.cs
@@ -276,12 +276,12 @@ namespace ClassicUO.IO
 
         public string ReadASCII(bool safe = false)
         {
-            return ReadString(Encoding.GetEncoding(1252), -1, 1, safe);
+            return ReadString(StringHelper.Cp1252Encoding, -1, 1, safe);
         }
 
         public string ReadASCII(int length, bool safe = false)
         {
-            return ReadString(Encoding.GetEncoding(1252), length, 1, safe);
+            return ReadString(StringHelper.Cp1252Encoding, length, 1, safe);
         }
 
         public string ReadUnicodeBE(bool safe = false)

--- a/src/IO/StackDataReader.cs
+++ b/src/IO/StackDataReader.cs
@@ -276,12 +276,12 @@ namespace ClassicUO.IO
 
         public string ReadASCII(bool safe = false)
         {
-            return ReadString(Encoding.GetEncoding("iso-8859-1"), -1, 1, safe);
+            return ReadString(Encoding.GetEncoding(1252), -1, 1, safe);
         }
 
         public string ReadASCII(int length, bool safe = false)
         {
-            return ReadString(Encoding.GetEncoding("iso-8859-1"), length, 1, safe);
+            return ReadString(Encoding.GetEncoding(1252), length, 1, safe);
         }
 
         public string ReadUnicodeBE(bool safe = false)

--- a/src/IO/StackDataWriter.cs
+++ b/src/IO/StackDataWriter.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using ClassicUO.Utility;
 
 namespace ClassicUO.IO
 {
@@ -284,14 +285,14 @@ namespace ClassicUO.IO
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str)
         {
-            WriteString<byte>(Encoding.GetEncoding(1252), str, -1);
+            WriteString<byte>(StringHelper.Cp1252Encoding, str, -1);
             WriteUInt8(0x00);
         }
 
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str, int length)
         {
-            WriteString<byte>(Encoding.GetEncoding(1252), str, length);
+            WriteString<byte>(StringHelper.Cp1252Encoding, str, length);
         }
 
 

--- a/src/IO/StackDataWriter.cs
+++ b/src/IO/StackDataWriter.cs
@@ -284,14 +284,14 @@ namespace ClassicUO.IO
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str)
         {
-            WriteString<byte>(Encoding.GetEncoding("iso-8859-1"), str, -1);
+            WriteString<byte>(Encoding.GetEncoding(1252), str, -1);
             WriteUInt8(0x00);
         }
 
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str, int length)
         {
-            WriteString<byte>(Encoding.GetEncoding("iso-8859-1"), str, length);
+            WriteString<byte>(Encoding.GetEncoding(1252), str, length);
         }
 
 

--- a/src/IO/StackDataWriter.cs
+++ b/src/IO/StackDataWriter.cs
@@ -284,14 +284,14 @@ namespace ClassicUO.IO
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str)
         {
-            WriteString<byte>(Encoding.ASCII, str, -1);
+            WriteString<byte>(Encoding.GetEncoding("iso-8859-1"), str, -1);
             WriteUInt8(0x00);
         }
 
         [MethodImpl(IMPL_OPTION)]
         public void WriteASCII(string str, int length)
         {
-            WriteString<byte>(Encoding.ASCII, str, length);
+            WriteString<byte>(Encoding.GetEncoding("iso-8859-1"), str, length);
         }
 
 

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -155,9 +155,6 @@ namespace ClassicUO
                 SetDllDirectory(libsPath);
             }
 
-            // Register the encoding provider that provides CP-1252, a text encoding used by UO.
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            
             if (string.IsNullOrWhiteSpace(Settings.GlobalSettings.Language))
             {
                 Log.Trace("language is not set. Trying to get the OS language.");

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -35,6 +35,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using ClassicUO.Configuration;
 using ClassicUO.Data;
@@ -154,6 +155,9 @@ namespace ClassicUO
                 SetDllDirectory(libsPath);
             }
 
+            // Register the encoding provider that provides CP-1252, a text encoding used by UO.
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            
             if (string.IsNullOrWhiteSpace(Settings.GlobalSettings.Language))
             {
                 Log.Trace("language is not set. Trying to get the OS language.");

--- a/src/Utility/StringHelper.cs
+++ b/src/Utility/StringHelper.cs
@@ -42,6 +42,21 @@ namespace ClassicUO.Utility
     {
         private static readonly char[] _dots = { '.', ',', ';', '!' };
 
+        private static Encoding _cp1252Encoding;
+
+        public static Encoding Cp1252Encoding
+        {
+            get
+            {
+                if (_cp1252Encoding == null)
+                {
+                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                    _cp1252Encoding = Encoding.GetEncoding(1252);
+                }
+                return _cp1252Encoding;
+            }
+        }
+
         public static string CapitalizeFirstCharacter(string str)
         {
             if (string.IsNullOrEmpty(str))

--- a/tools/ManifestCreator/Program.cs
+++ b/tools/ManifestCreator/Program.cs
@@ -80,6 +80,7 @@ namespace ManifestCreator
             "System.Memory.dll",
             "System.Numerics.Vectors.dll",
             "System.Runtime.CompilerServices.Unsafe.dll",
+            "System.Text.Encoding.CodePages.dll",
 
             // removed.
             //"Newtonsoft.Json.dll"


### PR DESCRIPTION
Reopening #1425 because this is still an issue. There was apparently something wrong with this PR, but I do not know what because I have been playing with this fix for the past month and have had no issues. Double-check that the new NuGet dependency is added and loaded correctly before merging.