### PR TITLE
Empty ascii strings are not filling the packet properly

### DIFF
--- a/src/IO/StackDataWriter.cs
+++ b/src/IO/StackDataWriter.cs
@@ -306,7 +306,11 @@ namespace ClassicUO.IO
 
             int start = Position;
 
-            if (!string.IsNullOrEmpty(str))
+            if (string.IsNullOrEmpty(str))
+            {
+                WriteZero(sizeof(byte));
+            }
+            else
             {
                 foreach (var b in StringHelper.StringToCp1252Bytes(str, length))
                 {


### PR DESCRIPTION
An empty ascii field should fill the length in the packet with nulls.
Currently it leaves garbage, and doesn't update the pointer properly.