### PR TITLE
Fix lights that have value below 0

### DIFF
--- a/src/IO/Resources/LightsLoader.cs
+++ b/src/IO/Resources/LightsLoader.cs
@@ -124,6 +124,11 @@ namespace ClassicUO.IO.Resources
                     for (int j = 0; j < entry.Width; j++)
                     {
                         ushort val = _file.ReadByte();
+                        // Light can be from -31 to 31. When they are below 0 they are bit inverted
+                        if (val > 0x1F)
+                        {
+                            val = (ushort)(~val & 0x1F);
+                        }
                         uint rgb24 = (uint) ((val << 19) | (val << 11) | (val << 3));
 
                         if (val != 0)


### PR DESCRIPTION
Lights data can be from -31 to 31, but values beyond 0 are bit invert

![image](https://user-images.githubusercontent.com/17531612/145773830-e9c88422-3c62-4e92-9d5c-4a94fa181eb6.png)
![image](https://user-images.githubusercontent.com/17531612/145774352-ba8e6810-2fa5-4df8-bcf6-5dc8654b5f43.png)
