### PR TITLE
Don't render ":" in journal if sender is empty

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/JournalManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalManager.cs
@@ -86,7 +86,14 @@ namespace ClassicUO.Game.Managers
                 CreateWriter();
             }
 
-            _fileWriter?.WriteLine($"[{timeNow:G}]  {name}: {text}");
+            string output = $"[{timeNow:G}]  {name}: {text}";
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                output = $"[{timeNow:G}]  {text}";
+            }
+
+            _fileWriter?.WriteLine(output);
         }
 
         private void CreateWriter()

--- a/src/ClassicUO.Client/Game/UI/Gumps/JournalGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/JournalGump.cs
@@ -304,6 +304,11 @@ namespace ClassicUO.Game.UI.Gumps
 
             string text = $"{usrSend}: {entry.Text}";
 
+            if (string.IsNullOrEmpty(usrSend))
+            {
+                text = entry.Text;
+            }
+
             _journalEntries.AddEntry
             (
                 text,


### PR DESCRIPTION
This
![image](https://github.com/ClassicUO/ClassicUO/assets/43113499/b9ed6bb0-4c29-49b0-b8c8-e210dcf022e5)


instead of this:
![image](https://github.com/ClassicUO/ClassicUO/assets/43113499/78ff7d54-15a2-46f2-aee2-bcac1bb4a2e4)


also fixed in journal log