### PR TITLE
Fix zero-length ReadString

### DIFF
--- a/src/IO/StackDataReader.cs
+++ b/src/IO/StackDataReader.cs
@@ -322,7 +322,7 @@ namespace ClassicUO.IO
         // from modernuo <3
         private string ReadString(Encoding encoding, int length, int sizeT, bool safe)
         {
-            if (Position + sizeT > Length)
+            if (length == 0 || Position + sizeT > Length)
             {
                 return string.Empty;
             }


### PR DESCRIPTION
ReadString was advancing the buffer even if the string length was 0. This could lead to client crashes on receiving certain packets that contained a 0-length string.