### PR TITLE
Customizable name plate/name overhead options

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -199,8 +199,7 @@ namespace ClassicUO.Configuration
         public int DragSelectStartX { get; set; } = 100;
         public int DragSelectStartY { get; set; } = 100;
         public bool DragSelectAsAnchor { get; set; } = false;
-        public NameOverheadTypeAllowed NameOverheadTypeAllowed { get; set; } = NameOverheadTypeAllowed.All;
-        public string LastActiveNameOverheadOption { get; set; }
+        public string LastActiveNameOverheadOption { get; set; } = "All";
         public bool NameOverheadToggled { get; set; } = false;
         public bool ShowTargetRangeIndicator { get; set; }
         public bool PartyInviteGump { get; set; }

--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -200,6 +200,7 @@ namespace ClassicUO.Configuration
         public int DragSelectStartY { get; set; } = 100;
         public bool DragSelectAsAnchor { get; set; } = false;
         public NameOverheadTypeAllowed NameOverheadTypeAllowed { get; set; } = NameOverheadTypeAllowed.All;
+        public string LastActiveNameOverheadOption { get; set; }
         public bool NameOverheadToggled { get; set; } = false;
         public bool ShowTargetRangeIndicator { get; set; }
         public bool PartyInviteGump { get; set; }

--- a/src/Game/GameObjects/Item.cs
+++ b/src/Game/GameObjects/Item.cs
@@ -38,11 +38,11 @@ using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.IO;
 using ClassicUO.IO.Resources;
-using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
 using ClassicUO.Utility.Platforms;
 using Microsoft.Xna.Framework;
+using MathHelper = ClassicUO.Utility.MathHelper;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -163,7 +163,7 @@ namespace ClassicUO.Game.GameObjects
         public int MultiDistanceBonus { get; private set; }
 
         public bool IsCorpse => /*MathHelper.InRange(Graphic, 0x0ECA, 0x0ED2) ||*/ Graphic == 0x2006;
-
+        public bool IsHumanCorpse => IsCorpse && MathHelper.InRange(Amount, 0x0190, 0x0193) || MathHelper.InRange(Amount, 0x00B7, 0x00BA) || MathHelper.InRange(Amount, 0x025D, 0x0260) || MathHelper.InRange(Amount, 0x029A, 0x029B) || MathHelper.InRange(Amount, 0x02B6, 0x02B7) || Amount == 0x03DB || Amount == 0x03DF || Amount == 0x03E2 || Amount == 0x02E8 || Amount == 0x02E9;
         public bool OnGround => !SerialHelper.IsValid(Container);
 
         public uint RootContainer

--- a/src/Game/GameObjects/Views/ItemView.cs
+++ b/src/Game/GameObjects/Views/ItemView.cs
@@ -200,8 +200,7 @@ namespace ClassicUO.Game.GameObjects
             ushort graphic = GetGraphicForAnimation();
             AnimationsLoader.Instance.ConvertBodyIfNeeded(ref graphic);
             byte group = AnimationsLoader.Instance.GetDeathAction(graphic, UsedLayer);
-
-            bool ishuman = MathHelper.InRange(Amount, 0x0190, 0x0193) || MathHelper.InRange(Amount, 0x00B7, 0x00BA) || MathHelper.InRange(Amount, 0x025D, 0x0260) || MathHelper.InRange(Amount, 0x029A, 0x029B) || MathHelper.InRange(Amount, 0x02B6, 0x02B7) || Amount == 0x03DB || Amount == 0x03DF || Amount == 0x03E2 || Amount == 0x02E8 || Amount == 0x02E9;
+            bool ishuman = IsHumanCorpse;
 
             DrawLayer
             (

--- a/src/Game/Managers/NameOverHeadManager.cs
+++ b/src/Game/Managers/NameOverHeadManager.cs
@@ -31,9 +31,15 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
 using ClassicUO.Configuration;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Utility.Logging;
+using SDL2;
 
 namespace ClassicUO.Game.Managers
 {
@@ -62,6 +68,8 @@ namespace ClassicUO.Game.Managers
             get => ProfileManager.CurrentProfile.NameOverheadToggled;
             set => ProfileManager.CurrentProfile.NameOverheadToggled = value;
         }
+
+        public static List<NameOverheadOption> Options { get; set; } = new List<NameOverheadOption>();
 
         public static bool IsAllowed(Entity serial)
         {
@@ -117,6 +125,159 @@ namespace ClassicUO.Game.Managers
         public static void ToggleOverheads()
         {
             IsToggled = !IsToggled;
+        }
+
+        public static void Load()
+        {
+            string path = Path.Combine(ProfileManager.ProfilePath, "nameoverhead.xml");
+
+            if (!File.Exists(path))
+            {
+                Log.Trace("No nameoverhead.xml file. Creating a default file.");
+
+
+                Options.Clear();
+                CreateDefaultEntries();
+                Save();
+
+                return;
+            }
+
+            Options.Clear();
+            XmlDocument doc = new XmlDocument();
+
+            try
+            {
+                doc.Load(path);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.ToString());
+
+                return;
+            }
+
+
+            XmlElement root = doc["nameoverhead"];
+
+            if (root != null)
+            {
+                foreach (XmlElement xml in root.GetElementsByTagName("nameoverheadoption"))
+                {
+                    var option = new NameOverheadOption(xml.GetAttribute("name"));
+                    option.Load(xml);
+                    Options.Add(option);
+                }
+            }
+        }
+
+        public static void Save()
+        {
+            var list = Options;
+
+            string path = Path.Combine(ProfileManager.ProfilePath, "nameoverhead.xml");
+
+            using (XmlTextWriter xml = new XmlTextWriter(path, Encoding.UTF8)
+            {
+                Formatting = Formatting.Indented,
+                IndentChar = '\t',
+                Indentation = 1
+            })
+            {
+                xml.WriteStartDocument(true);
+                xml.WriteStartElement("nameoverhead");
+
+                foreach (var option in list)
+                {
+                    option.Save(xml);
+                }
+
+                xml.WriteEndElement();
+                xml.WriteEndDocument();
+            }
+        }
+
+        private static void CreateDefaultEntries()
+        {
+            Options.AddRange
+            (
+                new[]
+                {
+                    new NameOverheadOption("All", 0),
+                    new NameOverheadOption("Mobiles only", 0),
+                    new NameOverheadOption("Items only", 0),
+                    new NameOverheadOption("Mobiles & Corpses only", 0),
+                    new NameOverheadOption("All Items", 0),
+                }
+            );
+        }
+    }
+
+    internal class NameOverheadOption : LinkedObject, IEquatable<NameOverheadOption>
+    {
+        public NameOverheadOption(string name, SDL.SDL_Keycode key, bool alt, bool ctrl, bool shift, int optionflagscode) : this(name)
+        {
+            Key = key;
+            Alt = alt;
+            Ctrl = ctrl;
+            Shift = shift;
+            NameOverheadOptionFlags = optionflagscode;
+        }
+
+        public NameOverheadOption(string name)
+        {
+            Name = name;
+        }
+
+        public NameOverheadOption(string name, int optionflagcode)
+        {
+            Name = name;
+            NameOverheadOptionFlags = optionflagcode;
+        }
+
+        public string Name { get; }
+
+        public SDL.SDL_Keycode Key { get; set; }
+        public bool Alt { get; set; }
+        public bool Ctrl { get; set; }
+        public bool Shift { get; set; }
+        public int NameOverheadOptionFlags { get; set; }
+
+        public bool Equals(NameOverheadOption other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return Key == other.Key && Alt == other.Alt && Ctrl == other.Ctrl && Shift == other.Shift && Name == other.Name;
+        }
+
+        public void Save(XmlTextWriter writer)
+        {
+            writer.WriteStartElement("nameoverheadoption");
+            writer.WriteAttributeString("name", Name);
+            writer.WriteAttributeString("key", ((int) Key).ToString());
+            writer.WriteAttributeString("alt", Alt.ToString());
+            writer.WriteAttributeString("ctrl", Ctrl.ToString());
+            writer.WriteAttributeString("shift", Shift.ToString());
+            writer.WriteAttributeString("optionflagscode", NameOverheadOptionFlags.ToString());
+
+            writer.WriteEndElement();
+        }
+
+        public void Load(XmlElement xml)
+        {
+            if (xml == null)
+            {
+                return;
+            }
+
+            Key = (SDL.SDL_Keycode) int.Parse(xml.GetAttribute("key"));
+            Alt = bool.Parse(xml.GetAttribute("alt"));
+            Ctrl = bool.Parse(xml.GetAttribute("ctrl"));
+            Shift = bool.Parse(xml.GetAttribute("shift"));
+            NameOverheadOptionFlags = int.Parse(xml.GetAttribute("optionflagscode"));
         }
     }
 }

--- a/src/Game/Managers/NameOverHeadManager.cs
+++ b/src/Game/Managers/NameOverHeadManager.cs
@@ -55,7 +55,7 @@ namespace ClassicUO.Game.Managers
         Containers = 1 << 0,
         Gold = 1 << 1,
         Stackable = 1 << 2,
-        Other = 1 << 3,
+        LockedDown = 1 << 3,
 
         // Corpses
         MonsterCorpses = 1 << 4,
@@ -76,7 +76,7 @@ namespace ClassicUO.Game.Managers
         Murderer = 1 << 15,
         Invulnerable = 1 << 16,
 
-        AllItems = Containers | Gold | Stackable | Other,
+        AllItems = Containers | Gold | Stackable | LockedDown,
         AllMobiles = Humanoid | Monster,
         MobilesAndCorpses = AllMobiles | MonsterCorpses | HumanoidCorpses,
     }
@@ -183,7 +183,10 @@ namespace ClassicUO.Game.Managers
             if (item.ItemData.IsStackable && ActiveOverheadOptions.HasFlag(NameOverheadOptions.Stackable))
                 return true;
 
-            return !item.ItemData.IsContainer && !item.IsCoin && !item.ItemData.IsStackable && ActiveOverheadOptions.HasFlag(NameOverheadOptions.Other);
+            if (item.IsLocked && ActiveOverheadOptions.HasFlag(NameOverheadOptions.LockedDown))
+                return true;
+
+            return false;
         }
 
         private static bool HandleCorpseOverhead(Item item)

--- a/src/Game/Managers/NameOverHeadManager.cs
+++ b/src/Game/Managers/NameOverHeadManager.cs
@@ -85,6 +85,10 @@ namespace ClassicUO.Game.Managers
         Enemy = 1 << 14,
         Murderer = 1 << 15,
         Invulnerable = 1 << 16,
+
+        AllItems = Containers | Gold | Stackable | Other,
+        AllMobiles = Humanoid | Monster,
+        MobilesAndCorpses = AllMobiles | MonsterCorpses | HumanoidCorpses,
     }
 
     internal static class NameOverHeadManager
@@ -165,7 +169,7 @@ namespace ClassicUO.Game.Managers
 
             if (ActiveOverheadOptions.HasFlag(NameOverheadOptions.Invulnerable) && mobile.NotorietyFlag == NotorietyFlag.Invulnerable)
                 return true;
-            
+
             return false;
         }
 
@@ -309,11 +313,14 @@ namespace ClassicUO.Game.Managers
             (
                 new[]
                 {
-                    new NameOverheadOption("All", 0),
-                    new NameOverheadOption("Mobiles only", 0),
-                    new NameOverheadOption("Items only", 0),
-                    new NameOverheadOption("Mobiles & Corpses only", 0),
-                    new NameOverheadOption("All Items", 0),
+                    new NameOverheadOption("All", int.MaxValue),
+                    new NameOverheadOption("Mobiles only", (int)NameOverheadOptions.AllMobiles),
+                    new NameOverheadOption("Items only", (int)NameOverheadOptions.AllItems),
+                    new NameOverheadOption("Mobiles & Corpses only", (int)NameOverheadOptions.MobilesAndCorpses),
+                    new NameOverheadOption("Only Allies", (int)(NameOverheadOptions.Ally | NameOverheadOptions.Innocent | NameOverheadOptions.OwnFollowers)),
+                    new NameOverheadOption("My Followers", (int)NameOverheadOptions.OwnFollowers),
+                    new NameOverheadOption("Stackable items", (int)NameOverheadOptions.Stackable),
+                    new NameOverheadOption("Stuff I can attack", (int)(NameOverheadOptions.Monster | NameOverheadOptions.Gray | NameOverheadOptions.Murderer)),
                 }
             );
         }

--- a/src/Game/Managers/NameOverHeadManager.cs
+++ b/src/Game/Managers/NameOverHeadManager.cs
@@ -324,9 +324,14 @@ namespace ClassicUO.Game.Managers
                 }
             );
         }
+
+        public static NameOverheadOption FindOption(string name)
+        {
+            return Options.Find(o => o.Name == name);
+        }
     }
 
-    internal class NameOverheadOption : LinkedObject, IEquatable<NameOverheadOption>
+    internal class NameOverheadOption
     {
         public NameOverheadOption(string name, SDL.SDL_Keycode key, bool alt, bool ctrl, bool shift, int optionflagscode) : this(name)
         {

--- a/src/Game/Managers/NameOverHeadManager.cs
+++ b/src/Game/Managers/NameOverHeadManager.cs
@@ -98,7 +98,7 @@ namespace ClassicUO.Game.Managers
         public static bool IsPermaToggled
         {
             get => ProfileManager.CurrentProfile.NameOverheadToggled;
-            set => ProfileManager.CurrentProfile.NameOverheadToggled = value;
+            private set => ProfileManager.CurrentProfile.NameOverheadToggled = value;
         }
 
         public static bool IsTemporarilyShowing { get; private set; }
@@ -223,7 +223,16 @@ namespace ClassicUO.Game.Managers
 
         public static void ToggleOverheads()
         {
-            IsPermaToggled = !IsPermaToggled;
+            SetOverheadToggled(!IsPermaToggled);
+        }
+
+        public static void SetOverheadToggled(bool toggled)
+        {
+            if (IsPermaToggled == toggled)
+                return;
+
+            IsPermaToggled = toggled;
+            _gump?.UpdateCheckboxes();
         }
 
         public static void Load()
@@ -313,17 +322,17 @@ namespace ClassicUO.Game.Managers
         {
             return Options.Find(o => o.Name == name);
         }
-        
+
         public static void AddOption(NameOverheadOption option)
         {
             Options.Add(option);
-            _gump.RedrawOverheadOptions();
+            _gump?.RedrawOverheadOptions();
         }
 
         public static void RemoveOption(NameOverheadOption option)
         {
             Options.Remove(option);
-            _gump.RedrawOverheadOptions();
+            _gump?.RedrawOverheadOptions();
         }
 
         public static NameOverheadOption FindOptionByHotkey(SDL.SDL_Keycode key, bool alt, bool ctrl, bool shift)
@@ -364,12 +373,12 @@ namespace ClassicUO.Game.Managers
 
             IsTemporarilyShowing = false;
         }
-        
+
         public static void SetActiveOption(NameOverheadOption option)
         {
             ActiveOverheadOptions = (NameOverheadOptions)option.NameOverheadOptionFlags;
             LastActiveNameOverheadOption = option.Name;
-            _gump.UpdateCheckboxes();
+            _gump?.UpdateCheckboxes();
         }
     }
 

--- a/src/Game/Managers/NameOverHeadManager.cs
+++ b/src/Game/Managers/NameOverHeadManager.cs
@@ -313,22 +313,17 @@ namespace ClassicUO.Game.Managers
         {
             return Options.Find(o => o.Name == name);
         }
-
+        
         public static void AddOption(NameOverheadOption option)
         {
             Options.Add(option);
-            UpdateHandlerGump();
-        }
-
-        private static void UpdateHandlerGump()
-        {
-            _gump.UpdateCheckboxes();
+            _gump.RedrawOverheadOptions();
         }
 
         public static void RemoveOption(NameOverheadOption option)
         {
             Options.Remove(option);
-            UpdateHandlerGump();
+            _gump.RedrawOverheadOptions();
         }
 
         public static NameOverheadOption FindOptionByHotkey(SDL.SDL_Keycode key, bool alt, bool ctrl, bool shift)
@@ -369,17 +364,12 @@ namespace ClassicUO.Game.Managers
 
             IsTemporarilyShowing = false;
         }
-
-        public static void SetActiveOption(string name)
-        {
-            SetActiveOption(FindOption(name));
-        }
-
+        
         public static void SetActiveOption(NameOverheadOption option)
         {
             ActiveOverheadOptions = (NameOverheadOptions)option.NameOverheadOptionFlags;
             LastActiveNameOverheadOption = option.Name;
-            UpdateHandlerGump();
+            _gump.UpdateCheckboxes();
         }
     }
 

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -151,6 +151,7 @@ namespace ClassicUO.Game.Scenes
             // #########################################################
 
             Macros.Load();
+            NameOverHeadManager.Load();
 
             _animatedStaticsManager = new AnimatedStaticsManager();
             _animatedStaticsManager.Initialize();
@@ -349,6 +350,7 @@ namespace ClassicUO.Game.Scenes
 
             Macros.Save();
             InfoBars.Save();
+            NameOverHeadManager.Save();
             ProfileManager.UnLoadProfile();
 
             StaticFilters.CleanCaveTextures();

--- a/src/Game/Scenes/GameScene.cs
+++ b/src/Game/Scenes/GameScene.cs
@@ -593,7 +593,7 @@ namespace ClassicUO.Game.Scenes
 
             GetViewPort();
 
-            var useObjectHandles = NameOverHeadManager.IsToggled || Keyboard.Ctrl && Keyboard.Shift;
+            var useObjectHandles = NameOverHeadManager.IsShowing;
             if (useObjectHandles != _useObjectHandles)
             {
                 _useObjectHandles = useObjectHandles;

--- a/src/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/Game/Scenes/GameSceneInputHandler.cs
@@ -1235,6 +1235,11 @@ namespace ClassicUO.Game.Scenes
                     }
                 }
             }
+
+            if (e.keysym.sym != SDL.SDL_Keycode.SDLK_UNKNOWN)
+            {
+                NameOverHeadManager.RegisterKeyDown(e.keysym);
+            }
         }
 
 
@@ -1362,6 +1367,8 @@ namespace ClassicUO.Game.Scenes
                     GameActions.ToggleWarMode();
                 }
             }
+
+            NameOverHeadManager.RegisterKeyUp(e.keysym);
         }
     }
 }

--- a/src/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -104,7 +104,7 @@ namespace ClassicUO.Game.UI.Controls
             AddCheckbox("Gold", NameOverheadOptions.Gold, 150, y);
             y += 22;
             AddCheckbox("Stackable", NameOverheadOptions.Stackable, 0, y);
-            AddCheckbox("Other items", NameOverheadOptions.Other, 150, y);
+            AddCheckbox("Locked down", NameOverheadOptions.LockedDown, 150, y);
             y += 28;
 
             AddLabel("Corpses", 75, y);

--- a/src/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -58,10 +58,15 @@ namespace ClassicUO.Game.UI.Controls
 
             CanMove = true;
 
-            _hotkeyBox = new HotkeyBox();
+            AddLabel("Set hotkey:", 0, 0);
+
+            _hotkeyBox = new HotkeyBox
+            {
+                X = 80
+            };
+
             _hotkeyBox.HotkeyChanged += BoxOnHotkeyChanged;
             _hotkeyBox.HotkeyCancelled += BoxOnHotkeyCancelled;
-
 
             Add(_hotkeyBox);
 
@@ -69,7 +74,7 @@ namespace ClassicUO.Game.UI.Controls
             (
                 new NiceButton
                 (
-                    0, _hotkeyBox.Height + 3, 170, 25,
+                    0, _hotkeyBox.Height + 3, 100, 25,
                     ButtonAction.Activate, "Uncheck all", 0, TEXT_ALIGN_TYPE.TS_LEFT
                 ) { ButtonParameter = (int)ButtonType.UncheckAll, IsSelectable = false }
             );
@@ -78,7 +83,7 @@ namespace ClassicUO.Game.UI.Controls
             (
                 new NiceButton
                 (
-                    150, _hotkeyBox.Height + 3, 170, 25,
+                    120, _hotkeyBox.Height + 3, 100, 25,
                     ButtonAction.Activate, "Check all", 0, TEXT_ALIGN_TYPE.TS_LEFT
                 ) { ButtonParameter = (int)ButtonType.CheckAll, IsSelectable = false }
             );
@@ -110,7 +115,7 @@ namespace ClassicUO.Game.UI.Controls
             y += 22;
             AddCheckbox("Own corpses", NameOverheadOptions.OwnCorpses, 0, y);
             y += 28;
-            
+
             AddLabel("Mobiles by type", 75, y);
             y += 28;
 
@@ -119,7 +124,7 @@ namespace ClassicUO.Game.UI.Controls
             y += 22;
             AddCheckbox("Own Followes", NameOverheadOptions.OwnFollowers, 0, y);
             y += 28;
-            
+
             AddLabel("Mobiles by notoriety", 75, y);
             y += 28;
 
@@ -167,6 +172,9 @@ namespace ClassicUO.Game.UI.Controls
                     Option.NameOverheadOptionFlags |= (int)optionFlag;
                 else
                     Option.NameOverheadOptionFlags &= ~(int)optionFlag;
+
+                if (NameOverHeadManager.LastActiveNameOverheadOption == Option.Name)
+                    NameOverHeadManager.ActiveOverheadOptions = (NameOverheadOptions)Option.NameOverheadOptionFlags;
             };
 
             checkboxDict.Add(optionFlag, checkbox);
@@ -215,7 +223,7 @@ namespace ClassicUO.Game.UI.Controls
             if (_hotkeyBox.Key == SDL.SDL_Keycode.SDLK_UNKNOWN)
                 return;
 
-            NameOverheadOption option = NameOverHeadManager.Options.FirstOrDefault(o => o.Key == _hotkeyBox.Key && o.Alt == alt && o.Ctrl == ctrl && o.Shift == shift);
+            NameOverheadOption option = NameOverHeadManager.FindOptionByHotkey(_hotkeyBox.Key, alt, ctrl, shift);
 
             if (option == null)
             {
@@ -244,8 +252,17 @@ namespace ClassicUO.Game.UI.Controls
         {
             switch ((ButtonType)buttonID)
             {
-                case ButtonType.CheckAll: break;
-                case ButtonType.UncheckAll: break;
+                case ButtonType.CheckAll:
+                    Option.NameOverheadOptionFlags = int.MaxValue;
+                    UpdateCheckboxesByCurrentOptionFlags();
+
+                    break;
+
+                case ButtonType.UncheckAll:
+                    Option.NameOverheadOptionFlags = 0x0;
+                    UpdateCheckboxesByCurrentOptionFlags();
+
+                    break;
             }
         }
 

--- a/src/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -91,39 +91,59 @@ namespace ClassicUO.Game.UI.Controls
 
         private void SetupOptionCheckboxes()
         {
-            var i = 0;
-            AddCheckbox("Containers", NameOverheadOptions.Containers, 0, 60 + 20 * i++);
-            AddCheckbox("Gold", NameOverheadOptions.Gold, 0, 60 + 20 * i++);
-            AddCheckbox("Stackable", NameOverheadOptions.Stackable, 0, 60 + 20 * i++);
-            AddCheckbox("Other items", NameOverheadOptions.Other, 0, 60 + 20 * i++);
+            var y = 60;
+            AddLabel("Items", 75, y);
+            y += 28;
 
-            AddCheckbox("Monster corpses", NameOverheadOptions.MonsterCorpses, 0, 60 + 20 * i++);
-            AddCheckbox("Humanoid corpses", NameOverheadOptions.HumanoidCorpses, 0, 60 + 20 * i++);
-            AddCheckbox("Own corpses", NameOverheadOptions.OwnCorpses, 0, 60 + 20 * i++);
-            // Items
-            // Containers = 1 << 0,
-            // Gold = 1 << 1,
-            // Stackable = 1 << 2,
-            // Other = 1 << 3,
-            //
-            // // Corpses
-            // MonsterCorpses = 1 << 4,
-            // HumanoidCorpses = 1 << 5,
-            // OwnCorpses = 1 << 6,
-            //
-            // // Mobiles (type)
-            // Humanoid = 1 << 7,
-            // Monster = 1 << 8,
-            // OwnFollowers = 1 << 9,
-            //
-            // // Mobiles (notoriety)
-            // Innocent = 1 << 10,
-            // Ally = 1 << 11,
-            // Gray = 1 << 12,
-            // Criminal = 1 << 13,
-            // Enemy = 1 << 14,
-            // Murderer = 1 << 15,
-            // Invulnerable = 1 << 16,
+            AddCheckbox("Containers", NameOverheadOptions.Containers, 0, y);
+            AddCheckbox("Gold", NameOverheadOptions.Gold, 150, y);
+            y += 22;
+            AddCheckbox("Stackable", NameOverheadOptions.Stackable, 0, y);
+            AddCheckbox("Other items", NameOverheadOptions.Other, 150, y);
+            y += 28;
+
+            AddLabel("Corpses", 75, y);
+            y += 28;
+
+            AddCheckbox("Monster corpses", NameOverheadOptions.MonsterCorpses, 0, y);
+            AddCheckbox("Humanoid corpses", NameOverheadOptions.HumanoidCorpses, 150, y);
+            y += 22;
+            AddCheckbox("Own corpses", NameOverheadOptions.OwnCorpses, 0, y);
+            y += 28;
+            
+            AddLabel("Mobiles by type", 75, y);
+            y += 28;
+
+            AddCheckbox("Humanoid", NameOverheadOptions.Humanoid, 0, y);
+            AddCheckbox("Monster", NameOverheadOptions.Monster, 150, y);
+            y += 22;
+            AddCheckbox("Own Followes", NameOverheadOptions.OwnFollowers, 0, y);
+            y += 28;
+            
+            AddLabel("Mobiles by notoriety", 75, y);
+            y += 28;
+
+            AddCheckbox("Innocent (blue)", NameOverheadOptions.Innocent, 0, y);
+            AddCheckbox("Allied (green)", NameOverheadOptions.Ally, 150, y);
+            y += 22;
+            AddCheckbox("Attackable (gray)", NameOverheadOptions.Gray, 0, y);
+            AddCheckbox("Criminal (gray)", NameOverheadOptions.Criminal, 150, y);
+            y += 22;
+            AddCheckbox("Enemy (orange)", NameOverheadOptions.Enemy, 0, y);
+            AddCheckbox("Murderer (red)", NameOverheadOptions.Murderer, 150, y);
+            y += 22;
+            AddCheckbox("Invulnerable (yellow)", NameOverheadOptions.Invulnerable, 0, y);
+        }
+
+        private void AddLabel(string name, int x, int y)
+        {
+            var label = new Label(name, true, 0xFFFF)
+            {
+                X = x,
+                Y = y,
+            };
+
+            Add(label);
         }
 
         private void AddCheckbox(string checkboxName, NameOverheadOptions optionFlag, int x, int y)

--- a/src/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -1,0 +1,243 @@
+﻿#region license
+
+// Copyright (c) 2021, andreakarasho
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. All advertising materials mentioning features or use of this software
+//    must display the following acknowledgement:
+//    This product includes software developed by andreakarasho - https://github.com/andreakarasho
+// 4. Neither the name of the copyright holder nor the
+//    names of its contributors may be used to endorse or promote products
+//    derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.IO.Resources;
+using ClassicUO.Resources;
+using SDL2;
+
+namespace ClassicUO.Game.UI.Controls
+{
+    internal class NameOverheadAssignControl : Control
+    {
+        private readonly HotkeyBox _hotkeyBox;
+        private readonly Dictionary<NameOverheadOptions, Checkbox> checkboxDict = new();
+
+        private enum ButtonType
+        {
+            CheckAll,
+            UncheckAll,
+        }
+
+        public NameOverheadAssignControl(NameOverheadOption option)
+        {
+            Option = option;
+
+            CanMove = true;
+
+            _hotkeyBox = new HotkeyBox();
+            _hotkeyBox.HotkeyChanged += BoxOnHotkeyChanged;
+            _hotkeyBox.HotkeyCancelled += BoxOnHotkeyCancelled;
+
+
+            Add(_hotkeyBox);
+
+            Add
+            (
+                new NiceButton
+                (
+                    0, _hotkeyBox.Height + 3, 170, 25,
+                    ButtonAction.Activate, "Uncheck all", 0, TEXT_ALIGN_TYPE.TS_LEFT
+                ) { ButtonParameter = (int)ButtonType.UncheckAll, IsSelectable = false }
+            );
+
+            Add
+            (
+                new NiceButton
+                (
+                    150, _hotkeyBox.Height + 3, 170, 25,
+                    ButtonAction.Activate, "Check all", 0, TEXT_ALIGN_TYPE.TS_LEFT
+                ) { ButtonParameter = (int)ButtonType.CheckAll, IsSelectable = false }
+            );
+
+            SetupOptionCheckboxes();
+
+            UpdateCheckboxesByCurrentOptionFlags();
+            UpdateValueInHotkeyBox();
+        }
+
+        private void SetupOptionCheckboxes()
+        {
+            var i = 0;
+            AddCheckbox("Containers", NameOverheadOptions.Containers, 0, 60 + 20 * i++);
+            AddCheckbox("Gold", NameOverheadOptions.Gold, 0, 60 + 20 * i++);
+            AddCheckbox("Stackable", NameOverheadOptions.Stackable, 0, 60 + 20 * i++);
+            AddCheckbox("Other items", NameOverheadOptions.Other, 0, 60 + 20 * i++);
+
+            AddCheckbox("Monster corpses", NameOverheadOptions.MonsterCorpses, 0, 60 + 20 * i++);
+            AddCheckbox("Humanoid corpses", NameOverheadOptions.HumanoidCorpses, 0, 60 + 20 * i++);
+            AddCheckbox("Own corpses", NameOverheadOptions.OwnCorpses, 0, 60 + 20 * i++);
+            // Items
+            // Containers = 1 << 0,
+            // Gold = 1 << 1,
+            // Stackable = 1 << 2,
+            // Other = 1 << 3,
+            //
+            // // Corpses
+            // MonsterCorpses = 1 << 4,
+            // HumanoidCorpses = 1 << 5,
+            // OwnCorpses = 1 << 6,
+            //
+            // // Mobiles (type)
+            // Humanoid = 1 << 7,
+            // Monster = 1 << 8,
+            // OwnFollowers = 1 << 9,
+            //
+            // // Mobiles (notoriety)
+            // Innocent = 1 << 10,
+            // Ally = 1 << 11,
+            // Gray = 1 << 12,
+            // Criminal = 1 << 13,
+            // Enemy = 1 << 14,
+            // Murderer = 1 << 15,
+            // Invulnerable = 1 << 16,
+        }
+
+        private void AddCheckbox(string checkboxName, NameOverheadOptions optionFlag, int x, int y)
+        {
+            var checkbox = new Checkbox
+            (
+                0x00D2, 0x00D3, checkboxName, 0xFF,
+                0xFFFF
+            )
+            {
+                IsChecked = true,
+                X = x,
+                Y = y
+            };
+
+            checkbox.ValueChanged += (sender, args) =>
+            {
+                var isChecked = ((Checkbox)sender).IsChecked;
+
+                if (isChecked)
+                    Option.NameOverheadOptionFlags |= (int)optionFlag;
+                else
+                    Option.NameOverheadOptionFlags &= ~(int)optionFlag;
+            };
+
+            checkboxDict.Add(optionFlag, checkbox);
+
+            Add(checkbox);
+        }
+
+        public NameOverheadOption Option { get; }
+
+        private void UpdateValueInHotkeyBox()
+        {
+            if (Option == null || _hotkeyBox == null)
+            {
+                return;
+            }
+
+            if (Option.Key != SDL.SDL_Keycode.SDLK_UNKNOWN)
+            {
+                SDL.SDL_Keymod mod = SDL.SDL_Keymod.KMOD_NONE;
+
+                if (Option.Alt)
+                {
+                    mod |= SDL.SDL_Keymod.KMOD_ALT;
+                }
+
+                if (Option.Shift)
+                {
+                    mod |= SDL.SDL_Keymod.KMOD_SHIFT;
+                }
+
+                if (Option.Ctrl)
+                {
+                    mod |= SDL.SDL_Keymod.KMOD_CTRL;
+                }
+
+                _hotkeyBox.SetKey(Option.Key, mod);
+            }
+        }
+
+        private void BoxOnHotkeyChanged(object sender, EventArgs e)
+        {
+            bool shift = (_hotkeyBox.Mod & SDL.SDL_Keymod.KMOD_SHIFT) != SDL.SDL_Keymod.KMOD_NONE;
+            bool alt = (_hotkeyBox.Mod & SDL.SDL_Keymod.KMOD_ALT) != SDL.SDL_Keymod.KMOD_NONE;
+            bool ctrl = (_hotkeyBox.Mod & SDL.SDL_Keymod.KMOD_CTRL) != SDL.SDL_Keymod.KMOD_NONE;
+
+            if (_hotkeyBox.Key == SDL.SDL_Keycode.SDLK_UNKNOWN)
+                return;
+
+            NameOverheadOption option = NameOverHeadManager.Options.FirstOrDefault(o => o.Key == _hotkeyBox.Key && o.Alt == alt && o.Ctrl == ctrl && o.Shift == shift);
+
+            if (option == null)
+            {
+                Option.Key = _hotkeyBox.Key;
+                Option.Shift = shift;
+                Option.Alt = alt;
+                Option.Ctrl = ctrl;
+
+                return;
+            }
+
+            if (Option == option)
+                return;
+
+            UpdateValueInHotkeyBox();
+            UIManager.Add(new MessageBoxGump(250, 150, string.Format(ResGumps.ThisKeyCombinationAlreadyExists, option.Name), null));
+        }
+
+        private void BoxOnHotkeyCancelled(object sender, EventArgs e)
+        {
+            Option.Alt = Option.Ctrl = Option.Shift = false;
+            Option.Key = SDL.SDL_Keycode.SDLK_UNKNOWN;
+        }
+
+        public override void OnButtonClick(int buttonID)
+        {
+            switch ((ButtonType)buttonID)
+            {
+                case ButtonType.CheckAll: break;
+                case ButtonType.UncheckAll: break;
+            }
+        }
+
+        private void UpdateCheckboxesByCurrentOptionFlags()
+        {
+            foreach (var kvp in checkboxDict)
+            {
+                var flag = kvp.Key;
+                var checkbox = kvp.Value;
+
+                checkbox.IsChecked = ((NameOverheadOptions)Option.NameOverheadOptionFlags).HasFlag(flag);
+            }
+        }
+    }
+}

--- a/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -103,7 +103,7 @@ namespace ClassicUO.Game.UI.Gumps
                     color: 0xFFFF
                 )
                 {
-                    Y = 10 + 20 * index,
+                    Y = 20 * index,
                     IsChecked = NameOverHeadManager.LastActiveNameOverheadOption == option.Name,
                 }
             );

--- a/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -77,15 +77,16 @@ namespace ClassicUO.Game.UI.Gumps
             );
 
             int biggestWidth = 100;
-            for (int i = 0; i < NameOverHeadManager.Options.Count; i++)
+            var options = NameOverHeadManager.GetAllOptions();
+            for (int i = 0; i < options.Count; i++)
             {
-                biggestWidth = Math.Max(biggestWidth, AddOverheadOptionButton(NameOverHeadManager.Options[i], i).Width);
+                biggestWidth = Math.Max(biggestWidth, AddOverheadOptionButton(options[i], i).Width);
             }
 
             // alpha.Width = Math.Max(mobilesCorpses.Width, Math.Max(items.Width, Math.Max(all.Width, mobiles.Width)));
             // alpha.Height = all.Height + mobiles.Height + items.Height + mobilesCorpses.Height;
             alpha.Width = biggestWidth;
-            alpha.Height = Math.Max(30, NameOverHeadManager.Options.Count * 20);
+            alpha.Height = Math.Max(30, options.Count * 20);
 
             Width = alpha.Width;
             Height = alpha.Height;
@@ -113,6 +114,7 @@ namespace ClassicUO.Game.UI.Gumps
                 if (button.IsChecked)
                 {
                     NameOverHeadManager.ActiveOverheadOptions = (NameOverheadOptions)option.NameOverheadOptionFlags;
+                    NameOverHeadManager.LastActiveNameOverheadOption = option.Name;
                 }
             };
 

--- a/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -66,7 +66,6 @@ namespace ClassicUO.Game.UI.Gumps
 
             LayerOrder = UILayer.Over;
 
-            RadioButton all, mobiles, items, mobilesCorpses;
             AlphaBlendControl alpha;
 
             Add
@@ -77,107 +76,47 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             );
 
+            int biggestWidth = 100;
+            for (int i = 0; i < NameOverHeadManager.Options.Count; i++)
+            {
+                biggestWidth = Math.Max(biggestWidth, AddOverheadOptionButton(NameOverHeadManager.Options[i], i).Width);
+            }
 
-            Add
-            (
-                all = new RadioButton
-                (
-                    0,
-                    0x00D0,
-                    0x00D1,
-                    ResGumps.All,
-                    color: 0xFFFF
-                )
-                {
-                    IsChecked = NameOverHeadManager.TypeAllowed == NameOverheadTypeAllowed.All
-                }
-            );
-
-            Add
-            (
-                mobiles = new RadioButton
-                (
-                    0,
-                    0x00D0,
-                    0x00D1,
-                    ResGumps.MobilesOnly,
-                    color: 0xFFFF
-                )
-                {
-                    Y = all.Y + all.Height,
-                    IsChecked = NameOverHeadManager.TypeAllowed == NameOverheadTypeAllowed.Mobiles
-                }
-            );
-
-            Add
-            (
-                items = new RadioButton
-                (
-                    0,
-                    0x00D0,
-                    0x00D1,
-                    ResGumps.ItemsOnly,
-                    color: 0xFFFF
-                )
-                {
-                    Y = mobiles.Y + mobiles.Height,
-                    IsChecked = NameOverHeadManager.TypeAllowed == NameOverheadTypeAllowed.Items
-                }
-            );
-
-            Add
-            (
-                mobilesCorpses = new RadioButton
-                (
-                    0,
-                    0x00D0,
-                    0x00D1,
-                    ResGumps.MobilesAndCorpsesOnly,
-                    color: 0xFFFF
-                )
-                {
-                    Y = items.Y + items.Height,
-                    IsChecked = NameOverHeadManager.TypeAllowed == NameOverheadTypeAllowed.MobilesCorpses
-                }
-            );
-
-            alpha.Width = Math.Max(mobilesCorpses.Width, Math.Max(items.Width, Math.Max(all.Width, mobiles.Width)));
-            alpha.Height = all.Height + mobiles.Height + items.Height + mobilesCorpses.Height;
+            // alpha.Width = Math.Max(mobilesCorpses.Width, Math.Max(items.Width, Math.Max(all.Width, mobiles.Width)));
+            // alpha.Height = all.Height + mobiles.Height + items.Height + mobilesCorpses.Height;
+            alpha.Width = biggestWidth;
+            alpha.Height = Math.Max(30, NameOverHeadManager.Options.Count * 20);
 
             Width = alpha.Width;
             Height = alpha.Height;
+        }
 
-            all.ValueChanged += (sender, e) =>
-            {
-                if (all.IsChecked)
+        private RadioButton AddOverheadOptionButton(NameOverheadOption option, int index)
+        {
+            RadioButton button;
+
+            Add
+            (
+                button = new RadioButton
+                (
+                    0, 0x00D0, 0x00D1, option.Name,
+                    color: 0xFFFF
+                )
                 {
-                    NameOverHeadManager.TypeAllowed = NameOverheadTypeAllowed.All;
+                    Y = 10 + 20 * index,
+                    IsChecked = NameOverHeadManager.LastActiveNameOverheadOption == option.Name,
+                }
+            );
+
+            button.ValueChanged += (sender, e) =>
+            {
+                if (button.IsChecked)
+                {
+                    NameOverHeadManager.ActiveOverheadOptions = (NameOverheadOptions)option.NameOverheadOptionFlags;
                 }
             };
 
-            mobiles.ValueChanged += (sender, e) =>
-            {
-                if (mobiles.IsChecked)
-                {
-                    NameOverHeadManager.TypeAllowed = NameOverheadTypeAllowed.Mobiles;
-                }
-            };
-
-            items.ValueChanged += (sender, e) =>
-            {
-                if (items.IsChecked)
-                {
-                    NameOverHeadManager.TypeAllowed = NameOverheadTypeAllowed.Items;
-                }
-            };
-
-            mobilesCorpses.ValueChanged += (sender, e) =>
-            {
-                if (mobilesCorpses.IsChecked)
-                {
-                    NameOverHeadManager.TypeAllowed = NameOverheadTypeAllowed.MobilesCorpses;
-                }
-            };
+            return button;
         }
 
 

--- a/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -45,7 +45,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override GumpType GumpType => GumpType.NameOverHeadHandler;
 
-        private static List<Control> _overheadButtons = new();
+        private static readonly List<RadioButton> _overheadButtons = new();
         private static Control _alpha;
 
         public NameOverHeadHandlerGump() : base(0, 0)
@@ -80,13 +80,12 @@ namespace ClassicUO.Game.UI.Gumps
             DrawChoiceButtons();
         }
 
-
         public void UpdateCheckboxes()
         {
             foreach (var button in _overheadButtons)
-                Remove(button);
-
-            DrawChoiceButtons();
+            {
+                button.IsChecked = NameOverHeadManager.LastActiveNameOverheadOption == button.Text;
+            }
         }
 
         protected override void OnDragEnd(int x, int y)
@@ -96,6 +95,14 @@ namespace ClassicUO.Game.UI.Gumps
             SetInScreen();
 
             base.OnDragEnd(x, y);
+        }
+
+        public void RedrawOverheadOptions()
+        {
+            foreach (var button in _overheadButtons)
+                Remove(button);
+
+            DrawChoiceButtons();
         }
 
         private void DrawChoiceButtons()

--- a/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -31,6 +31,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Resources;
@@ -44,6 +45,8 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override GumpType GumpType => GumpType.NameOverHeadHandler;
 
+        private static List<Control> _overheadButtons = new();
+        private static Control _alpha;
 
         public NameOverHeadHandlerGump() : base(0, 0)
         {
@@ -66,30 +69,50 @@ namespace ClassicUO.Game.UI.Gumps
 
             LayerOrder = UILayer.Over;
 
-            AlphaBlendControl alpha;
-
             Add
             (
-                alpha = new AlphaBlendControl(0.7f)
+                _alpha = new AlphaBlendControl(0.7f)
                 {
                     Hue = 34
                 }
             );
 
+            DrawChoiceButtons();
+        }
+
+
+        public void UpdateCheckboxes()
+        {
+            foreach (var button in _overheadButtons)
+                Remove(button);
+
+            DrawChoiceButtons();
+        }
+
+        protected override void OnDragEnd(int x, int y)
+        {
+            LastPosition = new Point(ScreenCoordinateX, ScreenCoordinateY);
+
+            SetInScreen();
+
+            base.OnDragEnd(x, y);
+        }
+
+        private void DrawChoiceButtons()
+        {
             int biggestWidth = 100;
             var options = NameOverHeadManager.GetAllOptions();
+
             for (int i = 0; i < options.Count; i++)
             {
                 biggestWidth = Math.Max(biggestWidth, AddOverheadOptionButton(options[i], i).Width);
             }
 
-            // alpha.Width = Math.Max(mobilesCorpses.Width, Math.Max(items.Width, Math.Max(all.Width, mobiles.Width)));
-            // alpha.Height = all.Height + mobiles.Height + items.Height + mobilesCorpses.Height;
-            alpha.Width = biggestWidth;
-            alpha.Height = Math.Max(30, options.Count * 20);
+            _alpha.Width = biggestWidth;
+            _alpha.Height = Math.Max(30, options.Count * 20);
 
-            Width = alpha.Width;
-            Height = alpha.Height;
+            Width = _alpha.Width;
+            Height = _alpha.Height;
         }
 
         private RadioButton AddOverheadOptionButton(NameOverheadOption option, int index)
@@ -113,22 +136,13 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 if (button.IsChecked)
                 {
-                    NameOverHeadManager.ActiveOverheadOptions = (NameOverheadOptions)option.NameOverheadOptionFlags;
-                    NameOverHeadManager.LastActiveNameOverheadOption = option.Name;
+                    NameOverHeadManager.SetActiveOption(option);
                 }
             };
 
+            _overheadButtons.Add(button);
+
             return button;
-        }
-
-
-        protected override void OnDragEnd(int x, int y)
-        {
-            LastPosition = new Point(ScreenCoordinateX, ScreenCoordinateY);
-
-            SetInScreen();
-
-            base.OnDragEnd(x, y);
         }
     }
 }

--- a/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -45,8 +45,9 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override GumpType GumpType => GumpType.NameOverHeadHandler;
 
-        private static readonly List<RadioButton> _overheadButtons = new();
-        private static Control _alpha;
+        private readonly List<RadioButton> _overheadButtons = new();
+        private Control _alpha;
+        private readonly Checkbox _keepOpenCheckbox;
 
         public NameOverHeadHandlerGump() : base(0, 0)
         {
@@ -77,6 +78,20 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             );
 
+            Add
+            (
+                _keepOpenCheckbox = new Checkbox
+                (
+                    0x00D2, 0x00D3, "Keep open", 0xFF,
+                    0xFFFF
+                )
+                {
+                    IsChecked = NameOverHeadManager.IsPermaToggled
+                }
+            );
+
+            _keepOpenCheckbox.ValueChanged += (sender, args) => NameOverHeadManager.SetOverheadToggled(_keepOpenCheckbox.IsChecked);
+
             DrawChoiceButtons();
         }
 
@@ -86,6 +101,8 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 button.IsChecked = NameOverHeadManager.LastActiveNameOverheadOption == button.Text;
             }
+
+            _keepOpenCheckbox.IsChecked = NameOverHeadManager.IsPermaToggled;
         }
 
         protected override void OnDragEnd(int x, int y)
@@ -116,7 +133,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             _alpha.Width = biggestWidth;
-            _alpha.Height = Math.Max(30, options.Count * 20);
+            _alpha.Height = Math.Max(30, options.Count * 20) + 22;
 
             Width = _alpha.Width;
             Height = _alpha.Height;
@@ -134,7 +151,7 @@ namespace ClassicUO.Game.UI.Gumps
                     color: 0xFFFF
                 )
                 {
-                    Y = 20 * index,
+                    Y = 20 * index + 22,
                     IsChecked = NameOverHeadManager.LastActiveNameOverheadOption == option.Name,
                 }
             );

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -145,6 +145,9 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _restorezoomCheckbox, _zoomCheckbox;
         private InputField _rows, _columns, _highlightAmount, _abbreviatedAmount;
 
+        // name overhead
+        private NameOverheadAssignControl _nameOverheadControl;
+
         // speech
         private Checkbox _scaleSpeechDelay, _saveJournalCheckBox;
         private Checkbox _showHouseContent;
@@ -365,6 +368,22 @@ namespace ClassicUO.Game.UI.Gumps
                     ButtonParameter = (int)Buttons.OpenIgnoreList
                 }
             );
+            
+            Add
+            (
+                new NiceButton
+                (
+                    10,
+                    10 + 30 * i++,
+                    140,
+                    25,
+                    ButtonAction.SwitchPage,
+                    "Name Overhead Options"
+                )
+                {
+                    ButtonParameter = 13
+                }
+            );
 
             Add
             (
@@ -441,6 +460,7 @@ namespace ClassicUO.Game.UI.Gumps
             BuildInfoBar();
             BuildContainers();
             BuildExperimental();
+            BuildNameOverhead();
 
             ChangePage(1);
         }
@@ -3378,6 +3398,239 @@ namespace ClassicUO.Game.UI.Gumps
             Add(rightArea, PAGE);
         }
 
+        private void BuildNameOverhead()
+        {
+            const int PAGE = 13;
+
+            ScrollArea rightArea = new ScrollArea
+            (
+                190,
+                52 + 25 + 4,
+                150,
+                360,
+                true
+            );
+
+            Add
+            (
+                new Line
+                (
+                    190,
+                    52 + 25 + 2,
+                    150,
+                    1,
+                    Color.Gray.PackedValue
+                ),
+                PAGE
+            );
+
+            Add
+            (
+                new Line
+                (
+                    191 + 150,
+                    21,
+                    1,
+                    418,
+                    Color.Gray.PackedValue
+                ),
+                PAGE
+            );
+
+            NiceButton addButton = new NiceButton
+            (
+                190,
+                20,
+                130,
+                20,
+                ButtonAction.Activate,
+                "New entry"
+            )
+            { IsSelectable = false, ButtonParameter = (int)Buttons.NewNameOverheadEntry };
+
+            Add(addButton, PAGE);
+
+            NiceButton delButton = new NiceButton
+            (
+                190,
+                52,
+                130,
+                20,
+                ButtonAction.Activate,
+                "Delete entry"
+            )
+            { IsSelectable = false, ButtonParameter = (int)Buttons.DeleteOverheadEntry };
+
+            Add(delButton, PAGE);
+
+
+            int startX = 5;
+            int startY = 5;
+
+            DataBox databox = new DataBox(startX, startY, 1, 1);
+            databox.WantUpdateSize = true;
+            rightArea.Add(databox);
+
+
+            addButton.MouseUp += (sender, e) =>
+            {
+                EntryDialog dialog = new
+                (
+                    250,
+                    150,
+                    "Name overhead entry name",
+                    name =>
+                    {
+                        if (string.IsNullOrWhiteSpace(name))
+                        {
+                            return;
+                        }
+
+                        if (NameOverHeadManager.FindOption(name) != null)
+                        {
+                            return;
+                        }
+
+                        NiceButton nb;
+
+                        databox.Add
+                        (
+                            nb = new NiceButton
+                            (
+                                0,
+                                0,
+                                130,
+                                25,
+                                ButtonAction.Activate,
+                                name
+                            )
+                            {
+                                ButtonParameter = (int)Buttons.Last + 1 + rightArea.Children.Count
+                            }
+                        );
+
+                        databox.ReArrangeChildren();
+
+                        nb.IsSelected = true;
+
+                        _nameOverheadControl?.Dispose();
+
+                        var option = new NameOverheadOption(name);
+                        NameOverHeadManager.Options.Add(option);
+
+                        _nameOverheadControl = new NameOverheadAssignControl(option)
+                        {
+                            X = 400,
+                            Y = 20
+                        };
+
+                        Add(_nameOverheadControl, PAGE);
+
+                        nb.MouseUp += (sss, eee) =>
+                        {
+                            _nameOverheadControl?.Dispose();
+
+                            _nameOverheadControl = new NameOverheadAssignControl(option)
+                            {
+                                X = 400,
+                                Y = 20
+                            };
+
+                            Add(_nameOverheadControl, PAGE);
+                        };
+                    }
+                )
+                {
+                    CanCloseWithRightClick = true
+                };
+
+                UIManager.Add(dialog);
+            };
+
+            delButton.MouseUp += (ss, ee) =>
+            {
+                NiceButton nb = databox.FindControls<NiceButton>().SingleOrDefault(a => a.IsSelected);
+
+                if (nb != null)
+                {
+                    QuestionGump dialog = new QuestionGump
+                    (
+                        ResGumps.MacroDeleteConfirmation,
+                        b =>
+                        {
+                            if (!b)
+                            {
+                                return;
+                            }
+
+                            if (_nameOverheadControl != null)
+                            {
+                                NameOverHeadManager.Options.Remove(_nameOverheadControl.Option);
+
+                                _nameOverheadControl.Dispose();
+                            }
+
+                            nb.Dispose();
+                            databox.ReArrangeChildren();
+                        }
+                    );
+
+                    UIManager.Add(dialog);
+                }
+            };
+
+
+            foreach (var option in NameOverHeadManager.Options)
+            {
+                NiceButton nb;
+
+                databox.Add
+                (
+                    nb = new NiceButton
+                    (
+                        0,
+                        0,
+                        130,
+                        25,
+                        ButtonAction.Activate,
+                        option.Name
+                    )
+                    {
+                        ButtonParameter = (int)Buttons.Last + 1 + rightArea.Children.Count,
+                        Tag = option
+                    }
+                );
+
+                nb.IsSelected = true;
+
+                nb.MouseUp += (sss, eee) =>
+                {
+                    NiceButton mupNiceButton = (NiceButton)sss;
+
+                    var option = mupNiceButton.Tag as NameOverheadOption;
+
+                    if (option == null)
+                    {
+                        return;
+                    }
+
+                    _nameOverheadControl?.Dispose();
+
+                    _nameOverheadControl = new NameOverheadAssignControl(option)
+                    {
+                        X = 400,
+                        Y = 20
+                    };
+
+                    Add(_nameOverheadControl, PAGE);
+                };
+            }
+
+            databox.ReArrangeChildren();
+
+            Add(rightArea, PAGE);
+        }
+
 
         public override void OnButtonClick(int buttonID)
         {
@@ -4450,7 +4703,10 @@ namespace ClassicUO.Game.UI.Gumps
             NewMacro,
             DeleteMacro,
 
-            Last = DeleteMacro
+            NewNameOverheadEntry,
+            DeleteOverheadEntry,
+
+            Last = DeleteMacro,
         }
 
 

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -3516,7 +3516,7 @@ namespace ClassicUO.Game.UI.Gumps
                         _nameOverheadControl?.Dispose();
 
                         var option = new NameOverheadOption(name);
-                        NameOverHeadManager.Options.Add(option);
+                        NameOverHeadManager.AddOption(option);
 
                         _nameOverheadControl = new NameOverheadAssignControl(option)
                         {
@@ -3565,7 +3565,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                             if (_nameOverheadControl != null)
                             {
-                                NameOverHeadManager.Options.Remove(_nameOverheadControl.Option);
+                                NameOverHeadManager.RemoveOption(_nameOverheadControl.Option);
 
                                 _nameOverheadControl.Dispose();
                             }
@@ -3580,7 +3580,7 @@ namespace ClassicUO.Game.UI.Gumps
             };
 
 
-            foreach (var option in NameOverHeadManager.Options)
+            foreach (var option in NameOverHeadManager.GetAllOptions())
             {
                 NiceButton nb;
 


### PR DESCRIPTION
This PR is meant to give players the ability to fine tune how they use the name overhead stuff by giving them more detailed options.

**THIS PR IS STILL A DRAFT because implementation is not finished and it's not fully tested, but please feel free to give feedback regardless!**

### Main Features

* Fine granular options as to which items/mobiles to display name plates for (✅ implemented)
* Detailed options page to configure those options (✅ implemented)
* Ability to switch through configurations by assigning each one a hotkey (✅ implemented)

## Planned additional features

* Switch between configs by pressing shift+ctrl+arrow up/down
* Add button on the overhead handler gump to allow it to stay up (similar to the macro toggle)
* Add option to enable health bar below name plate
* Add option to have background fill act as health bar
* Add option to show health % in the name plate
* Add option to allow players to customize min/max name plate width

### Options

The available options are currently as follows:

![image](https://user-images.githubusercontent.com/59250627/162633008-897eef30-00e9-4a91-a28b-535e166c5748.png)

### How will this change affect players (if they don't like it?)

When the PR is accepted, a default config will be created that mirrors the current functionality and options exactly. This way, players who don't like the new options are not forced to adapt and can simply use the name overhead functionality as they always have.

### Demo

![overhead_options_settings_demo](https://user-images.githubusercontent.com/59250627/162633043-88ca5d49-b370-49d9-a76a-06070ce327ab.gif)
