### PR TITLE
- Adding stopping of the gump parsing if null terminated

### DIFF
--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -6766,6 +6766,11 @@ namespace ClassicUO.Network
                 {
                     gump.MasterGumpSerial = gparams.Count > 0 ? SerialHelper.Parse(gparams[1]) : 0;
                 }
+                else if (string.Equals(entry, "\0", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    //This gump is null terminated: Breaking
+                    break;
+                }
                 else
                 {
                     Log.Warn(gparams[0]);


### PR DESCRIPTION
There are some GUMPs are null terminated. This adds an ability to check for it and break the current gump command queue. We could have it set to just do nothing though like a few of the others