### PR TITLE
Centralised intermediate and binary folders

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,4 +36,10 @@
     </PackageReference>
   </ItemGroup>
 
+<!-- Put all intermediate and binary files under same appropriate folder, not mixed in with source. -->
+  <PropertyGroup>
+    <OutputPath >$(SolutionDir)bin\$(Configuration)</OutputPath>
+    <BaseIntermediateOutputPath>$(SolutionDir)intermediate\$(Platform)\$(Configuration)\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+  </PropertyGroup>
+  
 </Project>


### PR DESCRIPTION
Moved files created during build to be under intermediate folder to keep out of source directories (source files only). Same for binaries to go under bin in root.