### PR TITLE
Show Mouse coordinates in WorldMap gump

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -293,6 +293,7 @@ namespace ClassicUO.Configuration
         public bool WorldMapShowParty { get; set; } = true;
         public int WorldMapZoomIndex { get; set; } = 4;
         public bool WorldMapShowCoordinates { get; set; } = true;
+        public bool WorldMapShowMouseCoordinates { get; set; } = true;
         public bool WorldMapShowMobiles { get; set; } = true;
         public bool WorldMapShowPlayerName { get; set; } = true;
         public bool WorldMapShowPlayerBar { get; set; } = true;

--- a/src/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/Game/UI/Gumps/WorldMapGump.cs
@@ -3262,34 +3262,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (button == MouseButtonType.Left && Keyboard.Ctrl)
                 {
-                    // Scale width to Zoom
-                    var newWidth = Width / Zoom;
-                    var newHeight = Height / Zoom;
-
-                    // Scale mouse cords to Zoom
-                    var newX = x / Zoom;
-                    var newY = y / Zoom;
-
-                    // Rotate Cords if map fliped
-                    // x' = (x + y)/Sqrt(2)
-                    // y' = (y - x)/Sqrt(2)
-                    if (_flipMap)
-                    {
-                        var nw = (newWidth + newHeight) / 1.41f;
-                        var nh = (newHeight - newWidth) / 1.41f;
-                        newWidth = (int)nw;
-                        newHeight = (int)nh;
-
-                        var nx = (newX + newY) / 1.41f;
-                        var ny = (newY - newX) / 1.41f;
-                        newX = (int)nx;
-                        newY = (int)ny;
-                    }
-
-                    // Calulate Click cords to Map Cords
-                    // (x,y) = MapCenter - ScaeldMapWidth/2 + ScaledMouseCords
-                    _mouseCenter.X = _center.X - (int)(newWidth / 2) + (int)newX;
-                    _mouseCenter.Y = _center.Y - (int)(newHeight / 2) + (int)newY;
+                    CanvasToWorld(x, y, out _mouseCenter.X, out _mouseCenter.Y);
 
                     // Check if file is loaded and contain markers
                     var userFile = _markerFiles.Where(f => f.Name == USER_MARKERS_FILE).FirstOrDefault();

--- a/src/Resources/ResGumps.Designer.cs
+++ b/src/Resources/ResGumps.Designer.cs
@@ -3576,6 +3576,15 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show mouse coordinates.
+        /// </summary>
+        public static string ShowMouseCoordinates {
+            get {
+                return ResourceManager.GetString("ShowMouseCoordinates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show party members.
         /// </summary>
         public static string ShowPartyMembers {

--- a/src/Resources/ResGumps.resx
+++ b/src/Resources/ResGumps.resx
@@ -1563,5 +1563,7 @@ Client version: '{0}'</value>
   </data>
   <data name="GridIfZoomed" xml:space="preserve">
     <value>Show/Hide 8x8 Grid if Zoomed</value>
+  <data name="ShowMouseCoordinates" xml:space="preserve">
+    <value>Show mouse coordinates</value>
   </data>
 </root>

--- a/src/Resources/ResGumps.resx
+++ b/src/Resources/ResGumps.resx
@@ -1563,6 +1563,7 @@ Client version: '{0}'</value>
   </data>
   <data name="GridIfZoomed" xml:space="preserve">
     <value>Show/Hide 8x8 Grid if Zoomed</value>
+  </data>
   <data name="ShowMouseCoordinates" xml:space="preserve">
     <value>Show mouse coordinates</value>
   </data>


### PR DESCRIPTION
Makes the WorldMap a bit more useful for GM tasks (for example, when issuing teleport commands).
![image](https://user-images.githubusercontent.com/2865280/182919048-e4bc4c75-f17f-4e00-9614-810b325eb874.png)
