### PR TITLE
Fix skills.idx case sensitivity on Unix

### DIFF
--- a/src/IO/Resources/SkillsLoader.cs
+++ b/src/IO/Resources/SkillsLoader.cs
@@ -32,6 +32,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using ClassicUO.Utility;
@@ -66,6 +67,11 @@ namespace ClassicUO.IO.Resources
 
                     string path = UOFileManager.GetUOFilePath("skills.mul");
                     string pathidx = UOFileManager.GetUOFilePath("Skills.idx");
+                    
+                    if (!File.Exists(pathidx))
+                    {
+                        path = UOFileManager.GetUOFilePath("skills.idx");
+                    }
 
                     FileSystemHelper.EnsureFileExists(path);
                     FileSystemHelper.EnsureFileExists(pathidx);


### PR DESCRIPTION
UOFiddler saves this file as all lowercase and some servers probably therefore use the all lowercase format. We have similar workarounds for eg. Gumpart.mul. In the long term it would probably be better to see if we can support case-insensitive filenames somehow.