### PR TITLE
fix on mouse over in context menu

### DIFF
--- a/src/Game/UI/Gumps/PopupMenuGump.cs
+++ b/src/Game/UI/Gumps/PopupMenuGump.cs
@@ -41,11 +41,14 @@ namespace ClassicUO.Game.UI.Gumps
 {
     internal class PopupMenuGump : Gump
     {
+        private ushort _selectedItem;
+        private readonly PopupMenuData _data;
+
         public PopupMenuGump(PopupMenuData data) : base(0, 0)
         {
             CanMove = false;
             CanCloseWithRightClick = true;
-
+            _data = data;
 
             ResizePic pic = new ResizePic(0x0A3C)
             {
@@ -85,14 +88,9 @@ namespace ClassicUO.Game.UI.Gumps
                     Tag = item.Index
                 };
 
-                box.MouseUp += (sender, e) =>
+                box.MouseEnter += (sender, e) =>
                 {
-                    if (e.Button == MouseButtonType.Left)
-                    {
-                        HitBox l = (HitBox) sender;
-                        GameActions.ResponsePopupMenu(data.Serial, (ushort) l.Tag);
-                        Dispose();
-                    }
+                    _selectedItem = (ushort)(sender as HitBox).Tag;
                 };
 
                 Add(box);
@@ -143,6 +141,15 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     box.Width = width - 20;
                 }
+            }
+        }
+
+        protected override void OnMouseUp(int x, int y, MouseButtonType button)
+        {
+            if (button == MouseButtonType.Left)
+            {
+                GameActions.ResponsePopupMenu(_data.Serial, _selectedItem);
+                Dispose();
             }
         }
     }


### PR DESCRIPTION
When the user presses and holds the mouse button, then releases it on another item, the wrong item is selected.

https://media.discordapp.net/attachments/290936867199909888/880832469740421180/CursorBug.gif