### PR TITLE
Fix data file case sensitivity on Unix

### DIFF
--- a/src/IO/UOFileManager.cs
+++ b/src/IO/UOFileManager.cs
@@ -58,19 +58,23 @@ namespace ClassicUO.IO
             if (!PlatformHelper.IsWindows && !File.Exists(uoFilePath))
             {
                 FileInfo finfo = new FileInfo(uoFilePath);
-
-                char firstChar = finfo.Name[0];
-
-                if (char.IsUpper(firstChar))
+                var dir = finfo.DirectoryName ?? Settings.GlobalSettings.UltimaOnlineDirectory;
+                var files = Directory.GetFiles(dir);
+                var matches = 0;
+                
+                foreach (var f in files)
                 {
-                    file = char.ToLowerInvariant(firstChar) + finfo.Name.Substring(1);
-                }
-                else
-                {
-                    file = char.ToUpperInvariant(firstChar) + finfo.Name.Substring(1);
+                    if (string.Equals(f, uoFilePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matches++;
+                        uoFilePath = f;
+                    }
                 }
 
-                uoFilePath = Path.Combine(finfo.DirectoryName ?? Settings.GlobalSettings.UltimaOnlineDirectory, file);
+                if (matches > 1)
+                {
+                    Log.Warn($"Multiple files with ambiguous case found for {file}, using {Path.GetFileName(uoFilePath)}. Check your data directory for duplicate files.");
+                }
             }
 
             return uoFilePath;


### PR DESCRIPTION
This should fix data file case sensitivity in all possible cases as suggested [here](https://github.com/ClassicUO/ClassicUO/pull/1434#issuecomment-953397668). If a data file isn't found, we check all the files in the directory and do a case insensitive match against them to see if there's a file with the same name but different case.

I decided to check all files so that the user can be warned if there are multiple potentially matching files. This is usually only done on startup so it should not be a problem that we potentially do some unnecessary iterations.