### PR TITLE
picinpic support for gumps sent by the server.

### DIFF
--- a/src/Game/UI/Controls/GumpPic.cs
+++ b/src/Game/UI/Controls/GumpPic.cs
@@ -182,4 +182,61 @@ namespace ClassicUO.Game.UI.Controls
             return base.Draw(batcher, x, y);
         }
     }
+
+    internal class GumpPicInPic : GumpPicBase
+    {
+        private int _SX, _SY;
+
+        public GumpPicInPic(int x, int y, ushort graphic, ushort width, ushort height, ushort sx, ushort sy)
+        {
+            X = x;
+            Y = y;
+            Graphic = graphic;
+            Width = width;
+            Height = height;
+            _SX = sx;
+            _SY = sy;
+            IsFromServer = true;
+        }
+
+        public GumpPicInPic(List<string> parts) : this(int.Parse(parts[1]), int.Parse(parts[2]), UInt16Converter.Parse(parts[3]), UInt16Converter.Parse(parts[4]), UInt16Converter.Parse(parts[5]), UInt16Converter.Parse(parts[6]), UInt16Converter.Parse(parts[7]))
+        {
+        }
+
+        public override bool Contains(int x, int y)
+        {
+            return true;
+        }
+
+        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        {
+            if (IsDisposed)
+            {
+                return false;
+            }
+
+            Vector3 hueVector = ShaderHueTranslator.GetHueVector
+            (
+                Hue,
+                false,
+                Alpha,
+                true
+            );
+
+            var texture = GumpsLoader.Instance.GetGumpTexture(Graphic, out var bounds);
+
+            if (texture != null)
+            {
+                batcher.Draw
+                (
+                    texture,
+                    new Rectangle(x + _SX, y + _SY, Width, Height),
+                    bounds,
+                    hueVector
+                );
+            }
+
+            return base.Draw(batcher, x, y);
+        }
+    }
 }

--- a/src/Game/UI/Controls/GumpPic.cs
+++ b/src/Game/UI/Controls/GumpPic.cs
@@ -185,7 +185,7 @@ namespace ClassicUO.Game.UI.Controls
 
     internal class GumpPicInPic : GumpPicBase
     {
-        private int _SX, _SY;
+        private int _sX, _sY;
 
         public GumpPicInPic(int x, int y, ushort graphic, ushort width, ushort height, ushort sx, ushort sy)
         {
@@ -194,8 +194,8 @@ namespace ClassicUO.Game.UI.Controls
             Graphic = graphic;
             Width = width;
             Height = height;
-            _SX = sx;
-            _SY = sy;
+            _sX = sx;
+            _sY = sy;
             IsFromServer = true;
         }
 
@@ -230,7 +230,7 @@ namespace ClassicUO.Game.UI.Controls
                 batcher.Draw
                 (
                     texture,
-                    new Rectangle(x + _SX, y + _SY, Width, Height),
+                    new Rectangle(x + _sX, y + _sY, Width, Height),
                     bounds,
                     hueVector
                 );

--- a/src/Network/PacketHandlers.cs
+++ b/src/Network/PacketHandlers.cs
@@ -6778,6 +6778,13 @@ namespace ClassicUO.Network
                 {
                     gump.MasterGumpSerial = gparams.Count > 0 ? SerialHelper.Parse(gparams[1]) : 0;
                 }
+                else if (string.Equals(entry, "picinpic", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    if (gparams.Count > 7)
+                    {
+                        gump.Add(new GumpPicInPic(gparams), page);
+                    }
+                }
                 else if (string.Equals(entry, "\0", StringComparison.InvariantCultureIgnoreCase))
                 {
                     //This gump is null terminated: Breaking


### PR DESCRIPTION
This should add the picinpic support for the gumps that are sent by the server.

This follows the issue: https://github.com/ClassicUO/ClassicUO/issues/1595