### PR TITLE
Fix sell gump graphic display if server sends item graphic as serial

### DIFF
--- a/src/Game/UI/Gumps/ShopGump.cs
+++ b/src/Game/UI/Gumps/ShopGump.cs
@@ -754,7 +754,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                     if (graphic >= AnimationsLoader.Instance.MAX_ANIMATIONS_DATA_INDEX_COUNT)
                     {
-                        return false;
+                        graphic = 0;
                     }
 
                     byte group = GetAnimGroup(graphic);

--- a/src/Game/UI/Gumps/ShopGump.cs
+++ b/src/Game/UI/Gumps/ShopGump.cs
@@ -377,7 +377,8 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 X = 5,
                 Y = y + 2,
-                NameFromCliloc = fromcliloc
+                NameFromCliloc = fromcliloc,
+                InBuyGump = IsBuyGump
             };
 
             _shopScrollArea.Add(shopItem);
@@ -718,6 +719,8 @@ namespace ClassicUO.Game.UI.Gumps
             public string Name { get; }
 
             public bool NameFromCliloc { get; set; }
+            
+            public bool InBuyGump { get; set; }
 
             private static byte GetAnimGroup(ushort graphic)
             {
@@ -748,7 +751,7 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 Vector3 hueVector;
 
-                if (SerialHelper.IsMobile(LocalSerial))
+                if (InBuyGump && SerialHelper.IsMobile(LocalSerial))
                 {
                     ushort graphic = Graphic;
 
@@ -784,7 +787,7 @@ namespace ClassicUO.Game.UI.Gumps
                         }
                     }
                 }
-                else if (SerialHelper.IsItem(LocalSerial))
+                else
                 {
                     var texture = ArtLoader.Instance.GetStaticTexture(Graphic, out var bounds);
 


### PR DESCRIPTION
Some servers send the item graphic as item serial in the sell gump under certain conditions. On my shard this is done when the player is selling stackable items, in order to merge multiple separate stacks into one item in the sell gump.

CUO was assuming that we were selling mobs in this situation. I did some testing and it seems the mob animation display logic is supposed to only apply to the buy gump, not the sell gump.