### PR TITLE
Fix BuffDebuff packet parsing

### DIFF
--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -5529,8 +5529,8 @@ namespace ClassicUO.Network
                         uint wtfCliloc = p.ReadUInt32BE();
 
                         ushort arg_length = p.ReadUInt16BE();
-                        p.Skip(4);
-                        string args = p.ReadUnicodeLE();
+                        var str = p.ReadUnicodeLE(2);
+                        var args = str + p.ReadUnicodeLE();
                         string title = ClilocLoader.Instance.Translate(
                             (int)titleCliloc,
                             args,


### PR DESCRIPTION
Correctly parse buff packet with cliloc args in title, on parity with OSI client.