### PR TITLE
Fix animation body.def bodyconv.def

### DIFF
--- a/src/Game/GameObjects/Item.cs
+++ b/src/Game/GameObjects/Item.cs
@@ -702,21 +702,17 @@ namespace ClassicUO.Game.GameObjects
                     if (id < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
                     {
                         byte action = AnimationsLoader.Instance.GetDeathAction(id, UsedLayer);
-                        ushort hue = 0;
-                        bool useUOP;
+                        var frames = AnimationsLoader.Instance.GetAnimationFrames(id, action, dir, out _, out _, isCorpse : true);
 
-                        AnimationsLoader.Instance.ReplaceAnimationValues(ref id, ref action, ref hue, out useUOP, isCorpse: true);
-                        int frameCount = AnimationsLoader.Instance.LoadAnimationFrames(id, action, dir, useUOP);
-
-                        if (frameCount > 0)
+                        if (frames.Length > 0)
                         {
                             // when the animation is done, stop to animate the corpse
-                            if (frameIndex >= frameCount)
+                            if (frameIndex >= frames.Length)
                             {
-                                frameIndex = (byte)(frameCount - 1);
+                                frameIndex = (byte)(frames.Length - 1);
                             }
 
-                            AnimIndex = (byte) (frameIndex % frameCount);
+                            AnimIndex = (byte) (frameIndex % frames.Length);
                         }
                     }
 

--- a/src/Game/GameObjects/Mobile.cs
+++ b/src/Game/GameObjects/Mobile.cs
@@ -578,15 +578,11 @@ namespace ClassicUO.Game.GameObjects
 
                 if (id < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
                 {
-                    ushort hue = 0;
-                    bool useUOP;
+                    var frames = AnimationsLoader.Instance.GetAnimationFrames(id, action, dir, out _, out _);
 
-                    AnimationsLoader.Instance.ReplaceAnimationValues(ref id, ref action, ref hue, out useUOP);
-                    int frameCount = AnimationsLoader.Instance.LoadAnimationFrames(id, action, dir, useUOP);
-
-                    if (frameCount != 0)
+                    if (frames.Length != 0)
                     {
-                        int fc = frameCount;
+                        int fc = frames.Length;
 
                         int frameIndex = AnimIndex + (AnimationFromServer && !_isAnimationForwardDirection ? -1 : 1);
 
@@ -615,7 +611,7 @@ namespace ClassicUO.Game.GameObjects
                                 }
                                 else
                                 {
-                                    frameIndex = (byte)(frameCount - 1);
+                                    frameIndex = (byte)(frames.Length - 1);
                                 }
                             }
                             else
@@ -661,7 +657,7 @@ namespace ClassicUO.Game.GameObjects
                             }
                         }
 
-                        AnimIndex = (byte) (frameIndex % frameCount);
+                        AnimIndex = (byte) (frameIndex % frames.Length);
                     }
                     else if ((Serial & 0x80000000) != 0)
                     {

--- a/src/Game/GameObjects/Views/ItemView.cs
+++ b/src/Game/GameObjects/Views/ItemView.cs
@@ -302,32 +302,28 @@ namespace ClassicUO.Game.GameObjects
                 return;
             }
 
-            ushort newHue = 0;
-            bool useUOP;
-
-            AnimationsLoader.Instance.ReplaceAnimationValues(ref graphic, ref animGroup, ref newHue, out useUOP, isEquip: layer != Layer.Invalid, isCorpse: layer == Layer.Invalid);
-            int frameCount = AnimationsLoader.Instance.LoadAnimationFrames(graphic, animGroup, dir, useUOP);
+            var frames = AnimationsLoader.Instance.GetAnimationFrames(graphic, animGroup, dir, out var newHue, out _, isEquip: layer != Layer.Invalid, isCorpse: layer == Layer.Invalid);
 
             if (color == 0)
             {
                 color = newHue;
             }
 
-            if (frameCount == 0)
+            if (frames.Length == 0)
             {
                 return;
             }
 
-            int fc = frameCount;
+            int fc = frames.Length;
 
             if (fc > 0 && animIndex >= fc)
             {
                 animIndex = (byte) (fc - 1);
             }
 
-            if (animIndex < frameCount)
+            if (animIndex < frames.Length)
             {
-                ref var spriteInfo = ref AnimationsLoader.Instance.GetAnimationFrame(graphic, animGroup, dir, animIndex, useUOP);
+                ref var spriteInfo = ref frames[animIndex];
 
                 if (spriteInfo.Texture == null)
                 {
@@ -552,21 +548,18 @@ namespace ClassicUO.Game.GameObjects
                     }
 
                     byte group = AnimationsLoader.Instance.GetDeathAction(graphic, UsedLayer);
-                    ushort hue = 0;
+                    var frames = AnimationsLoader.Instance.GetAnimationFrames(graphic, group, direction, out _, out var isUOP);
 
-                    AnimationsLoader.Instance.ReplaceAnimationValues(ref graphic, ref group, ref hue, out var isUop);
-                    int fc = AnimationsLoader.Instance.LoadAnimationFrames(graphic, group, direction, isUop);
-
-                    if (fc > 0 && animIndex >= 0)
+                    if (frames.Length > 0 && animIndex >= 0)
                     {
-                        animIndex = (byte)(animIndex % fc);
+                        animIndex = (byte)(animIndex % frames.Length);
                     }
                     else if (animIndex < 0)
                     {
                         animIndex = 0;
                     }
 
-                    ref var spriteInfo = ref AnimationsLoader.Instance.GetAnimationFrame(graphic, group, direction, animIndex, isUop);
+                    ref var spriteInfo = ref frames[animIndex];
 
                     if (spriteInfo.Texture != null)
                     {
@@ -578,7 +571,7 @@ namespace ClassicUO.Game.GameObjects
                             graphic,
                             group,
                             direction,
-                            isUop,
+                            isUOP,
                             animIndex,
                             IsFlipped ? x + spriteInfo.UV.Width - SelectedObject.TranslatedMousePositionByViewport.X : SelectedObject.TranslatedMousePositionByViewport.X - x,
                             SelectedObject.TranslatedMousePositionByViewport.Y - y

--- a/src/Game/GameObjects/Views/ItemView.cs
+++ b/src/Game/GameObjects/Views/ItemView.cs
@@ -198,7 +198,6 @@ namespace ClassicUO.Game.GameObjects
 
             byte animIndex = (byte) AnimIndex;
             ushort graphic = GetGraphicForAnimation();
-            AnimationsLoader.Instance.ConvertBodyIfNeeded(ref graphic);
             byte group = AnimationsLoader.Instance.GetDeathAction(graphic, UsedLayer);
 
             bool ishuman = MathHelper.InRange(Amount, 0x0190, 0x0193) || MathHelper.InRange(Amount, 0x00B7, 0x00BA) || MathHelper.InRange(Amount, 0x025D, 0x0260) || MathHelper.InRange(Amount, 0x029A, 0x029B) || MathHelper.InRange(Amount, 0x02B6, 0x02B7) || Amount == 0x03DB || Amount == 0x03DF || Amount == 0x03E2 || Amount == 0x02E8 || Amount == 0x02E9;
@@ -520,7 +519,6 @@ namespace ClassicUO.Game.GameObjects
                     if (layer == Layer.Invalid)
                     {
                         graphic = GetGraphicForAnimation();
-                        AnimationsLoader.Instance.ConvertBodyIfNeeded(ref graphic);
                     }
                     else if (ishuman)
                     {

--- a/src/Game/UI/Gumps/ShopGump.cs
+++ b/src/Game/UI/Gumps/ShopGump.cs
@@ -750,7 +750,6 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (SerialHelper.IsMobile(LocalSerial))
                 {
-                    ushort hue2 = Hue;
                     ushort graphic = Graphic;
 
                     if (graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
@@ -759,15 +758,13 @@ namespace ClassicUO.Game.UI.Gumps
                     }
 
                     byte group = GetAnimGroup(graphic);
+                    var frames = AnimationsLoader.Instance.GetAnimationFrames(graphic, group, 1, out var hue2, out _, true);
 
-                    AnimationsLoader.Instance.ReplaceAnimationValues(ref graphic, ref group, ref hue2, out var isUOP, isEquip: true);
-                    int frameCount = AnimationsLoader.Instance.LoadAnimationFrames(graphic, group, 1, false);
-
-                    if (frameCount != 0)
+                    if (frames.Length != 0)
                     {
                         hueVector = ShaderHueTranslator.GetHueVector(hue2, TileDataLoader.Instance.StaticData[Graphic].IsPartialHue, 1f);
 
-                        ref var spriteInfo = ref AnimationsLoader.Instance.GetAnimationFrame(graphic, group, 1, 0, isUOP);
+                        ref var spriteInfo = ref frames[0];
 
                         if (spriteInfo.Texture != null)
                         {

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -946,9 +946,9 @@ namespace ClassicUO.IO.Resources
         public bool PixelCheck(ushort animID, byte group, byte direction, bool uop, int frame, int x, int y)
         {
             ushort hue = 0;
-            ReplaceAnimationValues(ref animID, ref group, ref hue, out uop, forceUOP: uop);
+            ReplaceAnimationValues(ref animID, ref group, ref hue, out var isUOP, forceUOP: uop);
 
-            uint packed32 = (uint)((group | (direction << 8) | ((uop ? 0x01 : 0x00) << 16)));
+            uint packed32 = (uint)((group | (direction << 8) | ((isUOP ? 0x01 : 0x00) << 16)));
             uint packed32_2 = (uint)((animID | (frame << 16)));
             ulong packed = (packed32_2 | ((ulong)packed32 << 32));
 
@@ -1200,6 +1200,8 @@ namespace ClassicUO.IO.Resources
             {
                 return 0;
             }
+
+            ConvertBodyIfNeeded(ref id);
 
             ANIMATION_FLAGS flags = DataIndex[id].Flags;
 

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -58,7 +58,6 @@ namespace ClassicUO.IO.Resources
         [ThreadStatic] private static FrameInfo[] _frames;
         [ThreadStatic] private static byte[] _decompressedData;
 
-        private readonly Dictionary<ushort, byte> _animationSequenceReplacing = new Dictionary<ushort, byte>();
         private readonly Dictionary<ushort, Dictionary<ushort, EquipConvData>> _equipConv = new Dictionary<ushort, Dictionary<ushort, EquipConvData>>();
         private readonly UOFileMul[] _files = new UOFileMul[5];
         private readonly UOFileUop[] _filesUop = new UOFileUop[4];

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -238,15 +238,15 @@ namespace ClassicUO.IO.Resources
 
                 for (byte j = 0; j < MAX_ACTIONS; j++)
                 {
-                    if (DataIndex[i].Groups[j] == null)
-                    {
-                        DataIndex[i].Groups[j] = new AnimationGroup();
-                    }
-                    
                     if (j >= count)
                     {
                         continue;
                     }
+
+                    if (DataIndex[i].Groups[j] == null)
+                    {
+                        DataIndex[i].Groups[j] = new AnimationGroup();
+                    }    
 
                     for (byte d = 0; d < MAX_DIRECTIONS; d++)
                     {

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -1354,7 +1354,7 @@ namespace ClassicUO.IO.Resources
             }
             else
             {
-                frames = ReadMULAnimationFrames(animID, animGroup, direction, animDir);
+                frames = ReadMULAnimationFrames(animID, animGroup, direction, ref animDir);
             }
 
             if (frames.Length == 0)
@@ -1570,7 +1570,7 @@ namespace ClassicUO.IO.Resources
             return frames;
         }
 
-        private Span<FrameInfo> ReadMULAnimationFrames(ushort animID, byte animGroup, byte direction, AnimationDirection animDir)
+        private Span<FrameInfo> ReadMULAnimationFrames(ushort animID, byte animGroup, byte direction, ref AnimationDirection animDir)
         {
             UOFile file = _files[animDir.FileIndex];
             StackDataReader reader = new StackDataReader(new ReadOnlySpan<byte>((byte*)file.StartAddress.ToPointer(), (int)file.Length));

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -309,12 +309,7 @@ namespace ClassicUO.IO.Resources
                     }
                 }
             }
-
-            if (Client.Version < ClientVersion.CV_300)
-            {
-                return;
-            }
-
+        
             ProcessEquipConvDef();
             ProcessBodyDef();
             ProcessCorpseDef();
@@ -327,6 +322,11 @@ namespace ClassicUO.IO.Resources
 
         private void ProcessEquipConvDef()
         {
+            if (Client.Version < ClientVersion.CV_300)
+            {
+                return;
+            }
+
             var file = UOFileManager.GetUOFilePath("Equipconv.def");
 
             if (File.Exists(file))
@@ -374,25 +374,24 @@ namespace ClassicUO.IO.Resources
 
                         ushort color = (ushort)defReader.ReadInt();
 
-                        if (!_equipConv.TryGetValue(body, out Dictionary<ushort, EquipConvData> dict))
+                        if (!_equipConv.TryGetValue(body, out var dict))
                         {
-                            _equipConv.Add(body, new Dictionary<ushort, EquipConvData>());
-
-                            if (!_equipConv.TryGetValue(body, out dict))
-                            {
-                                continue;
-                            }
+                            _equipConv[body] = (dict = new Dictionary<ushort, EquipConvData>());
                         }
 
                         dict[graphic] = new EquipConvData(newGraphic, (ushort)gump, color);
                     }
                 }
             }
-
         }
 
         private void ProcessBodyConvDef(LockedFeatureFlags flags)
         {
+            if (Client.Version < ClientVersion.CV_300)
+            {
+                return;
+            }
+
             var file = UOFileManager.GetUOFilePath("Bodyconv.def");
 
             if (File.Exists(file))
@@ -550,6 +549,11 @@ namespace ClassicUO.IO.Resources
 
         private void ProcessBodyDef()
         {
+            if (Client.Version < ClientVersion.CV_300)
+            {
+                return;
+            }
+
             var file = UOFileManager.GetUOFilePath("Body.def");
             Dictionary<int, bool> filter = new Dictionary<int, bool>();
 
@@ -610,6 +614,11 @@ namespace ClassicUO.IO.Resources
 
         private void ProcessCorpseDef()
         {
+            if (Client.Version < ClientVersion.CV_300)
+            {
+                return;
+            }
+
             var file = UOFileManager.GetUOFilePath("Corpse.def");
             Dictionary<int, bool> filter = new Dictionary<int, bool>();
 
@@ -1323,7 +1332,7 @@ namespace ClassicUO.IO.Resources
                 {
                     ref var frame = ref frames[i];
 
-                    if (frame.Width == 0 || frame.Height == 0)
+                    if (frame.Width <= 0 || frame.Height <= 0)
                     {
                         /* Missing frame. */
                         continue;
@@ -1434,6 +1443,8 @@ namespace ClassicUO.IO.Resources
                      * to be missing. */
                     ushort headerFrameNum = (ushort)((animHeaderInfo->FrameID - 1) % frameCount);
 
+                    ref var frame = ref frames[frameNum];
+
                     if (frameNum < headerFrameNum)
                     {
                         /* Missing frame. Keep walking forward. */
@@ -1442,11 +1453,11 @@ namespace ClassicUO.IO.Resources
                         {
                             /* If the missing frame is for the direction we wanted, make sure
                              * to zero out the entry in the frames array. */
-                            frames[frameNum].Num = frameNum;
-                            frames[frameNum].CenterX = 0;
-                            frames[frameNum].CenterY = 0;
-                            frames[frameNum].Width = 0;
-                            frames[frameNum].Height = 0;
+                            frame.Num = frameNum;
+                            frame.CenterX = 0;
+                            frame.CenterY = 0;
+                            frame.Width = 0;
+                            frame.Height = 0;
                         }
 
                         continue;
@@ -1464,11 +1475,11 @@ namespace ClassicUO.IO.Resources
                         if (start + animHeaderInfo->DataOffset >= reader.Length)
                         {
                             /* File seems to be corrupt? Skip loading. */
-                            frames[frameNum].Num = frameNum;
-                            frames[frameNum].CenterX = 0;
-                            frames[frameNum].CenterY = 0;
-                            frames[frameNum].Width = 0;
-                            frames[frameNum].Height = 0;
+                            frame.Num = frameNum;
+                            frame.CenterX = 0;
+                            frame.CenterY = 0;
+                            frame.Width = 0;
+                            frame.Height = 0;
                             continue;
                         }
                         reader.Skip((int)animHeaderInfo->DataOffset);
@@ -1476,8 +1487,8 @@ namespace ClassicUO.IO.Resources
                         ushort* palette = (ushort*)reader.PositionAddress;
                         reader.Skip(512);
 
-                        frames[frameNum].Num = frameNum;
-                        ReadSpriteData(ref reader, palette, ref frames[frameNum], true);
+                        frame.Num = frameNum;
+                        ReadSpriteData(ref reader, palette, ref frame, true);
                     }
 
                     reader.Seek(start + sizeof(UOPAnimationHeader));

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -51,6 +51,9 @@ namespace ClassicUO.IO.Resources
     internal unsafe class AnimationsLoader : UOFileLoader
     {
         private static AnimationsLoader _instance;
+        private static uint _lastFlags = 0xFFFFFFFF;
+        [ThreadStatic] private static FrameInfo[] _frames;
+        [ThreadStatic] private static byte[] _decompressedData;
 
         private readonly Dictionary<ushort, byte> _animationSequenceReplacing = new Dictionary<ushort, byte>();
         private readonly AnimationGroup _empty = new AnimationGroup
@@ -952,10 +955,6 @@ namespace ClassicUO.IO.Resources
             return _picker.Get(packed, x, y);
         }
 
-        private static uint _lastFlags = 0xFFFFFFFF;
-
-        public bool FlagsApplied => _lastFlags != 0xFFFFFFFF;
-
         public void UpdateAnimationTable(uint flags)
         {
             if (flags != _lastFlags)
@@ -1374,20 +1373,6 @@ namespace ClassicUO.IO.Resources
             return animDir.SpriteInfos;
         }
 
-        private struct FrameInfo
-        {
-            public int Num;
-            public short CenterX;
-            public short CenterY;
-            public short Width;
-            public short Height;
-            public uint[] Pixels;
-        }
-
-        [ThreadStatic] private static FrameInfo[] _frames;
-
-        [ThreadStatic] private static byte[] _decompressedData = null;
-
         private Span<FrameInfo> ReadUOPAnimationFrames(ushort animID, byte animGroup, byte direction)
         {
             AnimationGroupUop animData = DataIndex[animID].GetUopGroup(ref animGroup);
@@ -1671,6 +1656,17 @@ namespace ClassicUO.IO.Resources
             centerY = 0;
             width = 0;
             height = ismounted ? 100 : 60;
+        }
+
+
+        private struct FrameInfo
+        {
+            public int Num;
+            public short CenterX;
+            public short CenterY;
+            public short Width;
+            public short Height;
+            public uint[] Pixels;
         }
 
         public struct SittingInfoData


### PR DESCRIPTION
### Theory
`Body.def` and `Corpse.def` must be read always before the `Bodyconv.def`. They will change the graphic only to animations at  **fileindex == 0** or **when the animation doesn't exist**. So here we need to check if `graphic != DataIndex[graphic].Graphic` until the graphic matches. The conversion here is allowed or we will see a mobile without a texture.

instead `Bodyconv.def` replaces animations at **fileindex >= 1 and when the flags allow the editing**.
Here we **don't** apply the conversion when `graphic != DataIndex[graphic].Graphic` or we will fallback to bodies replaced by `Body.def`.

### Test done
Tested with client 7.0.95.0 + ServUO.
Animations:
- Nightmare
- swamp dragon [normal, with armor, paroxymus]
- hellround

All of them are correctly displayed.

__________
Based on this PR: https://github.com/ClassicUO/ClassicUO/pull/1527