### PR TITLE
picinpic support for gumps sent by the server.

### DIFF
--- a/src/ClassicUO.Assets/GumpsLoader.cs
+++ b/src/ClassicUO.Assets/GumpsLoader.cs
@@ -172,6 +172,20 @@ namespace ClassicUO.Assets
             return spriteInfo.Texture;
         }
 
+        public Texture2D GetGumpPartialTexture(uint g, Rectangle partialBounds, out Rectangle bounds)
+        {
+            ref var spriteInfo = ref _spriteInfos[g];
+
+            if (spriteInfo.Texture == null)
+            {
+                AddSpriteToAtlas(_atlas, g);
+            }
+
+            bounds = new Rectangle(spriteInfo.UV.X + partialBounds.X, spriteInfo.UV.Y + partialBounds.Y, partialBounds.Width, partialBounds.Height);
+
+            return spriteInfo.Texture;
+        }
+
         private unsafe void AddSpriteToAtlas(TextureAtlas atlas, uint index)
         {
             ref UOFileIndex entry = ref GetValidRefEntry((int)index);

--- a/src/ClassicUO.Client/Game/UI/Controls/GumpPic.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/GumpPic.cs
@@ -182,4 +182,59 @@ namespace ClassicUO.Game.UI.Controls
             return base.Draw(batcher, x, y);
         }
     }
+
+    internal class GumpPicInPic : GumpPicBase
+    {
+        private readonly Rectangle _picInPicBounds;
+        public GumpPicInPic(int x, int y, ushort graphic, ushort sx, ushort sy, ushort width, ushort height)
+        {
+            X = x;
+            Y = y;
+            Graphic = graphic;
+            Width = width;
+            Height = height;
+            _picInPicBounds = new Rectangle(sx, sy, Width, Height);
+            IsFromServer = true;
+        }
+
+        public GumpPicInPic(List<string> parts) : this(int.Parse(parts[1]), int.Parse(parts[2]), UInt16Converter.Parse(parts[3]), UInt16Converter.Parse(parts[4]), UInt16Converter.Parse(parts[5]), UInt16Converter.Parse(parts[6]), UInt16Converter.Parse(parts[7]))
+        {
+        }
+
+        public override bool Contains(int x, int y)
+        {
+            return true;
+        }
+
+        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        {
+            if (IsDisposed)
+            {
+                return false;
+            }
+
+            Vector3 hueVector = ShaderHueTranslator.GetHueVector
+            (
+                Hue,
+                false,
+                Alpha,
+                true
+            );
+
+            var texture = GumpsLoader.Instance.GetGumpPartialTexture(Graphic, _picInPicBounds, out var bounds);
+
+            if (texture != null)
+            {
+                batcher.Draw
+                (
+                    texture,
+                    new Rectangle(x, y, Width, Height),
+                    bounds,
+                    hueVector
+                );
+            }
+
+            return base.Draw(batcher, x, y);
+        }
+    }
 }

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -6885,6 +6885,13 @@ namespace ClassicUO.Network
                 {
                     gump.MasterGumpSerial = gparams.Count > 0 ? SerialHelper.Parse(gparams[1]) : 0;
                 }
+                else if (string.Equals(entry, "picinpic", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    if (gparams.Count > 7)
+                    {
+                        gump.Add(new GumpPicInPic(gparams), page);
+                    }
+                }
                 else if (string.Equals(entry, "\0", StringComparison.InvariantCultureIgnoreCase))
                 {
                     //This gump is null terminated: Breaking


### PR DESCRIPTION
This should add the picinpic support for the gumps that are sent by the server.

This follows the issue: [https://github.com/ClassicUO/ClassicUO/issues/1595](https://github.com/ClassicUO/ClassicUO/issues/1595)

Thank you @SaschaKP for pointing me in the right direction.