### PR TITLE
Small optimization for buff icon time formatting

### DIFF
--- a/src/Game/UI/Gumps/BuffGump.cs
+++ b/src/Game/UI/Gumps/BuffGump.cs
@@ -332,7 +332,7 @@ namespace ClassicUO.Game.UI.Gumps
                         }
                         else
                         {
-                            _gText.Text = span.Minutes > 0 ? $"{span.Minutes}:{span.Seconds}" : $"{span.Seconds}";
+                            _gText.Text = span.Minutes > 0 ? $"{span.Minutes}:{span.Seconds:00}" : $"{span.Seconds:00}s";
                         }
                     }
 


### PR DESCRIPTION
Super small PR but I sometimes have the problem that I mistake single minute + single second as two seconds. This improved formatting ensures seconds are always rendered as 2 digits and if only seconds are left, an s is appended. This way there is no confusion anymore.

Seconds are now have a leading 0 if they're < 10
If only seconds are left, they're displayed as "XXs"

![image](https://user-images.githubusercontent.com/59250627/144244026-08992e0c-8809-4651-8a4b-6a9d769a566b.png)
