### PR TITLE
Apply new window size when maximised on login

### DIFF
--- a/src/GameController.cs
+++ b/src/GameController.cs
@@ -347,6 +347,10 @@ namespace ClassicUO
         public void MaximizeWindow()
         {
             SDL_MaximizeWindow(Window.Handle);
+
+            GraphicManager.PreferredBackBufferWidth = Client.Game.Window.ClientBounds.Width;
+            GraphicManager.PreferredBackBufferHeight = Client.Game.Window.ClientBounds.Height;
+            GraphicManager.ApplyChanges();
         }
 
         public bool IsWindowMaximized()


### PR DESCRIPTION
This fixes the issue where if you use a maximised window (rather than borderless window), attempt to log in and alt-tab away from ClassicUO before the gamescene is loaded, the resolution doesn't change from the login scene resolution.

![image](https://user-images.githubusercontent.com/7057924/215901412-6ee27316-2287-4296-a7b8-574372959fd5.png)

This is because FNA explicitly avoids acting on the window resize when the window is not focused

https://github.com/FNA-XNA/FNA/blob/591b3a37cdeabf3ccbd6b66f6ce71e67a4407337/src/FNAPlatform/SDL2_FNAPlatform.cs#L933-L937