### PR TITLE
Control light colours and light assignments with text files

### DIFF
--- a/src/Game/Data/LightColors.cs
+++ b/src/Game/Data/LightColors.cs
@@ -30,21 +30,30 @@
 
 #endregion
 
+using ClassicUO.Utility;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
 namespace ClassicUO.Game.Data
 {
     internal static class LightColors
     {
-        private static readonly uint[][] _lightCurveTables = new uint[5][]
-        {
-            new uint[32] { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2,3,4,6,8,10,12,14,16,18,20,22,24,26,28},
-            new uint[32] { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2,3,4,5,6,7,8},
-            new uint[32] { 0,1,2,4,6,8,11,14,17,20,23,26,29,30,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31},
-            new uint[32] { 0,0,0,0,0,0,0,0,1,1,2,2,3,3,4,4,5,6,7,8,9,10,11,12,13,15,17,19,21,23,25,27},
-            new uint[32] { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,5,10,15,20,25,30,30,18,18,18,18,18,18,18},
-        };
 
-        public static ushort GetHue(ushort id)
+        private static readonly Dictionary<ushort, LightShaderData> _shaderdata = new Dictionary<ushort, LightShaderData>();
+        private static readonly Dictionary<ushort, ItemLightData> _itemlightdata = new Dictionary<ushort, ItemLightData>();
+
+        public static ushort GetHue(ushort id, out bool ishue)
         {
+
+            ishue = false;
+
+            if (_itemlightdata.TryGetValue(id, out ItemLightData lightdata))
+            {
+                ishue = lightdata.IsHue;
+                return lightdata.Color;
+            }
+
             ushort color = 0;
 
             switch (id)
@@ -288,59 +297,226 @@ namespace ClassicUO.Game.Data
             return color;
         }
 
-        internal static void CreateLookupTables(uint[] buffer)
+        private static void MakeDefaultShaders(int count)
         {
+            _shaderdata.Clear();
 
-            for (uint i = 0; i < 32; i++)
+            for (ushort i = 1; i <= count; i++)
             {
-                uint tableA = _lightCurveTables[0][i];
-                uint tableB = _lightCurveTables[1][i];
-                uint tableC = _lightCurveTables[2][i];
-                uint tableD = _lightCurveTables[3][i];
-                uint tableE = _lightCurveTables[4][i];
-
-                // green small
-                buffer[32 * 0 + i] = tableA << 11 | 0xFF_00_00_00;
-
-                // light blue
-                buffer[32 * 1 + i] = i << 19 | (i >> 1) << 11 | (i >> 1) << 3 | 0xFF_00_00_00;
-
-                // dark blue
-                buffer[32 * 5 + i] = tableA << 19 | tableB << 3 | 0xFF_00_00_00;
-
-                // blue
-                buffer[32 * 9 + i] = i << 19 | (i >> 2) << 11 | (i >> 2) << 3 | 0xFF_00_00_00;
-
-                // green
-                buffer[32 * 19 + i] = i << 11 | 0xFF_00_00_00;
-
-                // orange
-                buffer[32 * 29 + i] = (tableC >> 1) << 11 | tableC << 3 | 0xFF_00_00_00;
-
-                // orange small
-                buffer[32 * 30 + i] = (tableA >> 1) << 11 | tableA << 3 | 0xFF_00_00_00;
-
-                // purple
-                buffer[32 * 31 + i] = i << 19 | i << 3 | 0xFF_00_00_00;
-
-                // red
-                buffer[32 * 39 + i] = i << 3 | 0xFF_00_00_00;
-
-                // yellow
-                buffer[32 * 49 + i] = i << 11 | i << 3 | 0xFF_00_00_00;
-
-                // yellow small
-                buffer[32 * 59 + i] = tableA << 11 | tableA << 3 | 0xFF_00_00_00;
-
-                // yellow medium
-                buffer[32 * 60 + i] = tableD << 11 | tableD << 3 | 0xFF_00_00_00;
-
-                // white medium
-                buffer[32 * 61 + i] = tableD << 19 | tableD << 11 | tableD << 3 | 0xFF_00_00_00;
-
-                // white small full
-                buffer[32 * 62 + i] = tableE << 19 | tableE << 11 | tableE << 3 | 0xFF_00_00_00;
+                _shaderdata[i] = new LightShaderData((uint)0xFF_FF_FF);
             }
+
+            // green small
+            _shaderdata[1] = new LightShaderData((uint)0x00_FF_00, greencurve: LightShaderCurve.A);
+
+            // light blue
+            _shaderdata[2] = new LightShaderData((uint)0x7F_7F_FF);
+
+            // dark blue
+            _shaderdata[6] = new LightShaderData((uint)0xFF_00_FF, bluecurve: LightShaderCurve.A, redcurve: LightShaderCurve.B);
+
+            // blue
+            _shaderdata[10] = new LightShaderData((uint)0x3F_3F_FF);
+
+            // green
+            _shaderdata[20] = new LightShaderData((uint)0x00_FF_00);
+
+            // orange
+            _shaderdata[30] = new LightShaderData((uint)0xFF_7F_00, greencurve: LightShaderCurve.C, redcurve: LightShaderCurve.C);
+
+            // orange small
+            _shaderdata[31] = new LightShaderData((uint)0xFF_7F_00, greencurve: LightShaderCurve.A, redcurve: LightShaderCurve.A);
+
+            // purple
+            _shaderdata[32] = new LightShaderData((uint)0xFF_00_FF);
+
+            // red
+            _shaderdata[40] = new LightShaderData((uint)0xFF_00_00);
+
+            // yellow
+            _shaderdata[50] = new LightShaderData((uint)0xFF_FF_00);
+
+            // yellow small
+            _shaderdata[60] = new LightShaderData((uint)0xFF_FF_00, redcurve: LightShaderCurve.A, greencurve: LightShaderCurve.A);
+
+            // yellow medium
+            _shaderdata[61] = new LightShaderData((uint)0xFF_FF_00, redcurve: LightShaderCurve.D, greencurve: LightShaderCurve.D);
+
+            // white medium
+            _shaderdata[62] = new LightShaderData((uint)0xFF_FF_FF, LightShaderCurve.D, LightShaderCurve.D, LightShaderCurve.D);
+
+            // white small full
+            _shaderdata[63] = new LightShaderData((uint)0xFF_FF_FF, LightShaderCurve.E, LightShaderCurve.E, LightShaderCurve.E);
+        }
+
+        public static void BuildLightShaderFiles(bool force)
+        {
+            string path = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Client");
+
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            path = Path.Combine(path, "lightshaders.txt");
+
+            if (!File.Exists(path) || force)
+            {
+                using (StreamWriter writer = new StreamWriter(File.Create(path)))
+                {
+                    writer.WriteLine("# FORMAT");
+
+                    writer.WriteLine("# ID RGB R_CURVE G_CURVE B_CURVE");
+                    writer.WriteLine("# HARD LIMIT IS 63");
+                    writer.WriteLine("#");
+                    writer.WriteLine("# DEFAULT SHADERS:");
+
+                    foreach (KeyValuePair<ushort, LightShaderData> e in _shaderdata)
+                    {
+                        writer.WriteLine($"# {e.Key} {e.Value.RGB:X6} {e.Value.RedCurve} {e.Value.GreenCurve} {e.Value.BlueCurve}");
+                    }
+                }
+            }
+
+            TextFileParser lightshadersParser = new TextFileParser(File.ReadAllText(path), new[] { ' ', '\t', ',' }, new[] { '#', ';' }, new[] { '"', '"' });
+
+            while (!lightshadersParser.IsEOF())
+            {
+                List<string> ss = lightshadersParser.ReadTokens();
+
+                if (ss != null && ss.Count != 0)
+                {
+                    LightShaderCurve curver = LightShaderCurve.Standard;
+                    LightShaderCurve curveg = LightShaderCurve.Standard;
+                    LightShaderCurve curveb = LightShaderCurve.Standard;
+
+                    if (ushort.TryParse(ss[0], out ushort id) && ss.Count > 1)
+                    {
+                        if (ss.Count > 2)
+                        {
+                            Enum.TryParse(ss[2], out curver);
+
+                            if (ss.Count > 4)
+                            {
+                                Enum.TryParse(ss[3], out curveg);
+                                Enum.TryParse(ss[4], out curveb);
+                            }
+                            else
+                            {
+                                curveg = curveb = curver;
+                            }
+                        }
+
+                        _shaderdata[id] = new LightShaderData(Convert.ToUInt32(ss[1], 16), curver, curveg, curveb);
+                    }
+                }
+            }
+        }
+
+        public static void LoadLights()
+        {
+            string path = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Client");
+
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            string lights = Path.Combine(path, "lights.txt");
+
+            if (!File.Exists(lights))
+            {
+                using (StreamWriter writer = new StreamWriter(lights))
+                {
+                    writer.WriteLine("# FORMAT");
+                    writer.WriteLine("# ITEM_ID LIGHT_SHADER_OR_HUE");
+                    writer.WriteLine("#");
+                    writer.WriteLine("# Example for shader");
+                    writer.WriteLine("# 0xE31 35");
+                    writer.WriteLine("#");
+                    writer.WriteLine("# Example for hue");
+                    writer.WriteLine("# 0xE31 H1234");
+                    writer.WriteLine("");
+                }
+            }
+
+            TextFileParser itemlightsparser = new TextFileParser(File.ReadAllText(lights), new[] { ' ', '\t', ',' }, new[] { '#', ';' }, new[] { '"', '"' });
+
+            while (!itemlightsparser.IsEOF())
+            {
+                List<string> ss = itemlightsparser.ReadTokens();
+
+                if (ss != null && ss.Count != 0)
+                {
+                    ItemLightData entry = new ItemLightData();
+
+                    ushort id = ss[0].StartsWith("0x") ? Convert.ToUInt16(ss[0], 16) : Convert.ToUInt16(ss[0]);
+
+                    string color = ss[1];
+
+                    if (color.StartsWith("H"))
+                    {
+                        color = color.Replace("H", "");
+                        entry.Color = ushort.Parse(color);
+                        entry.Color--;
+                        entry.IsHue = true;
+                    }
+                    else
+                    {
+                        entry.Color = ushort.Parse(color);
+                        entry.IsHue = false;
+                    }
+
+                    _itemlightdata[id] = entry;
+                }
+            }
+        }
+
+        internal static void CreateLightTextures(uint[] buffer, int count)
+        {
+            MakeDefaultShaders(count);
+            BuildLightShaderFiles(false);
+
+            byte[][] lightCurveTables = new byte[6][]
+            {
+                new byte[32] { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31},
+                new byte[32] { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2,3,4,6,8,10,12,14,16,18,20,22,24,26,28},
+                new byte[32] { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2,3,4,5,6,7,8},
+                new byte[32] { 0,1,2,4,6,8,11,14,17,20,23,26,29,30,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31},
+                new byte[32] { 0,0,0,0,0,0,0,0,1,1,2,2,3,3,4,4,5,6,7,8,9,10,11,12,13,15,17,19,21,23,25,27},
+                new byte[32] { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,5,10,15,20,25,30,30,18,18,18,18,18,18,18},
+            };
+
+            foreach (KeyValuePair<ushort, LightShaderData> entry in _shaderdata)
+            {
+                for (uint i = 0; i < 32; i++)
+                {
+                    uint r = (entry.Value.RGB & 0xFF_00_00) >> 16;
+                    uint g = (entry.Value.RGB & 0x00_FF_00) >> 8;
+                    uint b = (entry.Value.RGB & 0x00_00_FF);
+
+                    buffer[32 * (entry.Key - 1) + i] = 0xFF_00_00_00 | 
+                        ((lightCurveTables[(uint) entry.Value.BlueCurve][i] * b) / 31) << 16 |
+                        ((lightCurveTables[(uint) entry.Value.GreenCurve][i] * g) / 31) << 8 |
+                        ((lightCurveTables[(uint) entry.Value.RedCurve][i] * r) / 31);
+                }
+            }
+        }
+
+        public enum LightShaderCurve
+        {
+            Standard,
+            A, // small
+            B, // very small and dim
+            C, // full, flat
+            D, // medium dim
+            E  // halo
+        }
+
+        private struct ItemLightData
+        {
+            public ushort Color;
+            public bool IsHue;
         }
     }
 }

--- a/src/Game/Data/LightShaderData.cs
+++ b/src/Game/Data/LightShaderData.cs
@@ -1,0 +1,61 @@
+﻿#region license
+
+// Copyright (c) 2021, andreakarasho
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. All advertising materials mentioning features or use of this software
+//    must display the following acknowledgement:
+//    This product includes software developed by andreakarasho - https://github.com/andreakarasho
+// 4. Neither the name of the copyright holder nor the
+//    names of its contributors may be used to endorse or promote products
+//    derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using static ClassicUO.Game.Data.LightColors;
+
+namespace ClassicUO.Game.Data
+{
+    internal struct LightShaderData
+    {
+        public LightShaderData(uint rgb, LightShaderCurve redcurve = LightShaderCurve.Standard, LightShaderCurve greencurve = LightShaderCurve.Standard, LightShaderCurve bluecurve = LightShaderCurve.Standard)
+        {
+            RGB = rgb;
+            Hue = 0;
+            RedCurve = redcurve;
+            GreenCurve = greencurve;
+            BlueCurve = bluecurve;
+        }
+
+        public LightShaderData(ushort hue)
+        {
+            RGB = 0;
+            Hue = hue;
+            RedCurve = GreenCurve = BlueCurve = LightShaderCurve.Standard;
+        }
+
+        public uint RGB;
+        public ushort Hue;
+        public LightShaderCurve RedCurve;
+        public LightShaderCurve GreenCurve;
+        public LightShaderCurve BlueCurve;
+    }
+}

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -545,7 +545,7 @@ namespace ClassicUO.Game.Scenes
                     return;
                 }
 
-                light.Color = ProfileManager.CurrentProfile.UseColoredLights ? LightColors.GetHue(graphic) : (ushort) 0;
+                light.Color = ProfileManager.CurrentProfile.UseColoredLights ? LightColors.GetHue(graphic, out light.IsHue) : (ushort) 0;
 
                 if (light.Color != 0)
                 {
@@ -1147,7 +1147,7 @@ namespace ClassicUO.Game.Scenes
             batcher.SetBlendState(BlendState.Additive);
 
             Vector3 hue = Vector3.Zero;
-            hue.Y = ShaderHueTranslator.SHADER_LIGHTS;
+
             hue.Z = 1f;
 
             for (int i = 0; i < _lightCount; i++)
@@ -1162,6 +1162,7 @@ namespace ClassicUO.Game.Scenes
                 }
 
                 hue.X = l.Color;
+                hue.Y = l.IsHue ? ShaderHueTranslator.SHADER_HUED : ShaderHueTranslator.SHADER_LIGHTS;
 
                 batcher.Draw
                 (
@@ -1291,6 +1292,7 @@ namespace ClassicUO.Game.Scenes
         {
             public byte ID;
             public ushort Color;
+            public bool IsHue;
             public int DrawX, DrawY;
         }
     }

--- a/src/GameController.cs
+++ b/src/GameController.cs
@@ -136,12 +136,11 @@ namespace ClassicUO
                 _hueSamplers[0].SetDataPointerEXT(0, null, (IntPtr) ptr, TEXTURE_WIDTH * TEXTURE_HEIGHT * sizeof(uint));
                 _hueSamplers[1].SetDataPointerEXT(0, null, (IntPtr) ptr + TEXTURE_WIDTH * TEXTURE_HEIGHT * sizeof(uint), TEXTURE_WIDTH * TEXTURE_HEIGHT * sizeof(uint));
 
-                LightColors.CreateLookupTables(buffer);
+                LightColors.CreateLightTextures(buffer, LIGHTS_TEXTURE_HEIGHT);
                 _hueSamplers[2].SetDataPointerEXT(0, null, (IntPtr)ptr, LIGHTS_TEXTURE_WIDTH * LIGHTS_TEXTURE_HEIGHT * sizeof(uint));
             }      
         
             System.Buffers.ArrayPool<uint>.Shared.Return(buffer, true);
-
 
             GraphicsDevice.Textures[1] = _hueSamplers[0];
             GraphicsDevice.Textures[2] = _hueSamplers[1];
@@ -150,6 +149,8 @@ namespace ClassicUO
             GumpsLoader.Instance.CreateAtlas(GraphicsDevice);
             LightsLoader.Instance.CreateAtlas(GraphicsDevice);
             AnimationsLoader.Instance.CreateAtlas(GraphicsDevice);
+
+            LightColors.LoadLights();
 
             AnimatedStaticsManager.Initialize();
 


### PR DESCRIPTION
This PR is to allow shards to easily create new light colours and assign lights to items, which is currently all hardcoded.

- Allow custom RGB lights to be created by text file
- Allow RGB lights to be assigned to item IDs by text file
- Allow hue lights to be assigned to item IDs by text file
- Clean up of the code definition for RGB lights, so even hard coding new lights in a fork is easier

RGB lights are defined by an RGB colour and a set of curves, same as the original lights. https://roxya.github.io/CUOLightShaderTester/ shows how they work.

RGB light definition in `lightshaders.txt`:
```
# FORMAT
# ID RGB R_CURVE G_CURVE B_CURVE
# HARD LIMIT IS 63

1 00FF00 Standard A Standard
2 7F7FFF Standard Standard Standard
6 FF00FF B Standard A
10 3F3FFF Standard Standard Standard
```

The item assignment in `lights.txt`:

```
# FORMAT
# ITEM_ID LIGHT_SHADER_ID

0xE31 H2731       <-- Hue 2731
0xEFA 35          <--- RGB light 35
```

Example of a hue light:
![huelight](https://user-images.githubusercontent.com/7057924/153291134-fe4b5228-3661-444c-ab56-2496598662a5.png)

Example of a custom RGB light `BDFFD6 A A E`
![image](https://user-images.githubusercontent.com/7057924/156898723-08c02ef1-d6cb-4f39-92fa-92d32caa5c65.png)
