### PR TITLE
NameOverhead item text changes

### DIFF
--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -110,7 +110,7 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                     else
                     {
-                        t += StringHelper.CapitalizeAllWords(item.ItemData.Name);
+                        t += StringHelper.CapitalizeAllWords(StringHelper.GetPluralAdjustedString(item.ItemData.Name, item.Amount > 1));
                     }
                 }
 

--- a/src/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/Game/UI/Gumps/NameOverheadGump.cs
@@ -99,11 +99,18 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 if (!World.OPL.TryGetNameAndData(item, out string t, out _))
                 {
-                    t = StringHelper.CapitalizeAllWords(item.ItemData.Name);
-
-                    if (string.IsNullOrEmpty(t))
+                    if (!item.IsCorpse && item.Amount > 1)
                     {
-                        t = ClilocLoader.Instance.GetString(1020000 + item.Graphic, true, t);
+                        t = item.Amount.ToString() + ' ';
+                    }
+
+                    if (string.IsNullOrEmpty(item.ItemData.Name))
+                    {
+                        t += ClilocLoader.Instance.GetString(1020000 + item.Graphic, true, t);
+                    }
+                    else
+                    {
+                        t += StringHelper.CapitalizeAllWords(item.ItemData.Name);
                     }
                 }
 
@@ -112,10 +119,6 @@ namespace ClassicUO.Game.UI.Gumps
                     return false;
                 }
 
-                if (!item.IsCorpse && item.Amount > 1)
-                {
-                    t += ": " + item.Amount;
-                }
 
                 FontsLoader.Instance.SetUseHTML(true);
                 FontsLoader.Instance.RecalculateWidthByInfo = true;


### PR DESCRIPTION
- The OPL tends to have the quantity already so it's redundant when using tooltips.
- Evaluate plural strings in itemdata names like Diamond%s%

I don't know if it's worth using ValueStringBuilder instead of += concatenation here.