### PR TITLE
Use ISO-8859-1 instead of ASCII

### DIFF
--- a/src/Utility/StringHelper.cs
+++ b/src/Utility/StringHelper.cs
@@ -52,7 +52,7 @@ namespace ClassicUO.Utility
                 {
                     //Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
                     //_cp1252Encoding = Encoding.GetEncoding(1252);
-                    _cp1252Encoding = Encoding.ASCII;
+                    _cp1252Encoding = Encoding.GetEncoding("iso-8859-1");
                 }
                 return _cp1252Encoding;
             }


### PR DESCRIPTION
Since proper CP-1252 support is still pending, this is probably a good compromise. I don't know why I didn't think of this sooner. ISO-8859-1 is only missing 27 or so characters that CP-1252 has, which is a big improvement compared to the ~96 characters ASCII is missing.