### PR TITLE
Single-click for counter bar items

### DIFF
--- a/src/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/Game/UI/Gumps/CounterBarGump.cs
@@ -382,6 +382,10 @@ namespace ClassicUO.Game.UI.Gumps
                            Client.Game.GameCursor.ItemHold.Container
                         );
                     }
+                    else if (ProfileManager.CurrentProfile.CastSpellsByOneClick)
+                    {
+                        Use();
+                    }
                 }
                 else if (button == MouseButtonType.Right && Keyboard.Alt && Graphic != 0)
                 {
@@ -395,7 +399,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             protected override bool OnMouseDoubleClick(int x, int y, MouseButtonType button)
             {
-                if (button == MouseButtonType.Left)
+                if (button == MouseButtonType.Left && !ProfileManager.CurrentProfile.CastSpellsByOneClick)
                 {
                     Use();
                 }

--- a/src/Game/UI/Gumps/OptionsGump.cs
+++ b/src/Game/UI/Gumps/OptionsGump.cs
@@ -133,7 +133,7 @@ namespace ClassicUO.Game.UI.Gumps
         // combat & spells
         private ClickableColorBox _innocentColorPickerBox, _friendColorPickerBox, _crimialColorPickerBox, _canAttackColorPickerBox, _enemyColorPickerBox, _murdererColorPickerBox, _neutralColorPickerBox, _beneficColorPickerBox, _harmfulColorPickerBox;
         private HSliderBar _lightBar;
-        private Checkbox _buffBarTime, _castSpellsByOneClick, _queryBeforAttackCheckbox, _queryBeforeBeneficialCheckbox, _spellColoringCheckbox, _spellFormatCheckbox, _enableFastSpellsAssign;
+        private Checkbox _buffBarTime, _uiButtonsSingleClick, _queryBeforAttackCheckbox, _queryBeforeBeneficialCheckbox, _spellColoringCheckbox, _spellFormatCheckbox, _enableFastSpellsAssign;
 
         // macro
         private MacroControl _macroControl;
@@ -2659,16 +2659,16 @@ namespace ClassicUO.Game.UI.Gumps
 
             startY += _spellColoringCheckbox.Height + 2;
 
-            _castSpellsByOneClick = AddCheckBox
+            _uiButtonsSingleClick = AddCheckBox
             (
                 rightArea,
-                ResGumps.CastSpellsByOneClick,
+                ResGumps.UIButtonsSingleClick,
                 _currentProfile.CastSpellsByOneClick,
                 startX,
                 startY
             );
 
-            startY += _castSpellsByOneClick.Height + 2;
+            startY += _uiButtonsSingleClick.Height + 2;
 
             _buffBarTime = AddCheckBox
             (
@@ -3576,7 +3576,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _enemyColorPickerBox.Hue = 0x0031;
                     _queryBeforAttackCheckbox.IsChecked = true;
                     _queryBeforeBeneficialCheckbox.IsChecked = false;
-                    _castSpellsByOneClick.IsChecked = false;
+                    _uiButtonsSingleClick.IsChecked = false;
                     _buffBarTime.IsChecked = false;
                     _enableFastSpellsAssign.IsChecked = false;
                     _beneficColorPickerBox.Hue = 0x0059;
@@ -3948,7 +3948,7 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.MurdererHue = _murdererColorPickerBox.Hue;
             _currentProfile.EnabledCriminalActionQuery = _queryBeforAttackCheckbox.IsChecked;
             _currentProfile.EnabledBeneficialCriminalActionQuery = _queryBeforeBeneficialCheckbox.IsChecked;
-            _currentProfile.CastSpellsByOneClick = _castSpellsByOneClick.IsChecked;
+            _currentProfile.CastSpellsByOneClick = _uiButtonsSingleClick.IsChecked;
             _currentProfile.BuffBarTime = _buffBarTime.IsChecked;
             _currentProfile.FastSpellsAssign = _enableFastSpellsAssign.IsChecked;
 

--- a/src/Resources/ResGumps.Designer.cs
+++ b/src/Resources/ResGumps.Designer.cs
@@ -547,15 +547,6 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cast spells by one click.
-        /// </summary>
-        public static string CastSpellsByOneClick {
-            get {
-                return ResourceManager.GetString("CastSpellsByOneClick", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cell size:.
         /// </summary>
         public static string CellSize {
@@ -4115,6 +4106,15 @@ namespace ClassicUO.Resources {
         public static string TreesStumps {
             get {
                 return ResourceManager.GetString("TreesStumps", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Single-click UI buttons.
+        /// </summary>
+        public static string UIButtonsSingleClick {
+            get {
+                return ResourceManager.GetString("UIButtonsSingleClick", resourceCulture);
             }
         }
         

--- a/src/Resources/ResGumps.resx
+++ b/src/Resources/ResGumps.resx
@@ -596,8 +596,8 @@ Murderers, Criminals, Grays (Monsters/Animals)</value>
   <data name="EnableOverheadSpellHue" xml:space="preserve">
     <value>Enable Overhead Spell Hue</value>
   </data>
-  <data name="CastSpellsByOneClick" xml:space="preserve">
-    <value>Cast spells by one click</value>
+  <data name="UIButtonsSingleClick" xml:space="preserve">
+    <value>Single-click UI buttons</value>
   </data>
   <data name="ShowBuffDuration" xml:space="preserve">
     <value>Show buff duration</value>


### PR DESCRIPTION
The option "Cast spells by one click" works for other types of button (skill button, macro button), so it makes sense to work for the counter bar also. I've changed the description to reflect it being a single-click enabler for all button gumps.