### PR TITLE
Paperdoll equipment slot double click fix

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
@@ -772,7 +772,7 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     Item it_at_layer = mobile.FindItemByLayer(Layer);
 
-                    if (item != it_at_layer || _itemGump == null)
+                    if ((it_at_layer != null && _itemGump != null && _itemGump.Graphic != it_at_layer.DisplayedGraphic) || _itemGump == null)
                     {
                         if (_itemGump != null)
                         {


### PR DESCRIPTION
If you have an item equipped and you dclick another item to equip it in the same slot, the paperdoll equipment slot graphic is not updated. This commit fix the problem.
Tested with Sphere X server