### PR TITLE
Fix Paperdoll & Prompt font on old clients

### DIFF
--- a/src/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/Game/UI/Gumps/PaperdollGump.cs
@@ -378,7 +378,7 @@ namespace ClassicUO.Game.UI.Gumps
             Add(_paperDollInteractable);
 
             // Name and title
-            _titleLabel = new Label("", false, 0x0386, 185)
+            _titleLabel = new Label("", false, 0x0386, 185, font: 1)
             {
                 X = 39,
                 Y = 262

--- a/src/Game/UI/Gumps/QuestionGump.cs
+++ b/src/Game/UI/Gumps/QuestionGump.cs
@@ -54,7 +54,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             Add
             (
-                new Label(message, false, 0x0386, 165)
+                new Label(message, false, 0x0386, 165, font: 1)
                 {
                     X = 33, Y = 30
                 }


### PR DESCRIPTION
The automatic font override of RenderedText would automatically switch the font to id 0 for ClientVersion < 3.0.5d, making it appear fat. Meaning: incorrect.
Switched those two gumps to explicitly use font 1.

Without fix:
![image](https://user-images.githubusercontent.com/2865280/182916066-55ea847a-4942-447f-b019-db014aecb6ac.png)

With fix:
![image](https://user-images.githubusercontent.com/2865280/182916100-497d027f-d8d5-49ac-997c-436abeb611f6.png)
