### PR TITLE
Fix buy gump item names

### DIFF
--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -1955,7 +1955,7 @@ namespace ClassicUO.Network
 
                     if (container != null)
                     {
-                        ClearContainerAndRemoveItems(container, container.Graphic == 0x2006);
+                        ClearContainer(container);
                     }
                 }
 
@@ -6011,11 +6011,6 @@ namespace ClassicUO.Network
                 Log.Warn("AddItemToContainer function adds mobile as Item");
             }
 
-            if (item != null && (container.Graphic != 0x2006 || item.Layer == Layer.Invalid))
-            {
-                World.RemoveItem(item, true);
-            }
-
             item = World.GetOrCreateItem(serial);
             item.Graphic = graphic;
             item.CheckGraphicChange();
@@ -6444,6 +6439,29 @@ namespace ClassicUO.Network
             }
 
             container.Items = remove_unequipped ? new_first : null;
+        }
+
+        private static void ClearContainer(Entity container)
+        {
+            if (container == null || container.IsEmpty)
+            {
+                return;
+            }
+            
+            LinkedObject first = container.Items;
+            LinkedObject new_first = null;
+
+            while (first != null)
+            {
+                LinkedObject next = first.Next;
+                Item it = (Item) first;
+                
+                World.RemoveItemFromContainer(it);
+
+                first = next;
+            }
+
+            container.Items = null;
         }
 
         private static Gump CreateGump


### PR DESCRIPTION
Some servers send the names of items in the buy gump in 0xD6 MegaCliloc packets before opening the buy gump. ClassicUO was deleting and then recreating any existing items in the packet handler for the 0x3C UpdateContainedItems packet, which was causing the names sent in the MegaCliloc packets to be lost. This would result in a bug where opening a buy gump, closing it, and then immediately opening it again would display incorrect item names.

This PR fixes that, but it may have some side effects because I am honestly not sure why we were recreating these items in the first place. It seemed pointless but perhaps it serves some unknown purpose.