### PR TITLE
Fix race condition when handling plugins packets

### DIFF
--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -365,8 +365,10 @@ namespace ClassicUO
             Mouse.Update();
 
             var data = NetClient.Socket.CollectAvailableData();
-            var packetsCount = PacketHandlers.Handler.ParsePackets(UO.World, data);
-
+            int packetsCount = 0;
+            lock(PacketHandlers.Handler) {
+                packetsCount = PacketHandlers.Handler.ParsePackets(UO.World, data);
+            }
             NetClient.Socket.Statistics.TotalPacketsReceived += (uint)packetsCount;
             NetClient.Socket.Flush();
 


### PR DESCRIPTION
There's a race condition in the access of the packets CircularBuffers, between the render thread, which reads the packets from the Server->Client buffer, the Plugin->Client buffer and the Plugins thread which can enqueue new packets to be read by the Client.

Add a lock of the Handler in the render thread.

Fixes #1665
Fixes #1618 


I've tested this change for a couple of weeks and honestly I only saw an improvement in stability when using scripts or hotkeys in Razor Enhanced.
I double checked again and it should be all its necessary.

NOTE: It should also fix the sporadic error in https://github.com/ClassicUO/ClassicUO/issues/1616, which seems to be caused by the Client reading garbage packet data and interpreting map sizes incorrectly.
I think there can be a change made to put a limit in what a packet can say the map size is, to avoid even trying to allocate such a big Texture, which is why I wasn't sure if it made sense to include that in the fixed issues.

NOTE2: While the fix works, I think in the future an improvement can be made to the API to avoid locking the CircularBuffer here:
https://github.com/ClassicUO/ClassicUO/blob/fe11d90b84d77420bc59a82c50a7c01c113d0df2/src/ClassicUO.Client/Network/PacketHandlers.cs#L98
and the Handler, because one of the two seems redundant if we reorder where the locks are put.
Ideally we would lock only the CircularBuffer, not the whole Handler.