### PR TITLE
Don't calculate shop item prices using short (16 bit) types

### DIFF
--- a/src/Game/UI/Gumps/ShopGump.cs
+++ b/src/Game/UI/Gumps/ShopGump.cs
@@ -415,7 +415,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (_updateTotal)
             {
-                int sum = 0;
+                long sum = 0;
 
                 foreach (TransactionItem t in _transactionItems.Values)
                 {
@@ -487,7 +487,7 @@ namespace ClassicUO.Game.UI.Gumps
                     shopItem.Graphic,
                     shopItem.Hue,
                     total,
-                    (ushort) shopItem.Price,
+                    shopItem.Price,
                     shopItem.ShopItemName
                 );
 
@@ -863,7 +863,7 @@ namespace ClassicUO.Game.UI.Gumps
                 ushort graphic,
                 ushort hue,
                 int amount,
-                ushort price,
+                uint price,
                 string realname
             )
             {
@@ -1034,7 +1034,7 @@ namespace ClassicUO.Game.UI.Gumps
             public ushort Graphic { get; }
             public ushort Hue { get; }
 
-            public ushort Price { get; }
+            public uint Price { get; }
 
             public int Amount
             {


### PR DESCRIPTION
Players buying items which cost more than 65,535gp (for example, house
deeds on some servers) were seeing incorrect "Total" values in the shop
gump.

![image](https://user-images.githubusercontent.com/97489744/152660326-cfacab6d-46ad-4171-9f42-b6cc06c1645b.png)

Large totals may be crowded into a label that needs more spacing, but I think that issue is minor compared to showing an incorrect value.