### PR TITLE
Fix "Use old animations" flag

### DIFF
--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -1032,7 +1032,8 @@ namespace ClassicUO.IO.Resources
 
                 if (DataIndex[i].FileIndex == 1)
                 {
-                    replace = (World.ClientLockedFeatures.Flags & LockedFeatureFlags.LordBlackthornsRevenge) != 0;
+                    // TODO: Find out what client version introduced this negative feature flag change.
+                    replace = (World.ClientLockedFeatures.Flags & (LockedFeatureFlags.TheSecondAge | LockedFeatureFlags.Renaissance) == 0;
                 }
                 else if (DataIndex[i].FileIndex == 2)
                 {

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -1033,7 +1033,7 @@ namespace ClassicUO.IO.Resources
                 if (DataIndex[i].FileIndex == 1)
                 {
                     // TODO: Find out what client version introduced this negative feature flag change.
-                    replace = (World.ClientLockedFeatures.Flags & (LockedFeatureFlags.TheSecondAge | LockedFeatureFlags.Renaissance) == 0;
+                    replace = (World.ClientLockedFeatures.Flags & (LockedFeatureFlags.TheSecondAge | LockedFeatureFlags.Renaissance)) == 0;
                 }
                 else if (DataIndex[i].FileIndex == 2)
                 {


### PR DESCRIPTION
On an old server I ran, I had a player command to enable old animations. Here is a snippet:

```cs
bool turnon = e.Arguments[0].ToLower() == "on";
acct.SFO = turnon ? (FeatureFlags)0x03 : (FeatureFlags)0x0;
m.SendMessage( "Old style client packets has been turned {0}.", turnon ? "ON" : "OFF" );
m.Send( new MobileIncoming( m, m ) );
m.Send( SupportedFeatures.Instantiate( m.NetState ) );
m.Send( new MobileUpdate( m ) );
m.Send( new MobileAttributes( m ) );
```

Note: RunUO removes the T2A, Ren, and UOTD flags for AOS+ era causing the same effect. The UOTD/LBR flags do not need to be enabled for this as far as I remember.