### PR TITLE
Fix for artifact health bar and clearing feature flags while switching to another character

### DIFF
--- a/src/Game/World.cs
+++ b/src/Game/World.cs
@@ -758,6 +758,8 @@ namespace ClassicUO.Game
                 RemoveItem(item);
             }
 
+            UIManager.GetGump<BaseHealthBarGump>(Player.Serial)?.Dispose();
+
             ObjectToRemove = 0;
             LastObject = 0;
             Items.Clear();
@@ -768,7 +770,6 @@ namespace ClassicUO.Game
             Map = null;
             Light.Overall = Light.RealOverall = 0;
             Light.Personal = Light.RealPersonal = 0;
-            ClientFeatures.SetFlags(0);
             ClientLockedFeatures.SetFlags(0);
             Party?.Clear();
             TargetManager.LastAttack = 0;


### PR DESCRIPTION
Image is of remaining health bar after switching to a different character.

![image](https://user-images.githubusercontent.com/42147397/199459478-996f1ad4-d0ad-4701-976e-99fe142c100a.png)
