### PR TITLE
Fix Server Ping in Server List

### DIFF
--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -919,6 +919,7 @@ namespace ClassicUO.Game.Scenes
     internal class ServerListEntry
     {
         private IPAddress _ipAddress;
+        private IPAddress _ipAddressLittleEndian;
         private Ping _pinger = new Ping();
         private bool _sending;
         private readonly bool[] _last10Results = new bool[10];
@@ -952,6 +953,19 @@ namespace ClassicUO.Game.Scenes
                         (byte) (entry.Address & 0xFF)
                     }
                 );
+
+                // IP address in little-endian format, required for server ping
+                entry._ipAddressLittleEndian = new IPAddress
+                (
+                    new byte[]
+                    {
+                        (byte) (entry.Address & 0xFF),
+                        (byte) ((entry.Address >> 8) & 0xFF),
+                        (byte) ((entry.Address >> 16) & 0xFF),
+                        (byte) ((entry.Address >> 24) & 0xFF)
+                    }
+                );
+                
             }
             catch (Exception e)
             {
@@ -989,7 +1003,7 @@ namespace ClassicUO.Game.Scenes
                 {
                     _pinger.SendAsync
                     (
-                        _ipAddress,
+                        _ipAddressLittleEndian,
                         1000,
                         _buffData,
                         _pingOptions,


### PR DESCRIPTION
The System.Net.NetworkInformation.Ping class requires the IP address in little-endian format. Previously, it was passed in big-endian format (IP address in reverse order. 1.2.3.4 became 4.3.2.1). As a result, the servers were never pinged correctly. To save the IP address in the correct order in _ipAddress, the byte order must be reversed so that the least significant byte (LSB) comes first.