### PR TITLE
processes a Mounts.def file in the client directory (if it exists) and adjusts the internal CUO _mounts and animation table

### DIFF
--- a/src/Game/GameObjects/Item.cs
+++ b/src/Game/GameObjects/Item.cs
@@ -508,7 +508,13 @@ namespace ClassicUO.Game.GameObjects
             ProcessAnimation();
         }
 
-        private static readonly Dictionary<ushort, ushort> _mounts = new Dictionary<ushort, ushort>()
+        internal static void AddMount(ushort bodyId, ushort animationId)
+        {
+            if (! _mounts.ContainsKey(bodyId))
+                _mounts.Add(bodyId, animationId);
+        }
+
+        private static Dictionary<ushort, ushort> _mounts = new Dictionary<ushort, ushort>()
         {
             { 0x3E90, 0x0114 }, // 16016 Reptalon
             { 0x3E91, 0x0115 }, // 16017

--- a/src/IO/Resources/AnimationsLoader.cs
+++ b/src/IO/Resources/AnimationsLoader.cs
@@ -335,6 +335,7 @@ namespace ClassicUO.IO.Resources
             ProcessEquipConvDef();
             ProcessBodyDef();
             ProcessCorpseDef();
+            ProcessMountsDef();
         }
 
         public override unsafe Task Load()
@@ -342,6 +343,25 @@ namespace ClassicUO.IO.Resources
             return Task.Run(LoadInternal);
         }
 
+        internal void ProcessMountsDef()
+        {
+            var file = UOFileManager.GetUOFilePath("Mounts.def");
+
+            if (File.Exists(file))
+            {
+                using (DefReader defReader = new DefReader(file, 3))
+                {
+                    while (defReader.Next())
+                    {
+                        ushort bodyId = (ushort)defReader.ReadInt();
+                        ushort animationId = (ushort)defReader.ReadInt();
+                        ClassicUO.Game.GameObjects.Item.AddMount(bodyId, animationId);
+                        sbyte replacementMountedHeight = (sbyte)defReader.ReadInt();
+                        _dataIndex[animationId].MountedHeightOffset = replacementMountedHeight;
+                    }
+                }
+            }
+        }
         private void ProcessEquipConvDef()
         {
             if (Client.Version < ClientVersion.CV_300)


### PR DESCRIPTION
This is example modifies a bodyID of 1179 to use the 59 (red dragon) animation and the mount height of -30
Mounts.def  file looks like this:
#						
#  Fields:						
#  #bodyType	#animationId	#mountHeight
#
1179  59  -30	# Ridable dragon