### PR TITLE
"Ping" (send 0x73) in character select, create regardless of -no_server_ping

### DIFF
--- a/src/Game/Scenes/LoginScene.cs
+++ b/src/Game/Scenes/LoginScene.cs
@@ -199,8 +199,10 @@ namespace ClassicUO.Game.Scenes
                 }
             }
 
-            if (CUOEnviroment.NoServerPing == false && CurrentLoginStep == LoginSteps.CharacterCreation && Time.Ticks > _pingTime)
+            if ((CurrentLoginStep == LoginSteps.CharacterCreation || CurrentLoginStep == LoginSteps.CharacterSelection) && Time.Ticks > _pingTime)
             {
+                // Note that this will not be an ICMP ping, so it's better that this *not* be affected by -no_server_ping.
+
                 if (NetClient.Socket != null && NetClient.Socket.IsConnected)
                 {
                     NetClient.Socket.Statistics.SendPing();


### PR DESCRIPTION
The -no_server_ping command line option is meant to deactivate the feature that
sends real ICMP pings to the server from the server selection screen.

But it also had the effect of deactivating the application layer 0x73
packets (also called a "Ping" in the code) sent from the character
creation screens.  That was actually not desirable.  It only led to the
client hanging if a user took too long to finish creating their character.

This change disregards -no_server_ping in the character creation screen,
and it also sends the application layer 0x73 "ping" from the character
_selection_ screen, so that the user can also idle there safely.