### PR TITLE
Add AnimationLoader APIs that hide internal data structures

### DIFF
--- a/src/Game/GameObjects/Item.cs
+++ b/src/Game/GameObjects/Item.cs
@@ -701,27 +701,16 @@ namespace ClassicUO.Game.GameObjects
 
                     if (id < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
                     {
-                        byte animGroup = AnimationsLoader.Instance.GetDeathAction(id, UsedLayer);
-
+                        byte action = AnimationsLoader.Instance.GetDeathAction(id, UsedLayer);
                         ushort hue = 0;
+                        bool useUOP;
 
-                        AnimationDirection direction = AnimationsLoader.Instance.GetBodyAnimationGroup(ref id, ref animGroup, ref hue, isCorpse: true).Direction[dir];
+                        AnimationsLoader.Instance.ReplaceAnimationValues(ref id, ref action, ref hue, out useUOP, isCorpse: true);
+                        int frameCount = AnimationsLoader.Instance.LoadAnimationFrames(id, action, dir, useUOP);
 
-                        if (direction.FrameCount == 0 || direction.SpriteInfos == null)
+                        if (frameCount > 0)
                         {
-                            AnimationsLoader.Instance.LoadAnimationFrames(id, animGroup, dir, ref direction);
-                        }
-
-                        if (direction.Address != 0 && direction.Size != 0 || direction.IsUOP)
-                        {
-                            int fc = direction.FrameCount;
-
-                            if (frameIndex >= fc)
-                            {
-                                frameIndex = (byte) (fc - 1);
-                            }
-
-                            AnimIndex = (byte) (frameIndex % direction.FrameCount);
+                            AnimIndex = (byte) (frameIndex % frameCount);
                         }
                     }
 

--- a/src/Game/GameObjects/Mobile.cs
+++ b/src/Game/GameObjects/Mobile.cs
@@ -593,7 +593,7 @@ namespace ClassicUO.Game.GameObjects
             if (LastAnimationChangeTime < Time.Ticks && !NoIterateAnimIndex())
             {
                 ushort id = GetGraphicForAnimation();
-                byte animGroup = GetGroupForAnimation(this, id, true);
+                byte action = GetGroupForAnimation(this, id, true);
 
                 bool mirror = false;
                 AnimationsLoader.Instance.GetAnimDirection(ref dir, ref mirror);
@@ -602,17 +602,14 @@ namespace ClassicUO.Game.GameObjects
                 if (id < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
                 {
                     ushort hue = 0;
+                    bool useUOP;
 
-                    AnimationDirection direction = AnimationsLoader.Instance.GetBodyAnimationGroup(ref id, ref animGroup, ref hue, true).Direction[dir];
+                    AnimationsLoader.Instance.ReplaceAnimationValues(ref id, ref action, ref hue, out useUOP);
+                    int frameCount = AnimationsLoader.Instance.LoadAnimationFrames(id, action, dir, useUOP);
 
-                    if (direction != null && (direction.FrameCount == 0 || direction.SpriteInfos == null))
+                    if (frameCount != 0)
                     {
-                        AnimationsLoader.Instance.LoadAnimationFrames(id, animGroup, dir, ref direction);
-                    }
-
-                    if (direction != null && direction.FrameCount != 0)
-                    {
-                        int fc = direction.FrameCount;
+                        int fc = frameCount;
 
                         int frameIndex = AnimIndex + (AnimationFromServer && !_isAnimationForwardDirection ? -1 : 1);
 
@@ -641,7 +638,7 @@ namespace ClassicUO.Game.GameObjects
                                 }
                                 else
                                 {
-                                    frameIndex = (byte)(direction.FrameCount - 1);
+                                    frameIndex = (byte)(frameCount - 1);
                                 }
                             }
                             else
@@ -687,7 +684,7 @@ namespace ClassicUO.Game.GameObjects
                             }
                         }
 
-                        AnimIndex = (byte) (frameIndex % direction.FrameCount);
+                        AnimIndex = (byte) (frameIndex % frameCount);
                     }
                     else if ((Serial & 0x80000000) != 0)
                     {

--- a/src/Game/GameObjects/Views/ItemView.cs
+++ b/src/Game/GameObjects/Views/ItemView.cs
@@ -303,36 +303,31 @@ namespace ClassicUO.Game.GameObjects
             }
 
             ushort newHue = 0;
+            bool useUOP;
 
-            AnimationGroup gr =  AnimationsLoader.Instance.GetBodyAnimationGroup(ref graphic, ref animGroup, ref newHue, isCorpse: layer == Layer.Invalid);
+            AnimationsLoader.Instance.ReplaceAnimationValues(ref graphic, ref animGroup, ref newHue, out useUOP, isEquip: layer != Layer.Invalid, isCorpse: layer == Layer.Invalid);
+            int frameCount = AnimationsLoader.Instance.LoadAnimationFrames(graphic, animGroup, dir, useUOP);
 
             if (color == 0)
             {
                 color = newHue;
             }
 
-            AnimationDirection direction = gr.Direction[dir];
-
-            if (direction == null)
+            if (frameCount == 0)
             {
                 return;
             }
 
-            if ((direction.FrameCount == 0 || direction.SpriteInfos == null) && !AnimationsLoader.Instance.LoadAnimationFrames(graphic, animGroup, dir, ref direction))
-            {
-                return;
-            }
-
-            int fc = direction.FrameCount;
+            int fc = frameCount;
 
             if (fc > 0 && animIndex >= fc)
             {
                 animIndex = (byte) (fc - 1);
             }
 
-            if (animIndex < direction.FrameCount)
+            if (animIndex < frameCount)
             {
-                ref var spriteInfo = ref direction.SpriteInfos[animIndex];
+                ref var spriteInfo = ref AnimationsLoader.Instance.GetAnimationFrame(graphic, animGroup, dir, animIndex, useUOP);
 
                 if (spriteInfo.Texture == null)
                 {
@@ -557,8 +552,23 @@ namespace ClassicUO.Game.GameObjects
                     }
 
                     byte group = AnimationsLoader.Instance.GetDeathAction(graphic, UsedLayer);
+                    ushort hue = 0;
 
-                    if (GetTexture(ref graphic, ref group, ref animIndex, direction, out var spriteInfo, out var isUop))
+                    AnimationsLoader.Instance.ReplaceAnimationValues(ref graphic, ref group, ref hue, out var isUop);
+                    int fc = AnimationsLoader.Instance.LoadAnimationFrames(graphic, group, direction, isUop);
+
+                    if (fc > 0 && animIndex >= 0)
+                    {
+                        animIndex = (byte)(animIndex % fc);
+                    }
+                    else if (animIndex < 0)
+                    {
+                        animIndex = 0;
+                    }
+
+                    ref var spriteInfo = ref AnimationsLoader.Instance.GetAnimationFrame(graphic, group, direction, animIndex, isUop);
+
+                    if (spriteInfo.Texture != null)
                     {
                         int x = position.X - (IsFlipped ? spriteInfo.UV.Width - spriteInfo.Center.X : spriteInfo.Center.X);
                         int y = position.Y - (spriteInfo.UV.Height + spriteInfo.Center.Y);
@@ -581,61 +591,6 @@ namespace ClassicUO.Game.GameObjects
             }
 
             return false;
-        }
-
-        private static bool GetTexture(ref ushort graphic, ref byte animGroup, ref byte animIndex, byte direction, out SpriteInfo spriteInfo, out bool isUOP)
-        {
-            spriteInfo = default;
-            isUOP = false;
-
-            ushort hue = 0;
-
-            AnimationDirection animationSet = AnimationsLoader.Instance.GetBodyAnimationGroup
-            (
-                ref graphic,
-                ref animGroup,
-                ref hue,
-                true,
-                false
-            )
-            .Direction[direction];
-
-            if (animationSet == null ||
-                animationSet.Address == -1 ||
-                animationSet.FileIndex == -1 ||
-                animationSet.FrameCount == 0 ||
-                animationSet.SpriteInfos == null
-               )
-            {
-                return false;
-            }
-
-            int fc = animationSet.FrameCount;
-
-            if (fc > 0 && animIndex >= fc)
-            {
-                animIndex = (byte)(fc - 1);
-            }
-            else if (animIndex < 0)
-            {
-                animIndex = 0;
-            }
-
-            if (animIndex >= animationSet.FrameCount)
-            {
-                return false;
-            }
-
-            spriteInfo = animationSet.SpriteInfos[animIndex % animationSet.FrameCount];
-
-            if (spriteInfo.Texture == null)
-            {
-                return false;
-            }
-
-            isUOP = animationSet.IsUOP;
-
-            return true;
         }
     }
 }

--- a/src/Game/UI/Gumps/ShopGump.cs
+++ b/src/Game/UI/Gumps/ShopGump.cs
@@ -733,37 +733,6 @@ namespace ClassicUO.Game.UI.Gumps
                 return 0;
             }
 
-            private static AnimationDirection GetMobileAnimationDirection(ushort graphic, ref ushort hue, byte dirIndex)
-            {
-                if (graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
-                {
-                    return null;
-                }
-
-                byte group = GetAnimGroup(graphic);
-                IndexAnimation index = AnimationsLoader.Instance.DataIndex[graphic];
-
-                AnimationDirection direction = index.Groups[group].Direction[dirIndex];
-
-                for (int i = 0; i < 2 && direction.FrameCount == 0; i++)
-                {
-                    if (!AnimationsLoader.Instance.LoadAnimationFrames(graphic, group, dirIndex, ref direction))
-                    {
-                        //direction = AnimationsLoader.Instance.GetCorpseAnimationGroup(ref graphic, ref group, ref hue2).Direction[dirIndex];
-                        //graphic = item.ItemData.AnimID;
-                        //group = GetAnimGroup(graphic);
-                        //index = AnimationsLoader.Instance.DataIndex[graphic];
-                        //direction = AnimationsLoader.Instance.GetBodyAnimationGroup(ref graphic, ref group, ref hue2, true).Direction[dirIndex];
-                        ////direction = index.Groups[group].Direction[1];
-                        //AnimationsLoader.Instance.AnimID = graphic;
-                        //AnimationsLoader.Instance.AnimGroup = group;
-                        //AnimationsLoader.Instance.Direction = dirIndex;
-                    }
-                }
-
-                return direction;
-            }
-
             public void SetName(string s, bool new_name)
             {
                 _name.Text = new_name ? $"{s}: {Price}" : string.Format(ResGumps.Item0Price1, s, Price);
@@ -782,25 +751,40 @@ namespace ClassicUO.Game.UI.Gumps
                 if (SerialHelper.IsMobile(LocalSerial))
                 {
                     ushort hue2 = Hue;
-                    AnimationDirection direction = GetMobileAnimationDirection(Graphic, ref hue2, 1);
+                    ushort graphic = Graphic;
 
-                    if (direction != null && direction.SpriteInfos != null && direction.FrameCount != 0)
+                    if (graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                    {
+                        return false;
+                    }
+
+                    byte group = GetAnimGroup(graphic);
+
+                    AnimationsLoader.Instance.ReplaceAnimationValues(ref graphic, ref group, ref hue2, out var isUOP, isEquip: true);
+                    int frameCount = AnimationsLoader.Instance.LoadAnimationFrames(graphic, group, 1, false);
+
+                    if (frameCount != 0)
                     {
                         hueVector = ShaderHueTranslator.GetHueVector(hue2, TileDataLoader.Instance.StaticData[Graphic].IsPartialHue, 1f);
 
-                        batcher.Draw
-                        (
-                            direction.SpriteInfos[0].Texture,
-                            new Rectangle
+                        ref var spriteInfo = ref AnimationsLoader.Instance.GetAnimationFrame(graphic, group, 1, 0, isUOP);
+
+                        if (spriteInfo.Texture != null)
+                        {
+                            batcher.Draw
                             (
-                                x - 3, 
-                                y + 5 + 15,
-                                Math.Min(direction.SpriteInfos[0].UV.Width, 45),
-                                Math.Min(direction.SpriteInfos[0].UV.Height, 45)
-                            ),
-                            direction.SpriteInfos[0].UV,
-                            hueVector
-                        );
+                                spriteInfo.Texture,
+                                new Rectangle
+                                (
+                                    x - 3,
+                                    y + 5 + 15,
+                                    Math.Min(spriteInfo.UV.Width, 45),
+                                    Math.Min(spriteInfo.UV.Height, 45)
+                                ),
+                                spriteInfo.UV,
+                                hueVector
+                            );
+                        }
                     }
                 }
                 else if (SerialHelper.IsItem(LocalSerial))


### PR DESCRIPTION
Still haven't managed to entirely hide UOP vs non-UOP, but this is progress.