### PR TITLE
Change rclick gump close handling so it only happens when the user doesn't move the mouse away from the gump on r-click mouseup

### DIFF
--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -223,7 +223,10 @@ namespace ClassicUO.Game.Managers
 
             if (button == MouseButtonType.Right)
             {
-                _mouseDownControls[index]?.InvokeMouseCloseGumpWithRClick();
+                var mouseDownControl = _mouseDownControls[index];
+                // only attempt to close the gump if the mouse is still on the gump when right click mouse up occurs
+                if(mouseDownControl != null && MouseOverControl == mouseDownControl)
+                    mouseDownControl.InvokeMouseCloseGumpWithRClick();
             }
 
             _mouseDownControls[index] = null;


### PR DESCRIPTION
Previously you would always close the gump you r-clicked even if you moved away, therefore having no way to circumvent accidentally closing a gump