### PR TITLE
don't update counter bar items when counter bar is disabled

### DIFF
--- a/src/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/Game/UI/Gumps/CounterBarGump.cs
@@ -407,7 +407,7 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 base.Update();
 
-                if (_time < Time.Ticks)
+                if (Parent != null && Parent.IsEnabled && _time < Time.Ticks)
                 {
                     _time = Time.Ticks + 100;
 


### PR DESCRIPTION
Minor thing, the counters continue to update even after you disable them, as the gump isn't disposed when disabling (in order to keep the counter bar items intact). I cannot push to the main branch