### PR TITLE
Allow targeting the world map for positional targets

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -333,6 +333,7 @@ namespace ClassicUO.Configuration
         public string WorldMapHiddenMarkerFiles { get; set; } = string.Empty;
         public string WorldMapHiddenZoneFiles { get; set; } = string.Empty;
         public bool WorldMapShowGridIfZoomed { get; set; } = true;
+        public bool WorldMapAllowPositionalTarget { get; set; } = false;
 
 
         public static uint GumpsVersion { get; private set; }

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -214,6 +214,15 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow Positional Targeting.
+        /// </summary>
+        public static string AllowPositionalTargeting {
+            get {
+                return ResourceManager.GetString("AllowPositionalTargeting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hold ALT key + right click to close Anchored gumps.
         /// </summary>
         public static string AltCloseGumps {

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1570,6 +1570,9 @@ Client version: '{0}'</value>
   <data name="ShowMouseCoordinates" xml:space="preserve">
     <value>Show mouse coordinates</value>
   </data>
+  <data name="AllowPositionalTargeting" xml:space="preserve">
+    <value>Allow Positional Targeting</value>
+  </data>
   <data name="LightLevelType" xml:space="preserve">
     <value>Light Level Setting Type</value>
   </data>


### PR DESCRIPTION
Basically it's really nice for shard owners to be able to teleport around the map easily, or do bounding boxes.

It could just only be an option for playermobiles with a higher access level, but I added it as an option that defaults to off.