### PR TITLE
Show an 8x8 grid on world map if zoomed in far enough

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -303,6 +303,7 @@ namespace ClassicUO.Configuration
         public bool WorldMapShowMultis { get; set; } = true;
         public string WorldMapHiddenMarkerFiles { get; set; } = string.Empty;
         public string WorldMapHiddenZoneFiles { get; set; } = string.Empty;
+        public bool WorldMapShowGridIfZoomed { get; set; } = true;
 
 
         public static uint GumpsVersion { get; private set; }

--- a/src/Resources/ResGumps.Designer.cs
+++ b/src/Resources/ResGumps.Designer.cs
@@ -1466,6 +1466,24 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filter type [TEST]:.
+        /// </summary>
+        public static string FilterType {
+            get {
+                return ResourceManager.GetString("FilterType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} [{1}].
+        /// </summary>
+        public static string FilterTypeFormatON {
+            get {
+                return ResourceManager.GetString("FilterTypeFormatON", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fire Resistance.
         /// </summary>
         public static string FireResistance {
@@ -1642,6 +1660,15 @@ namespace ClassicUO.Resources {
         public static string GoToStory0 {
             get {
                 return ResourceManager.GetString("GoToStory0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show/Hide 8x8 Grid if Zoomed.
+        /// </summary>
+        public static string GridIfZoomed {
+            get {
+                return ResourceManager.GetString("GridIfZoomed", resourceCulture);
             }
         }
         
@@ -2441,7 +2468,7 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Map Zone Options.
+        ///   Looks up a localized string similar to Grid and Zone Options.
         /// </summary>
         public static string MapZoneOptions {
             get {

--- a/src/Resources/ResGumps.resx
+++ b/src/Resources/ResGumps.resx
@@ -1553,12 +1553,15 @@ Client version: '{0}'</value>
     <value>&lt;none&gt;</value>
   </data>
   <data name="MapZoneOptions" xml:space="preserve">
-    <value>Map Zone Options</value>
+    <value>Grid and Zone Options</value>
   </data>
   <data name="MapZoneReload" xml:space="preserve">
     <value>Reload Map Zones</value>
   </data>
   <data name="MapZoneFileLoaded" xml:space="preserve">
     <value>WorldMap zones loaded '{0}' </value>
+  </data>
+  <data name="GridIfZoomed" xml:space="preserve">
+    <value>Show/Hide 8x8 Grid if Zoomed</value>
   </data>
 </root>


### PR DESCRIPTION
The player can disable or re-enable this feature at will.

---
Full disclosure: I'm not actually sure whether all shard operators would want this.  Whether any shards are doing 8x8 skill gain or whatever significance 8x8 tiles have for resource spawning, I only know that some players on some shards find similar features in no-longer-maintained assistant apps to be useful for them.

I think it's really just a Quality of Life improvement, and I don't think it enables any player behavior that players can't achieve with other tools.  That said, I am not a shard operator, so I understand if there would be a different view.

![Recording 2022-02-07 at 00 48 57](https://user-images.githubusercontent.com/97489744/152732518-855903d8-619f-441a-9d37-251e87a6c78b.gif)