### PR TITLE
Check the actual size of AnimationsLoader data instead of using the constant

### DIFF
--- a/src/Game/GameObjects/Item.cs
+++ b/src/Game/GameObjects/Item.cs
@@ -699,7 +699,7 @@ namespace ClassicUO.Game.GameObjects
                     bool mirror = false;
                     AnimationsLoader.Instance.GetAnimDirection(ref dir, ref mirror);
 
-                    if (id < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
+                    if (id < AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
                     {
                         byte action = AnimationsLoader.Instance.GetDeathAction(id, UsedLayer);
                         var frames = AnimationsLoader.Instance.GetAnimationFrames(id, action, dir, out _, out _, isCorpse : true);

--- a/src/Game/GameObjects/Mobile.cs
+++ b/src/Game/GameObjects/Mobile.cs
@@ -399,7 +399,7 @@ namespace ClassicUO.Game.GameObjects
 
                 ushort graphic = GetGraphicForAnimation();
 
-                if (graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                if (graphic >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                 {
                     return;
                 }
@@ -576,7 +576,7 @@ namespace ClassicUO.Game.GameObjects
                 AnimationsLoader.Instance.GetAnimDirection(ref dir, ref mirror);
                 int currentDelay = Constants.CHARACTER_ANIMATION_DELAY;
 
-                if (id < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
+                if (id < AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
                 {
                     var frames = AnimationsLoader.Instance.GetAnimationFrames(id, action, dir, out _, out _);
 

--- a/src/Game/GameObjects/MobileAnimation.cs
+++ b/src/Game/GameObjects/MobileAnimation.cs
@@ -525,7 +525,7 @@ namespace ClassicUO.Game.GameObjects
                 graphic = mobile.GetGraphicForAnimation();
             }
 
-            if (graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+            if (graphic >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
             {
                 return 0;
             }
@@ -1449,7 +1449,7 @@ namespace ClassicUO.Game.GameObjects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte GetObjectNewAnimation(Mobile mobile, ushort type, ushort action, byte mode)
         {
-            if (mobile.Graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+            if (mobile.Graphic >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
             {
                 return 0;
             }

--- a/src/Game/GameObjects/Views/MobileView.cs
+++ b/src/Game/GameObjects/Views/MobileView.cs
@@ -189,7 +189,7 @@ namespace ClassicUO.Game.GameObjects
                 ushort mountGraphic = mount.GetGraphicForAnimation();
                 byte animGroupMount = 0;
 
-                if (mountGraphic != 0xFFFF && mountGraphic < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                if (mountGraphic != 0xFFFF && mountGraphic < AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                 {
                     mountOffsetY = AnimationsLoader.Instance.GetMountedHeightOffset(mountGraphic);
 
@@ -661,7 +661,7 @@ namespace ClassicUO.Game.GameObjects
             bool charIsSitting
         )
         {
-            if (id >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT || owner == null)
+            if (id >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT || owner == null)
             {
                 return;
             }

--- a/src/Game/UI/Gumps/ShopGump.cs
+++ b/src/Game/UI/Gumps/ShopGump.cs
@@ -752,7 +752,7 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     ushort graphic = Graphic;
 
-                    if (graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                    if (graphic >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                     {
                         return false;
                     }

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -76,6 +76,7 @@ namespace ClassicUO.IO.Resources
         public static AnimationsLoader Instance => _instance ?? (_instance = new AnimationsLoader());
 
         private IndexAnimation[] _dataIndex = new IndexAnimation[Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT];
+        public  int MAX_ANIMATIONS_DATA_INDEX_COUNT { get { return _dataIndex.Length; } }
 
         public IReadOnlyDictionary<ushort, Dictionary<ushort, EquipConvData>> EquipConversions => _equipConv;
 
@@ -161,7 +162,7 @@ namespace ClassicUO.IO.Resources
 
                             int id = int.Parse(parts[0]);
 
-                            if (id >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                            if (id >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                             {
                                 continue;
                             }
@@ -203,7 +204,7 @@ namespace ClassicUO.IO.Resources
                 }
             }
 
-            for (ushort i = 0; i < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT; i++)
+            for (ushort i = 0; i < AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT; i++)
             {
                 var idxFile = _files[0].IdxFile;
 
@@ -337,21 +338,21 @@ namespace ClassicUO.IO.Resources
                     {
                         ushort body = (ushort)defReader.ReadInt();
 
-                        if (body >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                        if (body >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                         {
                             continue;
                         }
 
                         ushort graphic = (ushort)defReader.ReadInt();
 
-                        if (graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                        if (graphic >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                         {
                             continue;
                         }
 
                         ushort newGraphic = (ushort)defReader.ReadInt();
 
-                        if (newGraphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                        if (newGraphic >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                         {
                             continue;
                         }
@@ -402,7 +403,7 @@ namespace ClassicUO.IO.Resources
                     {
                         ushort index = (ushort)defReader.ReadInt();
 
-                        if (index >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                        if (index >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                         {
                             continue;
                         }
@@ -411,7 +412,7 @@ namespace ClassicUO.IO.Resources
                         {
                             int body = defReader.ReadInt();
 
-                            if (body >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT || body < 0)
+                            if (body >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT || body < 0)
                             {
                                 continue;
                             }
@@ -632,7 +633,7 @@ namespace ClassicUO.IO.Resources
                             checkIndex = group[0];
                         }
 
-                        if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                        if (checkIndex >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                         {
                             continue;
                         }
@@ -666,7 +667,7 @@ namespace ClassicUO.IO.Resources
                     {
                         int index = defReader.ReadInt();
 
-                        if (index >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                        if (index >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                         {
                             continue;
                         }
@@ -696,7 +697,7 @@ namespace ClassicUO.IO.Resources
                             checkIndex = group[0];
                         }
 
-                        if (checkIndex >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+                        if (checkIndex >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                         {
                             continue;
                         }
@@ -720,7 +721,7 @@ namespace ClassicUO.IO.Resources
                 return;
             }
 
-            for (ushort animID = 0; animID < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT; animID++)
+            for (ushort animID = 0; animID < AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT; animID++)
             {
                 for (byte grpID = 0; grpID < MAX_ACTIONS; grpID++)
                 {
@@ -773,7 +774,7 @@ namespace ClassicUO.IO.Resources
             }
 
             UOFileUop animSeq = new UOFileUop(animationSequencePath, "build/animationsequence/{0:D8}.bin");
-            UOFileIndex[] animseqEntries = new UOFileIndex[Math.Max(animSeq.TotalEntriesCount, Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)];
+            UOFileIndex[] animseqEntries = new UOFileIndex[Math.Max(animSeq.TotalEntriesCount, AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)];
             animSeq.FillEntries(ref animseqEntries);
 
             Span<byte> spanAlloc = stackalloc byte[1024];
@@ -902,7 +903,7 @@ namespace ClassicUO.IO.Resources
 
         public void ConvertBodyIfNeeded(ref ushort graphic, bool isParent = false, bool forceUOP = false)
         {
-            if (graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+            if (graphic >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
             {
                 return;
             }
@@ -928,7 +929,7 @@ namespace ClassicUO.IO.Resources
         {
             useUOP = false;
 
-            if (graphic < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT && action < MAX_ACTIONS)
+            if (graphic < AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT && action < MAX_ACTIONS)
             {
                 IndexAnimation index = _dataIndex[graphic];
 
@@ -1204,7 +1205,7 @@ namespace ClassicUO.IO.Resources
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ANIMATION_GROUPS GetGroupIndex(ushort graphic)
         {
-            if (graphic >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+            if (graphic >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
             {
                 return ANIMATION_GROUPS.AG_HIGHT;
             }
@@ -1226,7 +1227,7 @@ namespace ClassicUO.IO.Resources
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public byte GetDeathAction(ushort id, bool second, bool isRunning = false)
         {
-            if (id >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT)
+            if (id >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
             {
                 return 0;
             }
@@ -1281,7 +1282,7 @@ namespace ClassicUO.IO.Resources
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsAnimationExists(ushort graphic, byte group, bool isCorpse = false)
         {
-            if (graphic < Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT && group < MAX_ACTIONS)
+            if (graphic < AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT && group < MAX_ACTIONS)
             {
                 var frames = GetAnimationFrames(graphic, group, 0, out var _, out _, false, isCorpse);
 
@@ -1306,7 +1307,7 @@ namespace ClassicUO.IO.Resources
             hue = 0;
             useUOP = false;
 
-            if (id >= Constants.MAX_ANIMATIONS_DATA_INDEX_COUNT || action >= MAX_ACTIONS || dir >= MAX_DIRECTIONS)
+            if (id >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT || action >= MAX_ACTIONS || dir >= MAX_DIRECTIONS)
             {
                 return Span<SpriteInfo>.Empty;
             }

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -590,20 +590,21 @@ namespace ClassicUO.IO.Resources
                         if (index >= _dataIndex.Length)
                         {
                             Array.Resize(ref _dataIndex, index + 1);
-
-                            if (_dataIndex[index] == null)
-                            {
-                                _dataIndex[index] = new IndexAnimation
-                                {
-                                    Groups = new AnimationGroup[MAX_ACTIONS]
-                                };
-
-                                for (int i = 0; i < MAX_ACTIONS; i++)
-                                {
-                                    _dataIndex[index].Groups[i] = new AnimationGroup();
-                                }
-                            }             
                         }
+
+                        if (_dataIndex[index] == null)
+                        {
+                            _dataIndex[index] = new IndexAnimation
+                            {
+                                Groups = new AnimationGroup[MAX_ACTIONS]
+                            };
+
+                            for (int i = 0; i < MAX_ACTIONS; i++)
+                            {
+                                _dataIndex[index].Groups[i] = new AnimationGroup();
+                            }
+                        }
+
 
                         if (filter.TryGetValue(index, out bool b) && b)
                         {


### PR DESCRIPTION
Since the Animation Data array is being expanded at load time by body.def, check in other parts of the code need to use the actual array size instead of the constant. 
This PR changes  adds a get property for teh array size, and changes the compare operations in the code to use the property instead of the constant