### PR TITLE
Add option to lock nameplates.

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -170,6 +170,7 @@ namespace ClassicUO.Configuration
         public bool HoldDownKeyAltToCloseAnchored { get; set; } = true;
         public bool CloseAllAnchoredGumpsInGroupWithRightClick { get; set; } = false;
         public bool HoldAltToMoveGumps { get; set; }
+        public bool LockOverheadNameGumps { get; set; }
 
         public bool HideScreenshotStoredInMessage { get; set; }
 

--- a/src/Game/GameCursor.cs
+++ b/src/Game/GameCursor.cs
@@ -565,7 +565,7 @@ namespace ClassicUO.Game
 
             ushort result = _cursorData[war, 9];
 
-            if (!UIManager.IsMouseOverWorld)
+            if (!UIManager.IsMouseOverWorld && (UIManager.MouseOverControl != null && !UIManager.MouseOverControl.AllowPlayerWorldMovement))
             {
                 return result;
             }

--- a/src/Game/GameObjects/Entity.cs
+++ b/src/Game/GameObjects/Entity.cs
@@ -163,7 +163,10 @@ namespace ClassicUO.Game.GameObjects
                     Socket.Send_NameRequest(Serial);
                 }
 
-                UIManager.Add(new NameOverheadGump(this));
+                if (!NameOverHeadManager.IsIngoredEntity(this))
+                {
+                    UIManager.Add(new NameOverheadGump(this));
+                }
             }
 
 

--- a/src/Game/Managers/NameOverHeadManager.cs
+++ b/src/Game/Managers/NameOverHeadManager.cs
@@ -31,6 +31,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using ClassicUO.Configuration;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.UI.Gumps;
@@ -50,6 +51,7 @@ namespace ClassicUO.Game.Managers
     internal static class NameOverHeadManager
     {
         private static NameOverHeadHandlerGump _gump;
+        private static HashSet<uint> _ignoredEntities = new HashSet<uint>();
 
         public static NameOverheadTypeAllowed TypeAllowed
         {
@@ -95,6 +97,8 @@ namespace ClassicUO.Game.Managers
 
         public static void Open()
         {
+            ClearIgnoredEntities();
+
             if (_gump == null || _gump.IsDisposed)
             {
                 _gump = new NameOverHeadHandlerGump();
@@ -117,6 +121,31 @@ namespace ClassicUO.Game.Managers
         public static void ToggleOverheads()
         {
             IsToggled = !IsToggled;
+        }
+
+        public static void ClearIgnoredEntities()
+        {
+            _ignoredEntities.Clear();
+        }
+
+        public static void IgnoreEntity(Entity entity)
+        {
+            if (entity == null)
+            {
+                return;
+            }
+
+            _ignoredEntities.Add(entity.Serial);
+        }
+
+        public static bool IsIngoredEntity(Entity entity)
+        {
+            if (entity == null)
+            {
+                return false;
+            }
+
+            return _ignoredEntities.Contains(entity.Serial);
         }
     }
 }

--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -581,6 +581,11 @@ namespace ClassicUO.Game.Managers
             {
                 for (LinkedListNode<Gump> el = Gumps.First; el != null; el = el.Next)
                 {
+                    if (el.Value is NameOverheadGump)
+                    {
+                        SortHealthBarOverNameplate(el);
+                    }
+
                     Gump c = el.Value;
 
                     if (c.LayerOrder == UILayer.Default)
@@ -616,6 +621,25 @@ namespace ClassicUO.Game.Managers
                 }
 
                 _needSort = false;
+            }
+        }
+
+        private static void SortHealthBarOverNameplate(LinkedListNode<Gump> nameplateNode)
+        {
+            var currentProfile = ProfileManager.CurrentProfile;
+
+            if (currentProfile == null || !currentProfile.LockOverheadNameGumps)
+            {
+                return;
+            }
+
+            for (LinkedListNode<Gump> current = Gumps.First; current != null; current = current.Next)
+            {
+                if (current.Value is BaseHealthBarGump)
+                {
+                    Gumps.Remove(current);
+                    Gumps.AddBefore(nameplateNode, current);
+                }
             }
         }
 

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -807,7 +807,7 @@ namespace ClassicUO.Game.Scenes
                 UIManager.ShowGamePopup(null);
             }
 
-            if (!UIManager.IsMouseOverWorld)
+            if (!UIManager.IsMouseOverWorld && !(UIManager.MouseOverControl != null && UIManager.MouseOverControl.AllowPlayerWorldMovement))
             {
                 return false;
             }

--- a/src/Game/UI/Controls/Control.cs
+++ b/src/Game/UI/Controls/Control.cs
@@ -70,6 +70,8 @@ namespace ClassicUO.Game.UI.Controls
             IsEnabled = true;
         }
 
+        public virtual bool AllowPlayerWorldMovement { get; set; }
+
         public virtual ClickPriority Priority { get; set; } = ClickPriority.Default;
 
         public uint ServerSerial { get; set; }
@@ -107,7 +109,7 @@ namespace ClassicUO.Game.UI.Controls
 
         public virtual bool CanMove { get; set; }
 
-        public bool CanCloseWithRightClick { get; set; } = true;
+        public virtual bool CanCloseWithRightClick { get; set; } = true;
 
         public bool CanCloseWithEsc { get; set; }
 

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -47,6 +47,11 @@ namespace ClassicUO.Game.UI.Gumps
 {
     internal class NameOverheadGump : Gump
     {
+        const ushort LOCK_GRAPHIC = 0x082C;
+
+        public override bool AllowPlayerWorldMovement => ProfileManager.CurrentProfile.LockOverheadNameGumps && !Keyboard.Alt;
+        public override bool CanCloseWithRightClick => !ProfileManager.CurrentProfile.LockOverheadNameGumps && !Keyboard.Alt;
+
         private AlphaBlendControl _background;
         private Point _lockedPosition;
         private bool _positionLocked;
@@ -55,9 +60,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public NameOverheadGump(uint serial) : base(serial, 0)
         {
-            CanMove = false;
             AcceptMouseInput = true;
-            CanCloseWithRightClick = true;
 
             Entity entity = World.Get(serial);
 
@@ -218,6 +221,11 @@ namespace ClassicUO.Game.UI.Gumps
                 entity.ObjectHandlesStatus = ObjectHandlesStatus.CLOSED;
             }
 
+            if (ProfileManager.CurrentProfile.LockOverheadNameGumps)
+            {
+                NameOverHeadManager.IgnoreEntity(entity);
+            }
+
             base.CloseWithRightClick();
         }
 
@@ -250,8 +258,8 @@ namespace ClassicUO.Game.UI.Gumps
                     (
                         gump = new HealthBarGumpCustom(entity)
                         {
-                            X = Mouse.Position.X - (rect.Width >> 1),
-                            Y = Mouse.Position.Y - (rect.Height >> 1)
+                            X = Mouse.LClickPosition.X - (rect.Width >> 1),
+                            Y = Mouse.LClickPosition.Y - (rect.Height >> 1)
                         }
                     );
                 }
@@ -424,6 +432,10 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                 }
             }
+            else if (button == MouseButtonType.Right)
+            {
+                CloseWithRightClick();
+            }
 
             base.OnMouseUp(x, y, button);
         }
@@ -446,7 +458,7 @@ namespace ClassicUO.Game.UI.Gumps
                     return;
                 }
 
-                _positionLocked = true;
+                _positionLocked = !ProfileManager.CurrentProfile.LockOverheadNameGumps;
 
                 AnimationsLoader.Instance.GetAnimationDimensions
                 (
@@ -607,6 +619,28 @@ namespace ClassicUO.Game.UI.Gumps
             );
 
             base.Draw(batcher, x, y);
+
+            if (Keyboard.Alt && ProfileManager.CurrentProfile.LockOverheadNameGumps)
+            {
+                var lockTexture = GumpsLoader.Instance.GetGumpTexture(LOCK_GRAPHIC, out var lockBounds);
+
+                if (lockTexture != null)
+                {
+                    if (UIManager.MouseOverControl != null && (UIManager.MouseOverControl == this || UIManager.MouseOverControl.RootParent == this))
+                    {
+                        hueVector.X = 34;
+                        hueVector.Y = 1;
+                    }
+
+                    batcher.Draw
+                    (
+                        lockTexture,
+                        new Vector2(x + (Width - lockBounds.Width), y),
+                        lockBounds,
+                        hueVector
+                    );
+                }
+            }
 
             int renderedTextOffset = Math.Max(0, Width - _renderedText.Width - 4) >> 1;
 

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -123,7 +123,15 @@ namespace ClassicUO.Game.UI.Gumps
                          _chatAdditionalButtonsCheckbox,
                          _chatShiftEnterCheckbox,
                          _enableCaveBorder;
-        private Checkbox _holdShiftForContext, _holdShiftToSplitStack, _reduceFPSWhenInactive, _sallosEasyGrab, _partyInviteGump, _objectsFading, _textFading, _holdAltToMoveGumps;
+        private Checkbox _holdShiftForContext,
+                        _holdShiftToSplitStack,
+                        _reduceFPSWhenInactive,
+                        _sallosEasyGrab,
+                        _partyInviteGump,
+                        _objectsFading,
+                        _textFading,
+                        _holdAltToMoveGumps,
+                        _lockOverheadNameGumps;
         private Combobox _hpComboBox, _healtbarType, _fieldsType, _hpComboBoxShowWhen;
 
         // infobar
@@ -1093,6 +1101,18 @@ namespace ClassicUO.Game.UI.Gumps
                     null,
                     ResGumps.ShiftStack,
                     _currentProfile.HoldShiftToSplitStack,
+                    0,
+                    0
+                )
+            );
+
+            section3.Add
+            (
+                _lockOverheadNameGumps = AddCheckBox
+                (
+                    null,
+                    ResGumps.LockOverheadNameGumps,
+                    _currentProfile.LockOverheadNameGumps,
                     0,
                     0
                 )
@@ -3448,6 +3468,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _holdShiftForContext.IsChecked = false;
                     _holdAltToMoveGumps.IsChecked = false;
                     _holdShiftToSplitStack.IsChecked = false;
+                    _lockOverheadNameGumps.IsChecked = false;
                     _enablePathfind.IsChecked = false;
                     _useShiftPathfind.IsChecked = false;
                     _alwaysRun.IsChecked = false;
@@ -4127,6 +4148,14 @@ namespace ClassicUO.Game.UI.Gumps
                         customhealthbar.Dispose();
                     }
                 }
+            }
+
+            var updateOverheadNames = _currentProfile.LockOverheadNameGumps != _lockOverheadNameGumps.IsChecked;
+            _currentProfile.LockOverheadNameGumps = _lockOverheadNameGumps.IsChecked;
+
+            if (updateOverheadNames)
+            {
+                NameOverHeadManager.IsToggled = false;
             }
 
             _currentProfile.CBBlackBGToggled = _customBarsBBG.IsChecked;

--- a/src/Resources/ResGumps.Designer.cs
+++ b/src/Resources/ResGumps.Designer.cs
@@ -2313,6 +2313,15 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lock Overhead Name Gumps.
+        /// </summary>
+        public static string LockOverheadNameGumps {
+            get {
+                return ResourceManager.GetString("LockOverheadNameGumps", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Login music.
         /// </summary>
         public static string LoginMusic {

--- a/src/Resources/ResGumps.resx
+++ b/src/Resources/ResGumps.resx
@@ -1546,4 +1546,7 @@ Client version: '{0}'</value>
   <data name="DragSelectStartingPosY" xml:space="preserve">
     <value>Starting Y position of health bars</value>
   </data>
+  <data name="LockOverheadNameGumps" xml:space="preserve">
+    <value>Lock Overhead Name Gumps</value>
+  </data>
 </root>


### PR DESCRIPTION
https://streamable.com/ha0988
(the cursor in the recording is slightly offset from where it actually is ingame. Ingame the cursor is over the nameplate to demoenstrate how it doesn't block movement and can be closed.)

Add option to lock nameplates.

Locked nameplates will not block player movement and can be closed by holding ALT (similar to anchored healthbars). They otherwise function the same as nameplates current do.
When a locked nameplate has been closed it will not reappear until the user has toggled nameplates.

To have a gump that will still accept input while not blocking player movement a new Control property was added; AllowPlayerWorldMovement. Also CanCloseWithRightClick needed to be made a virtual property.

Comments on a previous PR for the same feature can be found [here](https://github.com/ClassicUO/ClassicUO/pull/1468).