### PR TITLE
Fix body.def loading beciause body.def is not ordered

### DIFF
--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -590,20 +590,21 @@ namespace ClassicUO.IO.Resources
                         if (index >= _dataIndex.Length)
                         {
                             Array.Resize(ref _dataIndex, index + 1);
-
-                            if (_dataIndex[index] == null)
-                            {
-                                _dataIndex[index] = new IndexAnimation
-                                {
-                                    Groups = new AnimationGroup[MAX_ACTIONS]
-                                };
-
-                                for (int i = 0; i < MAX_ACTIONS; i++)
-                                {
-                                    _dataIndex[index].Groups[i] = new AnimationGroup();
-                                }
-                            }             
                         }
+
+                        if (_dataIndex[index] == null)
+                        {
+                            _dataIndex[index] = new IndexAnimation
+                            {
+                                Groups = new AnimationGroup[MAX_ACTIONS]
+                            };
+
+                            for (int i = 0; i < MAX_ACTIONS; i++)
+                            {
+                                _dataIndex[index].Groups[i] = new AnimationGroup();
+                            }
+                        }
+
 
                         if (filter.TryGetValue(index, out bool b) && b)
                         {


### PR DESCRIPTION
The change to handle body.def  initializes the index that its expanding the array to, but not the intermediate values. 
Since the body.def isn't ordered an entry fo 8000 will expand the array to 8000 and initialize 8000, but then if a number not yet used comes in, the array is large enough, but the entry is not initialized. 
This change check for null even if the array is not expanded. 