### PR TITLE
LClick Health Bar Targeting Fix

### DIFF
--- a/src/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/Game/UI/Gumps/HealthBarGump.cs
@@ -219,13 +219,7 @@ namespace ClassicUO.Game.UI.Gumps
                 return;
             }
 
-            if (TargetManager.IsTargeting)
-            {
-                _targetBroke = true;
-                TargetManager.Target(LocalSerial);
-                Mouse.LastLeftButtonClickTime = 0;
-            }
-            else if (_canChangeName)
+            if (_canChangeName)
             {
                 if (_textBox != null)
                 {
@@ -237,6 +231,19 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             base.OnMouseDown(x, y, button);
+        }
+
+        protected override void OnMouseUp(int x, int y, MouseButtonType button)
+        {
+            if (TargetManager.IsTargeting && UIManager.DraggingControl == null)
+            {
+                _targetBroke = true;
+
+                TargetManager.Target(LocalSerial);
+                Mouse.LastLeftButtonClickTime = 0;
+            }
+
+            base.OnMouseUp(x, y, button);
         }
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButtonType button)


### PR DESCRIPTION
Currently the way left mouse click/release works between in range healthbars and out of range health bars is different. For out of range bars you can click and drag without targeting, while with in range bars you target as soon as you click. So one you can drag with a target up and one you can't.

This change makes them work in a more similar manner. Now with both you can click and drag without actually targeting.

I guess the biggest thing to consider here is that this changes the way you target healthbars, before it was on mouse down, no it is on mouse up. I would say the most common way people are targeting is my simply clicking quickly to target and 99% percent of users most likely won't notice, but it may be something to consider.