### PR TITLE
Cleanup drag & drop UI

### DIFF
--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -650,12 +650,10 @@ namespace ClassicUO.Game.Managers
                     DraggingControl = dragTarget;
                     _dragOrigin = Mouse.LClickPosition;
 
-                    /* we need to keep the mouse down controls to invoke the mouseup
                      for (int i = 0; i < (int) MouseButtonType.Size; i++)
                      {
                         _mouseDownControls[i] = null;
                      }
-                    */
                 }
 
                 Point delta = Mouse.Position - _dragOrigin;

--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -650,10 +650,12 @@ namespace ClassicUO.Game.Managers
                     DraggingControl = dragTarget;
                     _dragOrigin = Mouse.LClickPosition;
 
-                    for (int i = 0; i < (int) MouseButtonType.Size; i++)
-                    {
+                    /* we need to keep the mouse down controls to invoke the mouseup
+                     for (int i = 0; i < (int) MouseButtonType.Size; i++)
+                     {
                         _mouseDownControls[i] = null;
-                    }
+                     }
+                    */
                 }
 
                 Point delta = Mouse.Position - _dragOrigin;

--- a/src/Game/Managers/UIManager.cs
+++ b/src/Game/Managers/UIManager.cs
@@ -626,7 +626,7 @@ namespace ClassicUO.Game.Managers
 
         public static void AttemptDragControl(Control control, bool attemptAlwaysSuccessful = false)
         {
-            if (_isDraggingControl || ItemHold.Enabled && !ItemHold.IsFixedPosition)
+            if ((_isDraggingControl && !attemptAlwaysSuccessful) || ItemHold.Enabled && !ItemHold.IsFixedPosition)
             {
                 return;
             }

--- a/src/Game/UI/Controls/Control.cs
+++ b/src/Game/UI/Controls/Control.cs
@@ -50,9 +50,8 @@ namespace ClassicUO.Game.UI.Controls
         internal static int _StepsDone = 1;
         internal static int _StepChanger = 1;
 
-        private bool _acceptKeyboardInput, _acceptMouseInput, _mouseIsDown;
+        private bool _acceptKeyboardInput, _acceptMouseInput;
         private int _activePage;
-        private bool _attempToDrag;
         private Rectangle _bounds;
         private bool _handlesKeyboardFocus;
         private Point _offset;
@@ -652,20 +651,11 @@ namespace ClassicUO.Game.UI.Controls
 
         protected virtual void OnMouseDown(int x, int y, MouseButtonType button)
         {
-            _mouseIsDown = true;
             Parent?.OnMouseDown(X + x, Y + y, button);
         }
 
         protected virtual void OnMouseUp(int x, int y, MouseButtonType button)
         {
-            _mouseIsDown = false;
-
-            if (_attempToDrag)
-            {
-                _attempToDrag = false;
-                InvokeDragEnd(new Point(x, y));
-            }
-
             Parent?.OnMouseUp(X + x, Y + y, button);
 
             if (button == MouseButtonType.Right && !IsDisposed && !CanCloseWithRightClick && !Keyboard.Alt && !Keyboard.Shift && !Keyboard.Ctrl)
@@ -681,21 +671,7 @@ namespace ClassicUO.Game.UI.Controls
 
         protected virtual void OnMouseOver(int x, int y)
         {
-            if (_mouseIsDown && !_attempToDrag)
-            {
-                Point offset = Mouse.LButtonPressed ? Mouse.LDragOffset : Mouse.MButtonPressed ? Mouse.MDragOffset : Point.Zero;
-
-                if (Math.Abs(offset.X) > Constants.MIN_GUMP_DRAG_DISTANCE || Math.Abs(offset.Y) > Constants.MIN_GUMP_DRAG_DISTANCE)
-
-                {
-                    InvokeDragBegin(new Point(x, y));
-                    _attempToDrag = true;
-                }
-            }
-            else
-            {
-                Parent?.OnMouseOver(X + x, Y + y);
-            }
+            Parent?.OnMouseOver(X + x, Y + y);
         }
 
         protected virtual void OnMouseEnter(int x, int y)
@@ -704,7 +680,6 @@ namespace ClassicUO.Game.UI.Controls
 
         protected virtual void OnMouseExit(int x, int y)
         {
-            _attempToDrag = false;
         }
 
         protected virtual bool OnMouseDoubleClick(int x, int y, MouseButtonType button)
@@ -718,7 +693,6 @@ namespace ClassicUO.Game.UI.Controls
 
         protected virtual void OnDragEnd(int x, int y)
         {
-            _mouseIsDown = false;
         }
 
         protected virtual void OnTextInput(string c)

--- a/src/Game/UI/Controls/ExpandableScroll.cs
+++ b/src/Game/UI/Controls/ExpandableScroll.cs
@@ -30,16 +30,18 @@
 
 #endregion
 
+using ClassicUO.Game.Managers;
 using ClassicUO.Input;
 using ClassicUO.IO.Resources;
 using ClassicUO.Renderer;
+using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Game.UI.Controls
 {
     internal class ExpandableScroll : Control
     {
         private const int c_ExpandableScrollHeight_Min = 274;
-        private const int c_ExpandableScrollHeight_Max = 1000;
+        private const int c_ExpandableScrollHeight_Max = 800;
         private const int c_GumplingExpanderY_Offset = 2; // this is the gap between the pixels of the btm Control texture and the height of the btm Control texture.
         private const int c_GumplingExpander_ButtonID = 0x7FBEEF;
         private readonly GumpPic _gumpBottom;
@@ -51,8 +53,8 @@ namespace ClassicUO.Game.UI.Controls
         private readonly GumpPicTiled _gumpRight;
         private readonly GumpPic _gumpTop;
         private bool _isExpanding;
-        private int _isExpanding_InitialX, _isExpanding_InitialY, _isExpanding_InitialHeight;
         private readonly bool _isResizable = true;
+        private Point _lastExpanderPosition;
 
         public ExpandableScroll(int x, int y, int height, ushort graphic, bool isResizable = true)
         {
@@ -140,7 +142,6 @@ namespace ClassicUO.Game.UI.Controls
 
                 _gumpExpander.MouseDown += expander_OnMouseDown;
                 _gumpExpander.MouseUp += expander_OnMouseUp;
-                _gumpExpander.MouseOver += expander_OnMouseOver;
             }
 
             int off = w0 - w3;
@@ -191,7 +192,6 @@ namespace ClassicUO.Game.UI.Controls
             {
                 _gumpExpander.MouseDown -= expander_OnMouseDown;
                 _gumpExpander.MouseUp -= expander_OnMouseUp;
-                _gumpExpander.MouseOver -= expander_OnMouseOver;
                 _gumpExpander.Dispose();
                 _gumpExpander = null;
             }
@@ -247,13 +247,21 @@ namespace ClassicUO.Game.UI.Controls
 
         public override void Update(double totalTime, double frameTime)
         {
+            if (Mouse.LButtonPressed && _isExpanding)
+            {
+                SpecialHeight += Mouse.Position.Y - _lastExpanderPosition.Y;
+                _lastExpanderPosition = Mouse.Position;
+            }
+
             if (SpecialHeight < c_ExpandableScrollHeight_Min)
             {
+                _lastExpanderPosition.Y += c_ExpandableScrollHeight_Min - SpecialHeight;
                 SpecialHeight = c_ExpandableScrollHeight_Min;
             }
 
             if (SpecialHeight > c_ExpandableScrollHeight_Max)
             {
+                _lastExpanderPosition.Y -= SpecialHeight - c_ExpandableScrollHeight_Max;
                 SpecialHeight = c_ExpandableScrollHeight_Max;
             }
 
@@ -265,81 +273,53 @@ namespace ClassicUO.Game.UI.Controls
                 Add(_gumplingTitle = new GumpPic(0, 0, (ushort) _gumplingTitleGumpID, 0));
             }
 
+            //if (!IsVisible)
+            //    IsVisible = true;
+            //TOP
+            _gumpTop.X = 0;
+            _gumpTop.Y = 0;
+            _gumpTop.WantUpdateSize = true;
+            //MIDDLE
+            _gumpRight.Y = _gumpMiddle.Y = _gumplingMidY;
+            _gumpRight.Height = _gumpMiddle.Height = _gumplingMidHeight;
+            _gumpRight.WantUpdateSize = _gumpMiddle.WantUpdateSize = true;
+            //BOTTOM
+            _gumpBottom.Y = _gumplingBottomY;
+            _gumpBottom.WantUpdateSize = true;
 
+            if (_isResizable)
             {
-                //if (!IsVisible)
-                //    IsVisible = true;
-                //TOP
-                _gumpTop.X = 0;
-                _gumpTop.Y = 0;
-                _gumpTop.WantUpdateSize = true;
-                //MIDDLE
-                _gumpRight.Y = _gumpMiddle.Y = _gumplingMidY;
-                _gumpRight.Height = _gumpMiddle.Height = _gumplingMidHeight;
-                _gumpRight.WantUpdateSize = _gumpMiddle.WantUpdateSize = true;
-                //BOTTOM
-                _gumpBottom.Y = _gumplingBottomY;
-                _gumpBottom.WantUpdateSize = true;
-
-                if (_isResizable)
-                {
-                    _gumpExpander.X = _gumplingExpanderX;
-                    _gumpExpander.Y = _gumplingExpanderY;
-                    _gumpExpander.WantUpdateSize = true;
-                }
-
-                if (_gumplingTitle != null)
-                {
-                    _gumplingTitle.X = (_gumpTop.Width - _gumplingTitle.Width) >> 1;
-                    _gumplingTitle.Y = (_gumpTop.Height - _gumplingTitle.Height) >> 1;
-                    _gumplingTitle.WantUpdateSize = true;
-                }
-
-                WantUpdateSize = true;
-                Parent?.OnPageChanged();
+                _gumpExpander.X = _gumplingExpanderX;
+                _gumpExpander.Y = _gumplingExpanderY;
+                _gumpExpander.WantUpdateSize = true;
             }
+
+            if (_gumplingTitle != null)
+            {
+                _gumplingTitle.X = (_gumpTop.Width - _gumplingTitle.Width) >> 1;
+                _gumplingTitle.Y = (_gumpTop.Height - _gumplingTitle.Height) >> 1;
+                _gumplingTitle.WantUpdateSize = true;
+            }
+
+            WantUpdateSize = true;
+            Parent?.OnPageChanged();
 
             base.Update(totalTime, frameTime);
         }
 
 
-        //new MouseEventArgs(x, y, button, ButtonState.Pressed)
         private void expander_OnMouseDown(object sender, MouseEventArgs args)
         {
-            int y = args.Y;
-            int x = args.X;
-            y += _gumpExpander.Y + ScreenCoordinateY - Y;
-
             if (args.Button == MouseButtonType.Left)
             {
                 _isExpanding = true;
-                _isExpanding_InitialHeight = SpecialHeight;
-                _isExpanding_InitialX = x;
-                _isExpanding_InitialY = y;
+                _lastExpanderPosition = Mouse.Position;
             }
         }
 
         private void expander_OnMouseUp(object sender, MouseEventArgs args)
         {
-            int y = args.Y;
-            y += _gumpExpander.Y + ScreenCoordinateY - Y;
-
-            if (_isExpanding)
-            {
-                _isExpanding = false;
-                SpecialHeight = _isExpanding_InitialHeight + (y - _isExpanding_InitialY);
-            }
-        }
-
-        private void expander_OnMouseOver(object sender, MouseEventArgs args)
-        {
-            int y = args.Y;
-            y += _gumpExpander.Y + ScreenCoordinateY - Y;
-
-            if (_isExpanding && y != _isExpanding_InitialY)
-            {
-                SpecialHeight = _isExpanding_InitialHeight + (y - _isExpanding_InitialY);
-            }
+            _isExpanding = false;
         }
     }
 }

--- a/src/Game/UI/Controls/HSliderBar.cs
+++ b/src/Game/UI/Controls/HSliderBar.cs
@@ -149,7 +149,19 @@ namespace ClassicUO.Game.UI.Controls
 
         public event EventHandler ValueChanged;
 
-      
+        public override void Update(double totalTime, double frameTime)
+        {
+            base.Update(totalTime, frameTime);
+
+            if (_clicked)
+            {
+                int x = Mouse.Position.X - X - ParentX;
+                int y = Mouse.Position.Y - Y - ParentY;
+
+                CalculateNew(x);
+            }
+        }
+
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
         {
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
@@ -278,14 +290,6 @@ namespace ClassicUO.Game.UI.Controls
             }
 
             CalculateOffset();
-        }
-
-        protected override void OnMouseOver(int x, int y)
-        {
-            if (_clicked)
-            {
-                CalculateNew(x);
-            }
         }
 
         private void CalculateNew(int x)

--- a/src/Game/UI/Controls/ScrollBarBase.cs
+++ b/src/Game/UI/Controls/ScrollBarBase.cs
@@ -130,6 +130,13 @@ namespace ClassicUO.Game.UI.Controls
         {
             base.Update(totalTime, frameTime);
 
+            if (_btnSliderClicked)
+            {
+                int x = Mouse.Position.X - X - ParentX;
+                int y = Mouse.Position.Y - Y - ParentY;
+
+                CalculateByPosition(x, y);
+            }
 
             if (MaxValue <= MinValue)
             {
@@ -218,14 +225,6 @@ namespace ClassicUO.Game.UI.Controls
             _btUpClicked = false;
             _btnSliderClicked = false;
             _StepChanger = _StepsDone = 1;
-        }
-
-        protected override void OnMouseOver(int x, int y)
-        {
-            if (_btnSliderClicked)
-            {
-                CalculateByPosition(x, y);
-            }
         }
 
         protected int GetSliderYPosition()

--- a/src/Game/UI/Gumps/CombatBookGump.cs
+++ b/src/Game/UI/Gumps/CombatBookGump.cs
@@ -40,6 +40,7 @@ using ClassicUO.Input;
 using ClassicUO.IO.Resources;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
+using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -277,10 +278,29 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
+        protected override void OnDragBegin(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragBegin(new Point(x, y));
+            }
+
+            base.OnDragBegin(x, y);
+        }
+
+        protected override void OnDragEnd(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragEnd(new Point(x, y));
+            }
+
+            base.OnDragEnd(x, y);
+        }
 
         private void OnGumpicDragBeginPrimary(object sender, EventArgs e)
         {
-            if (UIManager.IsDragging)
+            if (UIManager.DraggingControl != this || UIManager.MouseOverControl != sender)
             {
                 return;
             }
@@ -301,7 +321,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         private void OnGumpicDragBeginSecondary(object sender, EventArgs e)
         {
-            if (UIManager.IsDragging)
+            if (UIManager.DraggingControl != this || UIManager.MouseOverControl != sender)
             {
                 return;
             }

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -221,8 +221,16 @@ namespace ClassicUO.Game.UI.Gumps
             base.CloseWithRightClick();
         }     
 
-        protected override void OnDragBegin(int x, int y)
+        private void DoDrag()
         {
+            var delta = Mouse.Position - _lastLeftMousePositionDown;
+
+            if (Math.Abs(delta.X) <= Constants.MIN_GUMP_DRAG_DISTANCE && Math.Abs(delta.Y) <= Constants.MIN_GUMP_DRAG_DISTANCE)
+            {
+                return;
+            }
+
+            _leftMouseIsDown = false;
             _positionLocked = false;
 
             Entity entity = World.Get(LocalSerial);
@@ -280,8 +288,6 @@ namespace ClassicUO.Game.UI.Gumps
                 //else
                 //    GameActions.PickUp(LocalSerial, 0, 0);
             }
-
-            base.OnDragBegin(x, y);
         }
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButtonType button)
@@ -447,14 +453,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             if (_leftMouseIsDown)
             {
-                var delta = Mouse.Position - _lastLeftMousePositionDown;
-
-                if (Math.Abs(delta.X) > Constants.MIN_GUMP_DRAG_DISTANCE || Math.Abs(delta.Y) > Constants.MIN_GUMP_DRAG_DISTANCE)
-                {
-                    OnDragBegin(x, y);
-
-                    _leftMouseIsDown = false;
-                }
+                DoDrag();
             }
 
             if (!_positionLocked && SerialHelper.IsMobile(LocalSerial))

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -452,6 +452,8 @@ namespace ClassicUO.Game.UI.Gumps
                 if (Math.Abs(delta.X) > Constants.MIN_GUMP_DRAG_DISTANCE || Math.Abs(delta.Y) > Constants.MIN_GUMP_DRAG_DISTANCE)
                 {
                     OnDragBegin(x, y);
+
+                    _leftMouseIsDown = false;
                 }
             }
 

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -48,8 +48,8 @@ namespace ClassicUO.Game.UI.Gumps
     internal class NameOverheadGump : Gump
     {
         private AlphaBlendControl _background;
-        private Point _lockedPosition;
-        private bool _positionLocked;
+        private Point _lockedPosition, _lastLeftMousePositionDown;
+        private bool _positionLocked, _leftMouseIsDown;
         private readonly RenderedText _renderedText;
         private Texture2D _borderColor = SolidColorTextureCache.GetTexture(Color.Black);
 
@@ -219,7 +219,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             base.CloseWithRightClick();
-        }
+        }     
 
         protected override void OnDragBegin(int x, int y)
         {
@@ -280,6 +280,8 @@ namespace ClassicUO.Game.UI.Gumps
                 //else
                 //    GameActions.PickUp(LocalSerial, 0, 0);
             }
+
+            base.OnDragBegin(x, y);
         }
 
         protected override bool OnMouseDoubleClick(int x, int y, MouseButtonType button)
@@ -311,10 +313,23 @@ namespace ClassicUO.Game.UI.Gumps
             return false;
         }
 
+        protected override void OnMouseDown(int x, int y, MouseButtonType button)
+        {
+            if (button == MouseButtonType.Left)
+            {
+                _lastLeftMousePositionDown = Mouse.Position;
+                _leftMouseIsDown = true;
+            }
+
+            base.OnMouseDown(x, y, button);
+        }
+
         protected override void OnMouseUp(int x, int y, MouseButtonType button)
         {
             if (button == MouseButtonType.Left)
             {
+                _leftMouseIsDown = false;
+
                 if (!ItemHold.Enabled)
                 {
                     if (UIManager.IsDragging || Math.Max(Math.Abs(Mouse.LDragOffset.X), Math.Abs(Mouse.LDragOffset.Y)) >= 1)
@@ -430,12 +445,17 @@ namespace ClassicUO.Game.UI.Gumps
 
         protected override void OnMouseOver(int x, int y)
         {
-            if (_positionLocked)
+            if (_leftMouseIsDown)
             {
-                return;
+                var delta = Mouse.Position - _lastLeftMousePositionDown;
+
+                if (Math.Abs(delta.X) > Constants.MIN_GUMP_DRAG_DISTANCE || Math.Abs(delta.Y) > Constants.MIN_GUMP_DRAG_DISTANCE)
+                {
+                    OnDragBegin(x, y);
+                }
             }
 
-            if (SerialHelper.IsMobile(LocalSerial))
+            if (!_positionLocked && SerialHelper.IsMobile(LocalSerial))
             {
                 Mobile m = World.Mobiles.Get(LocalSerial);
 

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -1994,7 +1994,12 @@ namespace ClassicUO.Game.UI.Gumps
 
                         nb.DragBegin += (sss, eee) =>
                         {
-                            if (UIManager.IsDragging || Math.Max(Math.Abs(Mouse.LDragOffset.X), Math.Abs(Mouse.LDragOffset.Y)) < 5 || nb.ScreenCoordinateX > Mouse.LClickPosition.X || nb.ScreenCoordinateX < Mouse.LClickPosition.X - nb.Width || nb.ScreenCoordinateY > Mouse.LClickPosition.Y || nb.ScreenCoordinateY + nb.Height < Mouse.LClickPosition.Y)
+                            if (UIManager.DraggingControl != this || UIManager.MouseOverControl != sss)
+                            {
+                                return;
+                            }
+
+                            if (Math.Max(Math.Abs(Mouse.LDragOffset.X), Math.Abs(Mouse.LDragOffset.Y)) < 5 || nb.ScreenCoordinateX > Mouse.LClickPosition.X || nb.ScreenCoordinateX < Mouse.LClickPosition.X - nb.Width || nb.ScreenCoordinateY > Mouse.LClickPosition.Y || nb.ScreenCoordinateY + nb.Height < Mouse.LClickPosition.Y)
                             {
                                 return;
                             }
@@ -2110,7 +2115,12 @@ namespace ClassicUO.Game.UI.Gumps
                         return;
                     }
 
-                    if (UIManager.IsDragging || Math.Max(Math.Abs(Mouse.LDragOffset.X), Math.Abs(Mouse.LDragOffset.Y)) < 5 || nb.ScreenCoordinateX > Mouse.LClickPosition.X || nb.ScreenCoordinateX < Mouse.LClickPosition.X - nb.Width || nb.ScreenCoordinateY > Mouse.LClickPosition.Y || nb.ScreenCoordinateY + nb.Height < Mouse.LClickPosition.Y)
+                    if (UIManager.DraggingControl != this || UIManager.MouseOverControl != sss)
+                    {
+                        return;
+                    }
+
+                    if (Math.Max(Math.Abs(Mouse.LDragOffset.X), Math.Abs(Mouse.LDragOffset.Y)) < 5 || nb.ScreenCoordinateX > Mouse.LClickPosition.X || nb.ScreenCoordinateX < Mouse.LClickPosition.X - nb.Width || nb.ScreenCoordinateY > Mouse.LClickPosition.Y || nb.ScreenCoordinateY + nb.Height < Mouse.LClickPosition.Y)
                     {
                         return;
                     }
@@ -4396,6 +4406,26 @@ namespace ClassicUO.Game.UI.Gumps
             //area.ReArrangeChildren();
 
             return section;
+        }
+
+        protected override void OnDragBegin(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragBegin(new Point(x, y));
+            }
+
+            base.OnDragBegin(x, y);
+        }
+
+        protected override void OnDragEnd(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragEnd(new Point(x, y));
+            }
+
+            base.OnDragEnd(x, y);
         }
 
         private enum Buttons

--- a/src/Game/UI/Gumps/RacialAbilitiesBookGump.cs
+++ b/src/Game/UI/Gumps/RacialAbilitiesBookGump.cs
@@ -37,6 +37,7 @@ using ClassicUO.Input;
 using ClassicUO.IO.Resources;
 using ClassicUO.Network;
 using ClassicUO.Resources;
+using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -203,7 +204,7 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     pic.DragBegin += (sender, e) =>
                     {
-                        if (UIManager.IsDragging)
+                        if (UIManager.DraggingControl != this || UIManager.MouseOverControl != sender)
                         {
                             return;
                         }
@@ -244,6 +245,26 @@ namespace ClassicUO.Game.UI.Gumps
                     page1
                 );
             }
+        }
+
+        protected override void OnDragBegin(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragBegin(new Point(x, y));
+            }
+
+            base.OnDragBegin(x, y);
+        }
+
+        protected override void OnDragEnd(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragEnd(new Point(x, y));
+            }
+
+            base.OnDragEnd(x, y);
         }
 
         private void GetSummaryBookInfo(ref int abilityOnPage, ref ushort iconStartGraphic)

--- a/src/Game/UI/Gumps/SpellbookGump.cs
+++ b/src/Game/UI/Gumps/SpellbookGump.cs
@@ -850,7 +850,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         private void OnIconDragBegin(object sender, EventArgs e)
         {
-            if (UIManager.IsDragging)
+            if (UIManager.DraggingControl != this || UIManager.MouseOverControl != sender)
             {
                 return;
             }
@@ -1152,6 +1152,26 @@ namespace ClassicUO.Game.UI.Gumps
 
                     break;
             }
+        }
+
+        protected override void OnDragBegin(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragBegin(new Point(x, y));
+            }
+
+            base.OnDragBegin(x, y);
+        }
+
+        protected override void OnDragEnd(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragEnd(new Point(x, y));
+            }
+
+            base.OnDragEnd(x, y);
         }
 
         private void GetSpellRequires(int offset, out int y, out string text)


### PR DESCRIPTION
Drag & drop had an odd and tricky beahviour.
Under the hood the game allowed controls that cannot move [`CanMove = false;`] to invoke `DragBegin` & `DragEnd` methods into the `MouseOver` function.

The `DragBegin` & `DragEnd` methods are useful for moving controls and not for static ones. So they must be not called when the main gump is set to no move.

Although some control needs to get invoked their `DragBegin` and `DragEnd` methods like the `NameOverheadGump`.
In these particular cases I suggest to store the last left mouse position and trigger the `DragBegin` manually.