### PR TITLE
Fix Custom Health Bar Easy Grab Offset

### DIFF
--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -982,8 +982,8 @@ namespace ClassicUO.Game.Scenes
                                 (
                                     customgump = new HealthBarGumpCustom(obj)
                                     {
-                                        X = Mouse.Position.X - (rect.Width >> 1),
-                                        Y = Mouse.Position.Y - (rect.Height >> 1)
+                                        X = Mouse.LClickPosition.X - (rect.Width >> 1),
+                                        Y = Mouse.LClickPosition.Y - (rect.Height >> 1)
                                     }
                                 );
                             }


### PR DESCRIPTION
Fix issue with custom health bars being offset from cursor by start L Click drag position when opening health bar using easy grab.