### PR TITLE
Grid loot items order

### DIFF
--- a/src/Game/UI/Gumps/GridLootGump.cs
+++ b/src/Game/UI/Gumps/GridLootGump.cs
@@ -306,7 +306,8 @@ namespace ClassicUO.Game.UI.Gumps
         private bool ItemBelongsToGroup(Item it, int group)
         {
             // Note: items must be assigned to groups in a mutually-exclusive manner, so that each item occurs only once in the grid
-            if (it.IsMulti || it.Amount > 1)
+
+            if (it.ItemData.IsStackable)
                 return group > 0;
             else
                 return group == 0;

--- a/src/Game/UI/Gumps/GridLootGump.cs
+++ b/src/Game/UI/Gumps/GridLootGump.cs
@@ -222,36 +222,44 @@ namespace ClassicUO.Game.UI.Gumps
             int line = 1;
             int row = 0;
 
-            for (LinkedObject i = _corpse.Items; i != null; i = i.Next)
+            for (int displayGroup = 0; displayGroup < 2; displayGroup++)
             {
-                Item it = (Item) i;
-
-                if (it.IsLootable)
+                for (LinkedObject i = _corpse.Items; i != null; i = i.Next)
                 {
-                    GridLootItem gridItem = new GridLootItem(it, GRID_ITEM_SIZE);
+                    Item it = (Item)i;
 
-                    if (x >= MAX_WIDTH - 20)
+                    if (!ItemBelongsToGroup(it, displayGroup))
                     {
-                        x = 20;
-                        ++line;
-
-                        y += gridItem.Height + 20;
-
-                        if (y >= MAX_HEIGHT - 60)
-                        {
-                            _pagesCount++;
-                            y = 20;
-                            //line = 1;
-                        }
+                            continue;
                     }
 
-                    gridItem.X = x;
-                    gridItem.Y = y + 20;
-                    Add(gridItem, _pagesCount);
+                    if (it.IsLootable)
+                    {
+                        GridLootItem gridItem = new GridLootItem(it, GRID_ITEM_SIZE);
 
-                    x += gridItem.Width + 20;
-                    ++row;
-                    ++count;
+                        if (x >= MAX_WIDTH - 20)
+                        {
+                            x = 20;
+                            ++line;
+
+                            y += gridItem.Height + 20;
+
+                            if (y >= MAX_HEIGHT - 60)
+                            {
+                                _pagesCount++;
+                                y = 20;
+                                //line = 1;
+                            }
+                        }
+
+                        gridItem.X = x;
+                        gridItem.Y = y + 20;
+                        Add(gridItem, _pagesCount);
+
+                        x += gridItem.Width + 20;
+                        ++row;
+                        ++count;
+                    }
                 }
             }
 
@@ -293,6 +301,15 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 IsVisible = true;
             }
+        }
+
+        private bool ItemBelongsToGroup(Item it, int group)
+        {
+            // Note: items must be assigned to groups in a mutually-exclusive manner, so that each item occurs only once in the grid
+            if (it.IsMulti || it.Amount > 1)
+                return group > 0;
+            else
+                return group == 0;
         }
 
         public override void Dispose()


### PR DESCRIPTION
    The order in which items are shown in grid-loot will now depend on item
    type.
    Motivation: some items are likely to be always looted (e.g. gold, gems)
    and when looting is performed automatically (e.g. by Razor macros) it
    makes items to move in a grid making it harder to browse their
    properties. Hence, items like gold should be at the end of the grid.
