### PR TITLE
Camera translation macros (peek to mouse)

### DIFF
--- a/src/Game/Managers/MacroManager.cs
+++ b/src/Game/Managers/MacroManager.cs
@@ -1792,6 +1792,10 @@ namespace ClassicUO.Game.Managers
                     ProfileManager.CurrentProfile.EnableCaveBorder = !ProfileManager.CurrentProfile.EnableCaveBorder;
 
                     break;
+
+                case MacroType.LookAtMouse:
+                    // handle in gamesceneinput
+                    break;
             }
 
 
@@ -2163,6 +2167,12 @@ namespace ClassicUO.Game.Managers
                     count = 1 + MacroSubType.SpellStone - MacroSubType.BestHealPotion;
 
                     break;
+
+                case MacroType.LookAtMouse:
+                    offset = (int) MacroSubType.LookForwards;
+                    count = 1 + MacroSubType.LookBackwards - MacroSubType.LookForwards;
+
+                    break;
             }
         }
     }
@@ -2192,6 +2202,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.UsePotion:
                 case MacroType.Zoom:
                 case MacroType.UseObject:
+                case MacroType.LookAtMouse:
 
                     if (sub == MacroSubType.MSC_NONE)
                     {
@@ -2328,7 +2339,8 @@ namespace ClassicUO.Game.Managers
         ToggleCaveTiles,
         CloseInactiveHealthBars,
         CloseCorpses,
-        UseObject
+        UseObject,
+        LookAtMouse
     }
 
     internal enum MacroSubType
@@ -2578,6 +2590,9 @@ namespace ClassicUO.Game.Managers
         TrappedBox,
         SmokeBomb,
         HealStone,
-        SpellStone
+        SpellStone,
+
+        LookForwards,
+        LookBackwards
     }
 }

--- a/src/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/Game/Scenes/GameSceneDrawingSorting.cs
@@ -65,7 +65,7 @@ namespace ClassicUO.Game.Scenes
 
         private sbyte _maxGroundZ;
         private int _maxZ;
-        private Vector2 _minPixel, _maxPixel;
+        private Vector2 _minPixel, _maxPixel, _lastCamOffset;
         private bool _noDrawRoofs;
         private Point _offset, _maxTile, _minTile, _last_scaled_offset;
         private int _oldPlayerX, _oldPlayerY, _oldPlayerZ;
@@ -954,6 +954,12 @@ namespace ClassicUO.Game.Scenes
 
             int size = (int)(Math.Max(winGameWidth / 44f + 1, winGameHeight / 44f + 1) * zoom);
 
+            if (Camera.Offset.X != 0 || Camera.Offset.Y != 0)
+            {
+                tileOffX += (int) (zoom * (Camera.Offset.X + Camera.Offset.Y) / 44);
+                tileOffY += (int) (zoom * (Camera.Offset.Y - Camera.Offset.X) / 44);
+            };
+
             int realMinRangeX = Math.Max(0, tileOffX - size);
             int realMaxRangeX = tileOffX + size;
             int realMinRangeY = Math.Max(0, tileOffY - size);
@@ -974,10 +980,10 @@ namespace ClassicUO.Game.Scenes
             int maxPixelsX = p.X;
             int maxPixelsY = p.Y;
 
-
-            if (UpdateDrawPosition || oldDrawOffsetX != winDrawOffsetX || oldDrawOffsetY != winDrawOffsetY || old_scaled_offset.X != winGameScaledOffsetX || old_scaled_offset.Y != winGameScaledOffsetY)
+            if (UpdateDrawPosition || oldDrawOffsetX != winDrawOffsetX || oldDrawOffsetY != winDrawOffsetY || old_scaled_offset.X != winGameScaledOffsetX || old_scaled_offset.Y != winGameScaledOffsetY || _lastCamOffset != Camera.Offset)
             {
                 UpdateDrawPosition = true;
+                _lastCamOffset = Camera.Offset;
 
 
                 if (_use_render_target && (_world_render_target == null || _world_render_target.Width != (int) (winGameWidth * zoom) || _world_render_target.Height != (int) (winGameHeight * zoom)))

--- a/src/Utility/Easings.cs
+++ b/src/Utility/Easings.cs
@@ -1,0 +1,118 @@
+﻿using System;
+
+namespace ClassicUO.Utility
+{
+    // Credit Kryzarel https://gist.github.com/Kryzarel/bba64622057f21a1d6d44879f9cd7bd4
+
+    internal static class Easings
+    {
+        public static float Linear(float t) => t;
+        public static float InQuad(float t) => t * t;
+        public static float OutQuad(float t) => 1 - InQuad(1 - t);
+        public static float InOutQuad(float t)
+        {
+            if (t < 0.5) return InQuad(t * 2) / 2;
+            return 1 - InQuad((1 - t) * 2) / 2;
+        }
+
+        public static float InCubic(float t) => t * t * t;
+        public static float OutCubic(float t) => 1 - InCubic(1 - t);
+        public static float InOutCubic(float t)
+        {
+            if (t < 0.5) return InCubic(t * 2) / 2;
+            return 1 - InCubic((1 - t) * 2) / 2;
+        }
+
+        public static float InQuart(float t) => t * t * t * t;
+        public static float OutQuart(float t) => 1 - InQuart(1 - t);
+        public static float InOutQuart(float t)
+        {
+            if (t < 0.5) return InQuart(t * 2) / 2;
+            return 1 - InQuart((1 - t) * 2) / 2;
+        }
+
+        public static float InQuint(float t) => t * t * t * t * t;
+        public static float OutQuint(float t) => 1 - InQuint(1 - t);
+        public static float InOutQuint(float t)
+        {
+            if (t < 0.5) return InQuint(t * 2) / 2;
+            return 1 - InQuint((1 - t) * 2) / 2;
+        }
+
+        public static float InSine(float t) => (float) -Math.Cos(t * Math.PI / 2);
+        public static float OutSine(float t) => (float) Math.Sin(t * Math.PI / 2);
+        public static float InOutSine(float t) => (float) (Math.Cos(t * Math.PI) - 1) / -2;
+
+        public static float InExpo(float t) => (float) Math.Pow(2, 10 * (t - 1));
+        public static float OutExpo(float t) => 1 - InExpo(1 - t);
+        public static float InOutExpo(float t)
+        {
+            if (t < 0.5) return InExpo(t * 2) / 2;
+            return 1 - InExpo((1 - t) * 2) / 2;
+        }
+
+        public static float InCirc(float t) => -((float) Math.Sqrt(1 - t * t) - 1);
+        public static float OutCirc(float t) => 1 - InCirc(1 - t);
+        public static float InOutCirc(float t)
+        {
+            if (t < 0.5) return InCirc(t * 2) / 2;
+            return 1 - InCirc((1 - t) * 2) / 2;
+        }
+
+        public static float InElastic(float t) => 1 - OutElastic(1 - t);
+        public static float OutElastic(float t)
+        {
+            float p = 0.3f;
+            return (float) Math.Pow(2, -10 * t) * (float) Math.Sin((t - p / 4) * (2 * Math.PI) / p) + 1;
+        }
+        public static float InOutElastic(float t)
+        {
+            if (t < 0.5) return InElastic(t * 2) / 2;
+            return 1 - InElastic((1 - t) * 2) / 2;
+        }
+
+        public static float InBack(float t)
+        {
+            float s = 1.70158f;
+            return t * t * ((s + 1) * t - s);
+        }
+        public static float OutBack(float t) => 1 - InBack(1 - t);
+        public static float InOutBack(float t)
+        {
+            if (t < 0.5) return InBack(t * 2) / 2;
+            return 1 - InBack((1 - t) * 2) / 2;
+        }
+
+        public static float InBounce(float t) => 1 - OutBounce(1 - t);
+        public static float OutBounce(float t)
+        {
+            float div = 2.75f;
+            float mult = 7.5625f;
+
+            if (t < 1 / div)
+            {
+                return mult * t * t;
+            }
+            else if (t < 2 / div)
+            {
+                t -= 1.5f / div;
+                return mult * t * t + 0.75f;
+            }
+            else if (t < 2.5 / div)
+            {
+                t -= 2.25f / div;
+                return mult * t * t + 0.9375f;
+            }
+            else
+            {
+                t -= 2.625f / div;
+                return mult * t * t + 0.984375f;
+            }
+        }
+        public static float InOutBounce(float t)
+        {
+            if (t < 0.5) return InBounce(t * 2) / 2;
+            return 1 - InBounce((1 - t) * 2) / 2;
+        }
+    }
+}


### PR DESCRIPTION
This adds macros which allow you to "peek" towards or away from the mouse location when you hold the assigned key.

- LookAtMouse → LookForwards
- LookAtMouse → LookBackwards

The motivation is helping players see more things which are inside their view range, but outside of their viewport. Even at a full screen 1080p, a lot of your view range is hidden above and below the viewport if you use the default zoom.

https://user-images.githubusercontent.com/7057924/218719949-8670ae4f-1e0f-437b-b1db-68409e9f49c2.mp4

### Known issue

I decided to make it a "hold" instead of toggle, so the macro has special handling in GameSceneInputHandler similar to the Walk macros (let's call them non-macros). Therefore it has the same issue as Walk, that if you bind it to modifier+key and let go of the modifier first, the active state won't be removed. Therefore it's best used without modifier keys, though I'll look at a general fix for these.