### PR TITLE
Fix race condition when handling plugins packets

### DIFF
--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -157,7 +157,20 @@ namespace ClassicUO.Network
             if (data.IsEmpty)
                 return;
 
-            (fromPlugins ? _pluginsBuffer : _buffer).Enqueue(data);
+            if (fromPlugins)
+            {
+                lock (_pluginsBuffer)
+                {
+                    _pluginsBuffer.Enqueue(data);
+                }
+            }
+            else
+            {
+                lock (_buffer)
+                {
+                    _buffer.Enqueue(data);
+                }
+            }
         }
 
         private void AnalyzePacket(World world, ReadOnlySpan<byte> data, int offset)

--- a/src/ClassicUO.Client/Network/Plugin.cs
+++ b/src/ClassicUO.Client/Network/Plugin.cs
@@ -785,10 +785,7 @@ namespace ClassicUO.Network
 
         internal static bool OnPluginRecv(ref byte[] data, ref int length)
         {
-            lock (PacketHandlers.Handler)
-            {
-                PacketHandlers.Handler.Append(data.AsSpan(0, length), true);
-            }
+            PacketHandlers.Handler.Append(data.AsSpan(0, length), true);
 
             return true;
         }


### PR DESCRIPTION
There's a race condition in the access of the packets CircularBuffers, between the render thread, which reads the packets from the Server->Client buffer, the Plugin->Client buffer and the Plugins thread which can enqueue new packets to be read by the Client.

Add a lock when appending data to each of the receiving buffers. Remove the lock to the packet handler when the plugin appends new packets.

Fixes #1665
Fixes #1618

This is the second attempt, more info also at https://github.com/ClassicUO/ClassicUO/pull/1670