### PR TITLE
More verbose invalid gump command

### DIFF
--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -6768,7 +6768,7 @@ namespace ClassicUO.Network
                 }
                 else
                 {
-                    Log.Warn(gparams[0]);
+                    Log.Warn($"Invalid Gump Command: \"{gparams[0]}\"");
                 }
             }
 


### PR DESCRIPTION
Some custom servers are sending some invalid gump commands. This is an effort to try and improve the Log warnings.