### PR TITLE
Fixes sparse buffer filling by using an exclusive array pool

### DIFF
--- a/src/GameController.cs
+++ b/src/GameController.cs
@@ -47,6 +47,7 @@ using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
+using ClassicUO.Utility.Collections;
 using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -128,7 +129,7 @@ namespace ClassicUO
             _hueSamplers[2] = new Texture2D(GraphicsDevice, LIGHTS_TEXTURE_WIDTH, LIGHTS_TEXTURE_HEIGHT);
 
 
-            uint[] buffer = System.Buffers.ArrayPool<uint>.Shared.Rent(Math.Max(LIGHTS_TEXTURE_WIDTH * LIGHTS_TEXTURE_HEIGHT, TEXTURE_WIDTH * TEXTURE_HEIGHT * 2));
+            uint[] buffer = CleanArrayPool<uint>.Shared.Rent(Math.Max(LIGHTS_TEXTURE_WIDTH * LIGHTS_TEXTURE_HEIGHT, TEXTURE_WIDTH * TEXTURE_HEIGHT * 2));
 
             fixed (uint* ptr = buffer)
             {
@@ -140,7 +141,7 @@ namespace ClassicUO
                 _hueSamplers[2].SetDataPointerEXT(0, null, (IntPtr)ptr, LIGHTS_TEXTURE_WIDTH * LIGHTS_TEXTURE_HEIGHT * sizeof(uint));
             }      
         
-            System.Buffers.ArrayPool<uint>.Shared.Return(buffer, true);
+            CleanArrayPool<uint>.Shared.Return(buffer);
 
             GraphicsDevice.Textures[1] = _hueSamplers[0];
             GraphicsDevice.Textures[2] = _hueSamplers[1];

--- a/src/IO/Resources/FontsLoader.cs
+++ b/src/IO/Resources/FontsLoader.cs
@@ -31,12 +31,12 @@
 #endregion
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
@@ -675,7 +675,7 @@ namespace ClassicUO.IO.Resources
             }
 
             int blocksize = height * width;
-            uint[] pData = System.Buffers.ArrayPool<uint>.Shared.Rent(blocksize);
+            uint[] pData = CleanArrayPool<uint>.Shared.Rent(blocksize);
 
             try
             {
@@ -818,7 +818,7 @@ namespace ClassicUO.IO.Resources
             }
             finally
             {
-                System.Buffers.ArrayPool<uint>.Shared.Return(pData, true);
+                CleanArrayPool<uint>.Shared.Return(pData);
             }
         }
 
@@ -1824,7 +1824,7 @@ namespace ClassicUO.IO.Resources
 
             height += _htmlStatus.Margins.Y + _htmlStatus.Margins.Height + 4;
             int blocksize = height * width;
-            uint[] pData = System.Buffers.ArrayPool<uint>.Shared.Rent(blocksize);
+            uint[] pData = CleanArrayPool<uint>.Shared.Rent(blocksize);
 
             try
             {
@@ -2364,7 +2364,7 @@ namespace ClassicUO.IO.Resources
             }
             finally
             {
-                System.Buffers.ArrayPool<uint>.Shared.Return(pData, true);
+                CleanArrayPool<uint>.Shared.Return(pData);
             }
         }
 

--- a/src/IO/Resources/GumpsLoader.cs
+++ b/src/IO/Resources/GumpsLoader.cs
@@ -37,6 +37,7 @@ using System.Threading.Tasks;
 using ClassicUO.Game;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
+using ClassicUO.Utility.Collections;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -187,7 +188,7 @@ namespace ClassicUO.IO.Resources
 
             uint[] buffer = null;
 
-            Span<uint> pixels = entry.Width * entry.Height <= 1024 ? stackalloc uint[1024] : (buffer = System.Buffers.ArrayPool<uint>.Shared.Rent(entry.Width * entry.Height));
+            Span<uint> pixels = entry.Width * entry.Height <= 1024 ? stackalloc uint[1024] : (buffer = CleanArrayPool<uint>.Shared.Rent(entry.Width * entry.Height));
 
             try
             {
@@ -243,7 +244,7 @@ namespace ClassicUO.IO.Resources
             {
                 if (buffer != null)
                 {
-                    System.Buffers.ArrayPool<uint>.Shared.Return(buffer, true);
+                    CleanArrayPool<uint>.Shared.Return(buffer);
                 }             
             }
         }

--- a/src/IO/Resources/LightsLoader.cs
+++ b/src/IO/Resources/LightsLoader.cs
@@ -35,6 +35,7 @@ using System.Threading.Tasks;
 using ClassicUO.Game;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
+using ClassicUO.Utility.Collections;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -110,7 +111,7 @@ namespace ClassicUO.IO.Resources
 
             uint[] buffer = null;
           
-            Span<uint> pixels = entry.Width * entry.Height <= 1024 ? stackalloc uint[1024] : (buffer = System.Buffers.ArrayPool<uint>.Shared.Rent(entry.Width * entry.Height));
+            Span<uint> pixels = entry.Width * entry.Height <= 1024 ? stackalloc uint[1024] : (buffer = CleanArrayPool<uint>.Shared.Rent(entry.Width * entry.Height));
 
             try
             {
@@ -146,7 +147,7 @@ namespace ClassicUO.IO.Resources
             {
                 if (buffer != null)
                 {
-                    System.Buffers.ArrayPool<uint>.Shared.Return(buffer, true);
+                    CleanArrayPool<uint>.Shared.Return(buffer);
                 }             
             }
 

--- a/src/IO/Resources/MultiMapLoader.cs
+++ b/src/IO/Resources/MultiMapLoader.cs
@@ -37,6 +37,7 @@ using System.Threading.Tasks;
 using ClassicUO.Game;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
+using ClassicUO.Utility.Collections;
 using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -278,7 +279,7 @@ namespace ClassicUO.IO.Resources
             int pwidth = endX - startX;
             int pheight = endY - startY;
 
-            uint[] map = System.Buffers.ArrayPool<uint>.Shared.Rent(pwidth * pheight);
+            uint[] map = CleanArrayPool<uint>.Shared.Rent(pwidth * pheight);
             Texture2D texture = new Texture2D(Client.Game.GraphicsDevice, pwidth, pheight, false, SurfaceFormat.Color);
 
             try
@@ -311,7 +312,7 @@ namespace ClassicUO.IO.Resources
             }
             finally
             {
-                System.Buffers.ArrayPool<uint>.Shared.Return(map, true);
+                CleanArrayPool<uint>.Shared.Return(map);
             }
 
 

--- a/src/Utility/Collections/CleanArrayPool.cs
+++ b/src/Utility/Collections/CleanArrayPool.cs
@@ -1,0 +1,19 @@
+using System.Buffers;
+
+namespace ClassicUO.Utility.Collections
+{
+    public class CleanArrayPool<T>
+    {
+        private static CleanArrayPool<T> _sharedArrayPool = new CleanArrayPool<T>();
+        public static CleanArrayPool<T> Shared => _sharedArrayPool;
+
+        private ArrayPool<T> _pool = ArrayPool<T>.Create(0x100000, 8);
+
+        public T[] Rent(int minimumLength) => _pool.Rent(minimumLength);
+
+        public void Return(T[] array)
+        {
+            _pool.Return(array, true);
+        }
+    }
+}

--- a/src/Utility/Collections/CleanArrayPool.cs
+++ b/src/Utility/Collections/CleanArrayPool.cs
@@ -9,11 +9,16 @@ namespace ClassicUO.Utility.Collections
 
         private ArrayPool<T> _pool = ArrayPool<T>.Create(0x100000, 8);
 
-        public T[] Rent(int minimumLength) => _pool.Rent(minimumLength);
-
-        public void Return(T[] array)
+        public T[] Rent(int minimumLength)
         {
-            _pool.Return(array, true);
+            var array = _pool.Rent(minimumLength);
+#if NETCOREAPP3_1_OR_GREATER
+            Array.Clear(array, 0, minimumLength);
+#endif
+
+            return array;
         }
+
+        public void Return(T[] array) => _pool.Return(array);
     }
 }


### PR DESCRIPTION
In future versions of .NET (Core, 5/6/7+) the C# core uses `ArrayPool<T>.Shared` without clearing buffers on return. _It is not recommended that ArrayPool.Shared is used with buffers that are sparsely filled since they might be dirty when rented_.

To get around this, I created another ArrayPool that is exclusive for our use and will always be cleared on rent for .NET Core.