### PR TITLE
Startup fixes

### DIFF
--- a/src/Game/World.cs
+++ b/src/Game/World.cs
@@ -163,7 +163,7 @@ namespace ClassicUO.Game
 
         public static ClientFeatures ClientFeatures { get; } = new ClientFeatures();
 
-        public static string ServerName { get; set; }
+        public static string ServerName { get; set; } = "_";
 
 
 

--- a/src/IO/Resources/TexmapsLoader.cs
+++ b/src/IO/Resources/TexmapsLoader.cs
@@ -69,43 +69,40 @@ namespace ClassicUO.IO.Resources
                     _file.FillEntries(ref Entries);
                     string pathdef = UOFileManager.GetUOFilePath("TexTerr.def");
 
-                    if (!File.Exists(pathdef))
+                    if (File.Exists(pathdef))
                     {
-                        return;
-                    }
-
-                    using (DefReader defReader = new DefReader(pathdef))
-                    {
-                        while (defReader.Next())
+                        using (DefReader defReader = new DefReader(pathdef))
                         {
-                            int index = defReader.ReadInt();
-
-                            if (index < 0 || index >= Entries.Length)
+                            while (defReader.Next())
                             {
-                                continue;
-                            }
+                                int index = defReader.ReadInt();
 
-                            int[] group = defReader.ReadGroup();
-
-                            if (group == null)
-                            {
-                                continue;
-                            }
-
-                            for (int i = 0; i < group.Length; i++)
-                            {
-                                int checkindex = group[i];
-
-                                if (checkindex < 0 || checkindex >= Entries.Length)
+                                if (index < 0 || index >= Entries.Length)
                                 {
                                     continue;
                                 }
 
-                                Entries[index] = Entries[checkindex];
+                                int[] group = defReader.ReadGroup();
+
+                                if (group == null)
+                                {
+                                    continue;
+                                }
+
+                                for (int i = 0; i < group.Length; i++)
+                                {
+                                    int checkindex = group[i];
+
+                                    if (checkindex < 0 || checkindex >= Entries.Length)
+                                    {
+                                        continue;
+                                    }
+
+                                    Entries[index] = Entries[checkindex];
+                                }
                             }
                         }
                     }
-
                     _spriteInfos = new SpriteInfo[Entries.Length];
                 }
             );


### PR DESCRIPTION
Once More Unto the Breach

* Fix for empty world name (in case a shard skips the server selection and opts to use a default redirect instead)
* Fix for missing TexTerr.def. Since it is a newer file, old clients tend to ship without it

Gumps.def fix is not relevant anymore