### PR TITLE
Minimum light level setting

### DIFF
--- a/src/Configuration/Profile.cs
+++ b/src/Configuration/Profile.cs
@@ -160,6 +160,7 @@ namespace ClassicUO.Configuration
         public bool UseAlternativeLights { get; set; }
         public bool UseCustomLightLevel { get; set; }
         public byte LightLevel { get; set; }
+        public int LightLevelType { get; set; } // 0 = absolute, 1 = minimum
         public bool UseColoredLights { get; set; } = true;
         public bool UseDarkNights { get; set; }
         public int CloseHealthBarType { get; set; } // 0 = none, 1 == not exists, 2 == is dead

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -166,6 +166,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         // video
         private Checkbox _use_old_status_gump, _windowBorderless, _enableDeathScreen, _enableBlackWhiteEffect, _altLights, _enableLight, _enableShadows, _enableShadowsStatics, _auraMouse, _runMouseInSeparateThread, _useColoredLights, _darkNights, _partyAura, _hideChatGradient;
+        private Combobox _lightLevelType;
         private Checkbox _use_smooth_boat_movement;
         private HSliderBar _terrainShadowLevel;
 
@@ -1752,6 +1753,21 @@ namespace ClassicUO.Game.UI.Gumps
                     startX,
                     startY,
                     250
+                )
+            );
+
+            section3.Add(AddLabel(null, ResGumps.LightLevelType, startX, startY));
+
+            section3.AddRight
+            (
+                _lightLevelType = AddCombobox
+                (
+                    null,
+                    new[] { ResGumps.LightLevelTypeAbsolute, ResGumps.LightLevelTypeMinimum },
+                    _currentProfile.LightLevelType,
+                    startX,
+                    startY,
+                    150
                 )
             );
 
@@ -3513,6 +3529,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _currentProfile.DefaultScale = 1f;
                     _lightBar.Value = 0;
                     _enableLight.IsChecked = false;
+                    _lightLevelType.SelectedIndex = 0;
                     _useColoredLights.IsChecked = false;
                     _darkNights.IsChecked = false;
                     _enableShadows.IsChecked = true;
@@ -3899,10 +3916,11 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.UseAlternativeLights = _altLights.IsChecked;
             _currentProfile.UseCustomLightLevel = _enableLight.IsChecked;
             _currentProfile.LightLevel = (byte) (_lightBar.MaxValue - _lightBar.Value);
+            _currentProfile.LightLevelType = _lightLevelType.SelectedIndex;
 
             if (_enableLight.IsChecked)
             {
-                World.Light.Overall = _currentProfile.LightLevel;
+                World.Light.Overall = _currentProfile.LightLevelType == 1 ? Math.Min(World.Light.RealOverall, _currentProfile.LightLevel) : _currentProfile.LightLevel;
                 World.Light.Personal = 0;
             }
             else

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -766,8 +766,8 @@ namespace ClassicUO.Network
 
             if (ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.UseCustomLightLevel)
             {
-                World.Light.Overall = ProfileManager.CurrentProfile.LightLevel;
-            }
+                World.Light.Overall = ProfileManager.CurrentProfile.LightLevelType == 1 ? Math.Min(World.Light.Overall, ProfileManager.CurrentProfile.LightLevel) : ProfileManager.CurrentProfile.LightLevel;
+             }
 
             Client.Game.Audio.UpdateCurrentMusicVolume();
 
@@ -2007,9 +2007,9 @@ namespace ClassicUO.Network
 
             World.Light.RealOverall = level;
 
-            if (!ProfileManager.CurrentProfile.UseCustomLightLevel)
+            if (!ProfileManager.CurrentProfile.UseCustomLightLevel || ProfileManager.CurrentProfile.LightLevelType == 1)
             {
-                World.Light.Overall = level;
+                World.Light.Overall = ProfileManager.CurrentProfile.LightLevelType == 1 ? Math.Min(level, ProfileManager.CurrentProfile.LightLevel) : level;
             }
         }
 

--- a/src/Resources/ResGumps.Designer.cs
+++ b/src/Resources/ResGumps.Designer.cs
@@ -2286,6 +2286,33 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Light Level Setting Type.
+        /// </summary>
+        public static string LightLevelType {
+            get {
+                return ResourceManager.GetString("LightLevelType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Absolute.
+        /// </summary>
+        public static string LightLevelTypeAbsolute {
+            get {
+                return ResourceManager.GetString("LightLevelTypeAbsolute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minimum.
+        /// </summary>
+        public static string LightLevelTypeMinimum {
+            get {
+                return ResourceManager.GetString("LightLevelTypeMinimum", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Linear Clamp.
         /// </summary>
         public static string LinearClamp {

--- a/src/Resources/ResGumps.resx
+++ b/src/Resources/ResGumps.resx
@@ -1567,4 +1567,13 @@ Client version: '{0}'</value>
   <data name="ShowMouseCoordinates" xml:space="preserve">
     <value>Show mouse coordinates</value>
   </data>
+  <data name="LightLevelType" xml:space="preserve">
+    <value>Light Level Setting Type</value>
+  </data>
+  <data name="LightLevelTypeAbsolute" xml:space="preserve">
+    <value>Absolute</value>
+  </data>
+  <data name="LightLevelTypeMinimum" xml:space="preserve">
+    <value>Minimum</value>
+  </data>
 </root>


### PR DESCRIPTION
Instead of an absolute light level, players will have the option of setting a minimum light level. Then they can still experience the intended light cycle without committing to playing in darkness.