### PR TITLE
The order in which items are shown in grid-loot will now depend on item type or its parameters.

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
@@ -222,36 +222,44 @@ namespace ClassicUO.Game.UI.Gumps
             int line = 1;
             int row = 0;
 
-            for (LinkedObject i = _corpse.Items; i != null; i = i.Next)
+            for (int displayGroup = 0; displayGroup < 2; displayGroup++)
             {
-                Item it = (Item) i;
-
-                if (it.IsLootable)
+                for (LinkedObject i = _corpse.Items; i != null; i = i.Next)
                 {
-                    GridLootItem gridItem = new GridLootItem(it, GRID_ITEM_SIZE);
+                    Item it = (Item)i;
 
-                    if (x >= MAX_WIDTH - 20)
+                    if (!ItemBelongsToGroup(it, displayGroup))
                     {
-                        x = 20;
-                        ++line;
-
-                        y += gridItem.Height + 20;
-
-                        if (y >= MAX_HEIGHT - 60)
-                        {
-                            _pagesCount++;
-                            y = 20;
-                            //line = 1;
-                        }
+                        continue;
                     }
 
-                    gridItem.X = x;
-                    gridItem.Y = y + 20;
-                    Add(gridItem, _pagesCount);
+                    if (it.IsLootable)
+                    {
+                        GridLootItem gridItem = new GridLootItem(it, GRID_ITEM_SIZE);
 
-                    x += gridItem.Width + 20;
-                    ++row;
-                    ++count;
+                        if (x >= MAX_WIDTH - 20)
+                        {
+                            x = 20;
+                            ++line;
+
+                            y += gridItem.Height + 20;
+
+                            if (y >= MAX_HEIGHT - 60)
+                            {
+                                _pagesCount++;
+                                y = 20;
+                                //line = 1;
+                            }
+                        }
+
+                        gridItem.X = x;
+                        gridItem.Y = y + 20;
+                        Add(gridItem, _pagesCount);
+
+                        x += gridItem.Width + 20;
+                        ++row;
+                        ++count;
+                    }
                 }
             }
 
@@ -295,6 +303,14 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
+        private bool ItemBelongsToGroup(Item it, int group)
+        {
+            // Note: items must be assigned to groups in a mutually-exclusive manner, so that each item occurs only once in the grid
+            if (it.ItemData.IsStackable)
+                return group > 0;
+            else
+                return group == 0;
+        }
         public override void Dispose()
         {
             if (_corpse != null)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
@@ -228,38 +228,35 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     Item it = (Item)i;
 
-                    if (!ItemBelongsToGroup(it, displayGroup))
+                    if (!ItemBelongsToGroup(it, displayGroup) || !it.IsLootable)
                     {
                         continue;
                     }
 
-                    if (it.IsLootable)
+                    GridLootItem gridItem = new GridLootItem(it, GRID_ITEM_SIZE);
+
+                    if (x >= MAX_WIDTH - 20)
                     {
-                        GridLootItem gridItem = new GridLootItem(it, GRID_ITEM_SIZE);
+                        x = 20;
+                        ++line;
 
-                        if (x >= MAX_WIDTH - 20)
+                        y += gridItem.Height + 20;
+
+                        if (y >= MAX_HEIGHT - 60)
                         {
-                            x = 20;
-                            ++line;
-
-                            y += gridItem.Height + 20;
-
-                            if (y >= MAX_HEIGHT - 60)
-                            {
-                                _pagesCount++;
-                                y = 20;
-                                //line = 1;
-                            }
+                            _pagesCount++;
+                            y = 20;
+                            //line = 1;
                         }
-
-                        gridItem.X = x;
-                        gridItem.Y = y + 20;
-                        Add(gridItem, _pagesCount);
-
-                        x += gridItem.Width + 20;
-                        ++row;
-                        ++count;
                     }
+
+                    gridItem.X = x;
+                    gridItem.Y = y + 20;
+                    Add(gridItem, _pagesCount);
+
+                    x += gridItem.Width + 20;
+                    ++row;
+                    ++count;
                 }
             }
 
@@ -311,6 +308,7 @@ namespace ClassicUO.Game.UI.Gumps
             else
                 return group == 0;
         }
+
         public override void Dispose()
         {
             if (_corpse != null)


### PR DESCRIPTION
Motivation: some items are likely to be always looted (e.g. gold, gems) and when looting is performed (usually automatically e.g. by Razor macros, but also manually by other players) it makes other items to move in a grid making it harder to browse their properties. Hence, items like gold should be at the end of the grid. Stackable items have no custom properties, so displaying them at the bottom of the grid is beneficial for players: it is more convenient to browse the loot and allows saving the time.