### PR TITLE
Fix invisible ship masts in the winter

### DIFF
--- a/src/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/Game/Scenes/GameSceneDrawingSorting.cs
@@ -731,7 +731,7 @@ namespace ClassicUO.Game.Scenes
                         UpdateObjectHandles(item, useObjectHandles);
                     }
 
-                    if (!IsFoliageVisibleAtSeason(ref itemData, World.Season))
+                    if (!item.IsMulti && !IsFoliageVisibleAtSeason(ref itemData, World.Season))
                     {
                         continue;
                     }


### PR DESCRIPTION
Ship masts have the Foliage flag, so ClassicUO was making them invisible when the in-game season was set to winter or desolation.

![2021-11-03_003610](https://user-images.githubusercontent.com/5822375/140002311-6f332b39-582d-41d2-bff2-e551c10ffe28.png)

This PR changes it so that if a Foliage item is part of a multi it won't get hidden. This also means that any actual leaves etc. that are part of a multi will not get hidden in the winter, but I think that's how it's supposed to work anyway. If this is not desired, then we'll have to make an exception for ship masts, because in older clients they do not have the MultiMovable flag (which was only added in HSA) in the tiledata to distinguish them from trees.

PS: this stupid bug took me over 4 hours to debug.

PPS: the Trees to Stumps setting currently also hides ship masts in pre-HSA clients, because it checks the MultiMovable flag. I'm not changing that because people who use Trees to Stumps probably don't care to see masts either.