### PR TITLE
Add WebSocket connection support

### DIFF
--- a/src/ClassicUO.Client/Configuration/Settings.cs
+++ b/src/ClassicUO.Client/Configuration/Settings.cs
@@ -66,6 +66,11 @@ namespace ClassicUO.Configuration
         [JsonPropertyName("ip")] public string IP { get; set; } = "127.0.0.1";
 
         [JsonPropertyName("port"), JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)] public ushort Port { get; set; } = 2593;
+        
+        /**
+         * Ignores the login servers relay packet, connects back with the settings IP
+         */
+        [JsonPropertyName("ignore_relay_ip")] public bool IgnoreRelayIp { get; set; } = true;
 
         [JsonPropertyName("ultimaonlinedirectory")] public string UltimaOnlineDirectory { get; set; } = "";
 

--- a/src/ClassicUO.Client/Configuration/Settings.cs
+++ b/src/ClassicUO.Client/Configuration/Settings.cs
@@ -70,7 +70,7 @@ namespace ClassicUO.Configuration
         /**
          * Ignores the login servers relay packet, connects back with the settings IP
          */
-        [JsonPropertyName("ignore_relay_ip")] public bool IgnoreRelayIp { get; set; } = true;
+        [JsonPropertyName("ignore_relay_ip")] public bool IgnoreRelayIp { get; set; } = false;
 
         [JsonPropertyName("ultimaonlinedirectory")] public string UltimaOnlineDirectory { get; set; } = "";
 

--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -683,7 +683,15 @@ namespace ClassicUO.Game.Scenes
             uint seed = p.ReadUInt32BE();
 
             NetClient.Socket.Disconnect();
-            NetClient.Socket.Connect(new IPAddress(ip).ToString(), port);
+
+            // Ignore the packet, connect with the original IP regardless (i.e. websocket proxying)
+            if (Settings.GlobalSettings.IgnoreRelayIp || ip == 0)
+            {
+                Log.Trace("Ignoring relay server packet IP address");
+                NetClient.Socket.Connect(Settings.GlobalSettings.IP, Settings.GlobalSettings.Port);
+            }
+            else
+                NetClient.Socket.Connect(new IPAddress(ip).ToString(), port);
 
             if (NetClient.Socket.IsConnected)
             {

--- a/src/ClassicUO.Client/Network/NetClient.cs
+++ b/src/ClassicUO.Client/Network/NetClient.cs
@@ -160,7 +160,7 @@ namespace ClassicUO.Network
             var addr = $"{(IsWebsocketAddress(ip) ? "" : "tcp://")}{ip}:{port}";
             if (!Uri.TryCreate(addr, UriKind.RelativeOrAbsolute, out var uri))
             {
-                throw new UriFormatException($" NetClient::Connect() invalid Uri {addr}");
+                throw new UriFormatException($"NetClient::Connect() invalid Uri {addr}");
             }
             
             Log.Trace($"Connecting to {uri}");

--- a/src/ClassicUO.Client/Network/NetClient.cs
+++ b/src/ClassicUO.Client/Network/NetClient.cs
@@ -64,9 +64,6 @@ namespace ClassicUO.Network
 
         public static NetClient Socket { get; private set; } = new();
 
-        public static bool IsWebsocketAddress(string ip) => ip.ToLowerInvariant().Substring(0, 2) is "ws" or "wss";
-
-
         public EncryptionType Load(ClientVersion clientVersion, EncryptionType encryption)
         {
             PacketsTable = new PacketsTable(clientVersion);
@@ -157,17 +154,17 @@ namespace ClassicUO.Network
             Statistics.Reset();
 
 
-            var addr = $"{(IsWebsocketAddress(ip) ? "" : "tcp://")}{ip}:{port}";
+            var isWebsocketAddress = ip.ToLowerInvariant().Substring(0, 2) is "ws" or "wss";
+            var addr = $"{(isWebsocketAddress ? "" : "tcp://")}{ip}:{port}";
+            
             if (!Uri.TryCreate(addr, UriKind.RelativeOrAbsolute, out var uri))
-            {
                 throw new UriFormatException($"NetClient::Connect() invalid Uri {addr}");
-            }
             
             Log.Trace($"Connecting to {uri}");
 
             // First connected socket sets the type for any future sockets.
             // This prevents the client from swapping from WS -> TCP on game server login
-            SetupSocket(_socketType ??= uri.Scheme is "ws" or "wss" ? SocketWrapperType.WebSocket : SocketWrapperType.TcpSocket);
+            SetupSocket(_socketType ??= isWebsocketAddress ? SocketWrapperType.WebSocket : SocketWrapperType.TcpSocket);
             _socket.Connect(uri);
         }
 

--- a/src/ClassicUO.Client/Network/NetClient.cs
+++ b/src/ClassicUO.Client/Network/NetClient.cs
@@ -36,100 +36,11 @@ using ClassicUO.Utility.Logging;
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Net.WebSockets;
+using ClassicUO.Network.Socket;
 
 namespace ClassicUO.Network
 {
-    sealed class SocketWrapper : IDisposable
-    {
-        private TcpClient _socket;
-
-        public bool IsConnected => _socket?.Client?.Connected ?? false;
-
-        public EndPoint LocalEndPoint => _socket?.Client?.LocalEndPoint;
-
-
-        public event EventHandler OnConnected, OnDisconnected;
-        public event EventHandler<SocketError> OnError;
-
-
-        public void Connect(string ip, int port)
-        {
-            if (IsConnected) return;
-
-            _socket = new TcpClient();
-            _socket.NoDelay = true;
-
-            try
-            {
-                _socket.Connect(ip, port);
-
-                if (!IsConnected)
-                {
-                    OnError?.Invoke(this, SocketError.NotConnected);
-                    return;
-                }
-
-                OnConnected?.Invoke(this, EventArgs.Empty);
-            }
-            catch (SocketException socketEx)
-            {
-                Log.Error($"error while connecting {socketEx}");
-                OnError?.Invoke(this, socketEx.SocketErrorCode);
-            }
-            catch (Exception ex)
-            {
-                Log.Error($"error while connecting {ex}");
-                OnError?.Invoke(this, SocketError.SocketError);
-            }
-        }
-
-        public void Send(byte[] buffer, int offset, int count)
-        {
-            var stream = _socket.GetStream();
-            stream.Write(buffer, offset, count);
-            stream.Flush();
-        }
-
-        public int Read(byte[] buffer)
-        {
-            if (!IsConnected) return 0;
-
-            var available = Math.Min(buffer.Length, _socket.Available);
-            var done = 0;
-
-            var stream = _socket.GetStream();
-
-            while (done < available)
-            {
-                var toRead = Math.Min(buffer.Length, available - done);
-                var read = stream.Read(buffer, done, toRead);
-
-                if (read <= 0)
-                {
-                    OnDisconnected?.Invoke(this, EventArgs.Empty);
-                    Disconnect();
-
-                    return 0;
-                }
-
-                done += read;
-            }
-
-            return done;
-        }
-
-        public void Disconnect()
-        {
-            _socket?.Close();
-            Dispose();
-        }
-
-        public void Dispose()
-        {
-            _socket?.Dispose();
-        }
-    }
-
     internal sealed class NetClient
     {
         private const int BUFF_SIZE = 0x10000;
@@ -139,28 +50,22 @@ namespace ClassicUO.Network
         private readonly byte[] _sendingBuffer = new byte[4096];
         private readonly Huffman _huffman = new Huffman();
         private bool _isCompressionEnabled;
-        private readonly SocketWrapper _socket;
         private uint? _localIP;
         private readonly CircularBuffer _sendStream;
+        private SocketWrapper _socket = null;
+        private SocketWrapperType? _socketType;
 
 
         public NetClient()
         {
             Statistics = new NetStatistics(this);
             _sendStream = new CircularBuffer();
-
-            _socket = new SocketWrapper();
-            _socket.OnConnected += (o, e) =>
-            {
-                Statistics.Reset();
-                Connected?.Invoke(this, EventArgs.Empty);
-            };
-            _socket.OnDisconnected += (o, e) => Disconnected?.Invoke(this, SocketError.Success);
-            _socket.OnError += (o, e) => Disconnected?.Invoke(this, SocketError.SocketError);
         }
 
+        public static NetClient Socket { get; private set; } = new();
 
-        public static NetClient Socket { get; private set; } = new NetClient();
+        public static bool IsWebsocketAddress(string ip) => ip.ToLowerInvariant().Substring(0, 2) is "ws" or "wss";
+
 
         public EncryptionType Load(ClientVersion clientVersion, EncryptionType encryption)
         {
@@ -224,6 +129,26 @@ namespace ClassicUO.Network
         public event EventHandler Connected;
         public event EventHandler<SocketError> Disconnected;
 
+        private void SetupSocket(SocketWrapperType wrapperType)
+        {
+            _socket?.Dispose();
+
+            _socket = wrapperType switch
+            {
+                SocketWrapperType.TcpSocket => new TcpSocketWrapper(),
+                SocketWrapperType.WebSocket => new WebSocketWrapper(),
+                _ => throw new ArgumentOutOfRangeException(nameof(wrapperType), wrapperType, null)
+            };
+
+            _socket.OnConnected += (o, e) =>
+            {
+                Statistics.Reset();
+                Connected?.Invoke(this, EventArgs.Empty);
+            };
+
+            _socket.OnDisconnected += (_, _) => Disconnected?.Invoke(this, SocketError.Success);
+            _socket.OnError += (_, e) => Disconnected?.Invoke(this, e);
+        }
 
         public void Connect(string ip, ushort port)
         {
@@ -231,7 +156,19 @@ namespace ClassicUO.Network
             _huffman.Reset();
             Statistics.Reset();
 
-            _socket.Connect(ip, port);
+
+            var addr = $"{(IsWebsocketAddress(ip) ? "" : "tcp://")}{ip}:{port}";
+            if (!Uri.TryCreate(addr, UriKind.RelativeOrAbsolute, out var uri))
+            {
+                throw new UriFormatException($" NetClient::Connect() invalid Uri {addr}");
+            }
+            
+            Log.Trace($"Connecting to {uri}");
+
+            // First connected socket sets the type for any future sockets.
+            // This prevents the client from swapping from WS -> TCP on game server login
+            SetupSocket(_socketType ??= uri.Scheme is "ws" or "wss" ? SocketWrapperType.WebSocket : SocketWrapperType.TcpSocket);
+            _socket.Connect(uri);
         }
 
         public void Disconnect()
@@ -248,8 +185,14 @@ namespace ClassicUO.Network
             _sendStream.Clear();
         }
 
+
         public ArraySegment<byte> CollectAvailableData()
         {
+            if (_socket == null)
+            {
+                return ArraySegment<byte>.Empty;
+            }
+            
             try
             {
                 var size = _socket.Read(_compressedBuffer);
@@ -317,7 +260,8 @@ namespace ClassicUO.Network
                 return;
             }
 
-            if (message.IsEmpty) return;
+            if (message.IsEmpty)
+                return;
 
             PacketLogger.Default?.Log(message, true);
 
@@ -338,14 +282,16 @@ namespace ClassicUO.Network
 
         private void ProcessEncryption(Span<byte> buffer)
         {
-            if (!_isCompressionEnabled) return;
+            if (!_isCompressionEnabled)
+                return;
 
             Encryption?.Decrypt(buffer, buffer, buffer.Length);
         }
 
         private void ProcessSend()
         {
-            if (!IsConnected) return;
+            if (!IsConnected)
+                return;
 
             try
             {
@@ -354,6 +300,7 @@ namespace ClassicUO.Network
                     while (_sendStream.Length > 0)
                     {
                         var read = _sendStream.Dequeue(_sendingBuffer, 0, _sendingBuffer.Length);
+
                         if (read <= 0)
                         {
                             break;
@@ -398,6 +345,7 @@ namespace ClassicUO.Network
                 return buffer;
 
             var size = 65536;
+
             if (!_huffman.Decompress(buffer, _uncompressedBuffer, ref size))
             {
                 Disconnect();

--- a/src/ClassicUO.Client/Network/NetClient.cs
+++ b/src/ClassicUO.Client/Network/NetClient.cs
@@ -153,6 +153,8 @@ namespace ClassicUO.Network
             _huffman.Reset();
             Statistics.Reset();
 
+            if (string.IsNullOrEmpty(ip))
+                throw new ArgumentNullException(nameof(ip));
 
             var isWebsocketAddress = ip.ToLowerInvariant().Substring(0, 2) is "ws" or "wss";
             var addr = $"{(isWebsocketAddress ? "" : "tcp://")}{ip}:{port}";

--- a/src/ClassicUO.Client/Network/Socket/SocketWrapper.cs
+++ b/src/ClassicUO.Client/Network/Socket/SocketWrapper.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using ClassicUO.Utility.Logging;
+using System.Net.WebSockets;
+
+
+namespace ClassicUO.Network.Socket;
+
+public enum SocketWrapperType
+{
+    TcpSocket,
+    WebSocket
+}
+
+abstract class SocketWrapper : IDisposable
+{
+    public abstract bool IsConnected { get; }
+
+    public abstract EndPoint LocalEndPoint { get; }
+
+
+    public event EventHandler OnConnected, OnDisconnected;
+    public event EventHandler<SocketError> OnError;
+
+
+    public abstract void Connect(Uri uri);
+    public abstract void Send(byte[] buffer, int offset, int count);
+
+    public abstract int Read(byte[] buffer);
+
+    public abstract void Disconnect();
+
+    public abstract void Dispose();
+
+    protected virtual void InvokeOnConnected()
+    {
+        OnConnected?.Invoke(this, EventArgs.Empty);
+    }
+
+    protected virtual void InvokeOnDisconnected()
+    {
+        OnDisconnected?.Invoke(this, EventArgs.Empty);
+    }
+
+    protected virtual void InvokeOnError(SocketError e)
+    {
+        OnError?.Invoke(this, e);
+    }
+}

--- a/src/ClassicUO.Client/Network/Socket/SocketWrapper.cs
+++ b/src/ClassicUO.Client/Network/Socket/SocketWrapper.cs
@@ -4,7 +4,6 @@ using System.Net.Sockets;
 using ClassicUO.Utility.Logging;
 using System.Net.WebSockets;
 
-
 namespace ClassicUO.Network.Socket;
 
 public enum SocketWrapperType

--- a/src/ClassicUO.Client/Network/Socket/TcpSocketWrapper.cs
+++ b/src/ClassicUO.Client/Network/Socket/TcpSocketWrapper.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Net.Sockets;
 using ClassicUO.Utility.Logging;
 
-
 namespace ClassicUO.Network.Socket;
 
 sealed class TcpSocketWrapper : SocketWrapper
@@ -17,7 +16,8 @@ sealed class TcpSocketWrapper : SocketWrapper
 
     public override void Connect(Uri uri)
     {
-        if (IsConnected) return;
+        if (IsConnected)
+            return;
 
         _socket = new TcpClient();
         _socket.NoDelay = true;
@@ -29,6 +29,7 @@ sealed class TcpSocketWrapper : SocketWrapper
             if (!IsConnected)
             {
                 InvokeOnError(SocketError.NotConnected);
+
                 return;
             }
 
@@ -37,12 +38,12 @@ sealed class TcpSocketWrapper : SocketWrapper
         catch (SocketException socketEx)
         {
             Log.Error($"error while connecting {socketEx}");
-            InvokeOnError( socketEx.SocketErrorCode);
+            InvokeOnError(socketEx.SocketErrorCode);
         }
         catch (Exception ex)
         {
             Log.Error($"error while connecting {ex}");
-            InvokeOnError( SocketError.SocketError);
+            InvokeOnError(SocketError.SocketError);
         }
     }
 
@@ -55,7 +56,8 @@ sealed class TcpSocketWrapper : SocketWrapper
 
     public override int Read(byte[] buffer)
     {
-        if (!IsConnected) return 0;
+        if (!IsConnected)
+            return 0;
 
         var available = Math.Min(buffer.Length, _socket.Available);
         var done = 0;

--- a/src/ClassicUO.Client/Network/Socket/TcpSocketWrapper.cs
+++ b/src/ClassicUO.Client/Network/Socket/TcpSocketWrapper.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using ClassicUO.Utility.Logging;
+
+
+namespace ClassicUO.Network.Socket;
+
+sealed class TcpSocketWrapper : SocketWrapper
+{
+    private TcpClient _socket;
+
+    public override bool IsConnected => _socket?.Client?.Connected ?? false;
+
+    public override EndPoint LocalEndPoint => _socket?.Client?.LocalEndPoint;
+
+
+    public override void Connect(Uri uri)
+    {
+        if (IsConnected) return;
+
+        _socket = new TcpClient();
+        _socket.NoDelay = true;
+
+        try
+        {
+            _socket.Connect(uri.Host, uri.Port);
+
+            if (!IsConnected)
+            {
+                InvokeOnError(SocketError.NotConnected);
+                return;
+            }
+
+            InvokeOnConnected();
+        }
+        catch (SocketException socketEx)
+        {
+            Log.Error($"error while connecting {socketEx}");
+            InvokeOnError( socketEx.SocketErrorCode);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"error while connecting {ex}");
+            InvokeOnError( SocketError.SocketError);
+        }
+    }
+
+    public override void Send(byte[] buffer, int offset, int count)
+    {
+        var stream = _socket.GetStream();
+        stream.Write(buffer, offset, count);
+        stream.Flush();
+    }
+
+    public override int Read(byte[] buffer)
+    {
+        if (!IsConnected) return 0;
+
+        var available = Math.Min(buffer.Length, _socket.Available);
+        var done = 0;
+
+        var stream = _socket.GetStream();
+
+        while (done < available)
+        {
+            var toRead = Math.Min(buffer.Length, available - done);
+            var read = stream.Read(buffer, done, toRead);
+
+            if (read <= 0)
+            {
+                InvokeOnDisconnected();
+                Disconnect();
+
+                return 0;
+            }
+
+            done += read;
+        }
+
+        return done;
+    }
+
+    public override void Disconnect()
+    {
+        _socket?.Close();
+        Dispose();
+    }
+
+    public override void Dispose()
+    {
+        _socket?.Dispose();
+    }
+}

--- a/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
+++ b/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
@@ -11,17 +11,21 @@ using static System.Buffers.ArrayPool<byte>;
 
 namespace ClassicUO.Network.Socket;
 
+/// <summary>
+/// Handles websocket connections to shards that support it. `ws(s)://[hostname]` as the ip in settings.json.
+/// For testing see `tools/ws/README.md` 
+/// </summary>
 sealed class WebSocketWrapper : SocketWrapper
 {
     private const int MAX_RECEIVE_BUFFER_SIZE = 1024 * 1024; // 1MB
-    private const int WS_KEEP_ALIVE_INTERVAL = 5; // seconds
-    
+    private const int WS_KEEP_ALIVE_INTERVAL = 5;            // seconds
+
     private ClientWebSocket _webSocket;
     private TcpSocket _rawSocket;
 
     public override bool IsConnected => _webSocket?.State is WebSocketState.Connecting or WebSocketState.Open;
-    public bool IsCanceled => _tokenSource.IsCancellationRequested;
     public override EndPoint LocalEndPoint => _rawSocket?.LocalEndPoint;
+    public bool IsCanceled => _tokenSource.IsCancellationRequested;
 
     private CancellationTokenSource _tokenSource = new();
     private CircularBuffer _circularBuffer;

--- a/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
+++ b/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassicUO.Utility.Logging;
+using TcpSocket = System.Net.Sockets.Socket;
+using static System.Buffers.ArrayPool<byte>;
+
+namespace ClassicUO.Network.Socket;
+
+sealed class WebSocketWrapper : SocketWrapper
+{
+    private const int MAX_RECEIVE_BUFFER_SIZE = 1024 * 1024; // 1MB
+    private const int WS_KEEP_ALIVE_INTERVAL = 5; // seconds
+    
+    private ClientWebSocket _webSocket;
+    private TcpSocket _rawSocket;
+
+    public override bool IsConnected => _webSocket?.State is WebSocketState.Connecting or WebSocketState.Open;
+    public bool IsCanceled => _tokenSource.IsCancellationRequested;
+    public override EndPoint LocalEndPoint => _rawSocket?.LocalEndPoint;
+
+    private CancellationTokenSource _tokenSource = new();
+    private CircularBuffer _circularBuffer;
+
+    public override void Connect(Uri uri) => ConnectAsync(uri, _tokenSource).Wait();
+
+    public override void Send(byte[] buffer, int offset, int count) =>
+        _webSocket.SendAsync(buffer.AsMemory().Slice(offset, count), WebSocketMessageType.Binary, true, _tokenSource.Token);
+
+    public override int Read(byte[] buffer) => _circularBuffer.Dequeue(buffer, 0, buffer.Length);
+
+    public async Task ConnectAsync(Uri uri, CancellationTokenSource tokenSource = null)
+    {
+        if (IsConnected)
+            return;
+
+        _tokenSource = tokenSource ?? new CancellationTokenSource();
+        _circularBuffer = new CircularBuffer();
+
+        try
+        {
+            await ConnectWebSocketAsyncCore(uri);
+
+            if (IsConnected)
+                InvokeOnConnected();
+            else
+                InvokeOnError(SocketError.NotConnected);
+        }
+        catch (WebSocketException ex)
+        {
+            SocketError error = ex.InnerException?.InnerException switch
+            {
+                SocketException socketException => socketException.SocketErrorCode,
+                _ => SocketError.SocketError
+            };
+
+            Log.Error($"Error {ex.GetType().Name} {error} while connecting to {uri} {ex}");
+            InvokeOnError(error);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Unknown Error {ex.GetType().Name} while connecting to {uri} {ex}");
+            InvokeOnError(SocketError.SocketError);
+        }
+    }
+
+
+    private async Task ConnectWebSocketAsyncCore(Uri uri)
+    {
+        // Take control of creating the raw socket, turn off Nagle, also lets us peek at `Available` bytes.
+        _rawSocket = new TcpSocket(SocketType.Stream, ProtocolType.Tcp)
+        {
+            NoDelay = true
+        };
+
+        _webSocket = new ClientWebSocket();
+        _webSocket.Options.KeepAliveInterval = TimeSpan.FromSeconds(WS_KEEP_ALIVE_INTERVAL); // ping/pong
+
+        using var httpClient = new HttpClient
+        (
+            new SocketsHttpHandler
+            {
+                ConnectCallback = async (context, token) =>
+                {
+                    try
+                    {
+                        await _rawSocket.ConnectAsync(context.DnsEndPoint, token);
+
+                        return new NetworkStream(_rawSocket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        _rawSocket?.Dispose();
+                        _rawSocket = null;
+                        _webSocket?.Dispose();
+                        _webSocket = null;
+
+                        throw;
+                    }
+                }
+            }
+        );
+
+
+        await _webSocket.ConnectAsync(uri, httpClient, _tokenSource.Token);
+
+        Log.Trace($"Connected WebSocket: {uri}");
+
+        // Kicks off the async receiving loop 
+        StartReceiveAsync();
+    }
+
+    private async Task StartReceiveAsync()
+    {
+        var buffer = Shared.Rent(4096);
+        var memory = buffer.AsMemory();
+        var position = 0;
+
+        try
+        {
+            while (IsConnected)
+            {
+                GrowReceiveBufferIfNeeded(ref buffer, ref memory);
+
+                var receiveResult = await _webSocket.ReceiveAsync(memory.Slice(position), _tokenSource.Token);
+
+                // Ignoring message types:
+                // 1. WebSocketMessageType.Text: shouldn't be sent by the server, though might be useful for multiplexing commands
+                // 2. WebSocketMessageType.Close: will be handled by IsConnected
+                if (receiveResult.MessageType == WebSocketMessageType.Binary)
+                    position += receiveResult.Count;
+
+                if (!receiveResult.EndOfMessage)
+                    continue;
+
+                _circularBuffer.Enqueue(buffer, 0, position);
+                position = 0;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            Log.Trace("WebSocket OperationCanceledException on websocket " + (IsCanceled ? "(was requested)" : "(remote cancelled)"));
+        }
+        catch (Exception e)
+        {
+            Log.Trace($"WebSocket error in StartReceiveAsync {e}");
+            InvokeOnError(SocketError.SocketError);
+        }
+
+        if (!IsCanceled)
+            InvokeOnError(SocketError.ConnectionReset);
+    }
+
+    // This is probably unnecessary, but WebSocket frames can be up to 2^63 bytes so we put some cap on it, yet to see packets larger than 4KB come through.
+    // We peek the raw tcp socket available bytes, grow if the frame is bigger, we're naively assuming no compression.
+    private void GrowReceiveBufferIfNeeded(ref byte[] buffer, ref Memory<byte> memory)
+    {
+        if (_rawSocket.Available <= buffer.Length)
+            return;
+
+        if (_rawSocket.Available > MAX_RECEIVE_BUFFER_SIZE)
+            throw new SocketException((int)SocketError.MessageSize, $"WebSocket message frame too large: {_rawSocket.Available} > {MAX_RECEIVE_BUFFER_SIZE}");
+
+        Log.Trace($"WebSocket growing receive buffer {buffer.Length} bytes to {_rawSocket.Available} bytes");
+
+        Shared.Return(buffer);
+        buffer = Shared.Rent(_rawSocket.Available);
+        memory = buffer.AsMemory();
+    }
+
+    public override void Disconnect()
+    {
+        if (!IsConnected)
+            return;
+
+        _tokenSource?.Cancel();
+        _webSocket?.CloseAsync(WebSocketCloseStatus.NormalClosure, "Disconnect", _tokenSource?.Token ?? default);
+    }
+
+    public override void Dispose()
+    {
+    }
+}

--- a/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
+++ b/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
@@ -151,6 +151,7 @@ sealed class WebSocketWrapper : SocketWrapper
                 {
                     _receiveStream.Enqueue(buffer, 0, position);
                 }
+
                 position = 0;
             }
         }
@@ -162,6 +163,10 @@ sealed class WebSocketWrapper : SocketWrapper
         {
             Log.Trace($"WebSocket error in StartReceiveAsync {e}");
             InvokeOnError(SocketError.SocketError);
+        }
+        finally
+        {
+            Shared.Return(buffer);
         }
 
         if (!IsCanceled)

--- a/tools/ws/README.md
+++ b/tools/ws/README.md
@@ -1,0 +1,18 @@
+# Test WebSocket TCP proxy
+This is just a simple node script for testing CUO websocket connections. 
+
+**Do not use it in production it's not built for that.**
+
+## Installation
+Install a recent version of Node.js (tested with node v20+)
+
+Run:
+```bash
+npm install
+```
+
+## Usage
+- Set `ip` in CUO settings.json to `ws://127.0.0.1:2594`
+- Set `ignore_relay_ip` in CUO settings.json (this requires the target to be both the login server & game server).
+- Start a shard running at 127.0.0.1:2593, otherwise update the `target` in `proxy.mjs`.
+- Run `node proxy.mjs`

--- a/tools/ws/package-lock.json
+++ b/tools/ws/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "ws",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@maximegris/node-websockify": "^1.0.7"
+      }
+    },
+    "node_modules/@maximegris/node-websockify": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@maximegris/node-websockify/-/node-websockify-1.0.7.tgz",
+      "integrity": "sha512-UIrO+wxxiBxWwIr63eCt8w0aXBGL2BM1pbibW/8m5Zh3Q9VxXPUjnu2c/1sgFyWRfvZfGIbkAa4JxUQXzf2Evw==",
+      "dependencies": {
+        "mime": "2.4.4",
+        "ws": "7.2.1"
+      },
+      "bin": {
+        "websockify": "websockify.js"
+      },
+      "engines": {
+        "node": ">=0.8.9"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/tools/ws/package.json
+++ b/tools/ws/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@maximegris/node-websockify": "^1.0.7"
+  }
+}

--- a/tools/ws/proxy.mjs
+++ b/tools/ws/proxy.mjs
@@ -1,0 +1,6 @@
+import websockify from '@maximegris/node-websockify';
+
+/**
+ * Note: this won't work on OSI or any shard that uses a different IP for the gameserver than the loginserver
+ */
+websockify({ source: '127.0.0.1:2594', target: '127.0.0.1:2593' });

--- a/tools/ws/wsProxy.mjs
+++ b/tools/ws/wsProxy.mjs
@@ -1,0 +1,8 @@
+import websockify from '@maximegris/node-websockify';
+
+/**
+ * Note: 
+ *  use `ignore_relay_ip` in CUO settings.json if testing
+ *  also this won't work on OSI or any shard that uses a different host for the gameserver than the loginserver
+ */
+websockify({ source: '127.0.0.1:2594', target: '127.0.0.1:2593' });

--- a/tools/ws/wsProxy.mjs
+++ b/tools/ws/wsProxy.mjs
@@ -1,8 +1,0 @@
-import websockify from '@maximegris/node-websockify';
-
-/**
- * Note: 
- *  use `ignore_relay_ip` in CUO settings.json if testing
- *  also this won't work on OSI or any shard that uses a different host for the gameserver than the loginserver
- */
-websockify({ source: '127.0.0.1:2594', target: '127.0.0.1:2593' });


### PR DESCRIPTION
Implements WebSockets as an alternative connection method allowing shards to protect their shards from DDoS attacks by putting them behind Cloudflare/Fastly/Cloudfront.

# Changes
- Refactored `SocketWrapper` to be an abstract class that `TcpSocketWrapper` and `WebSocketWrapper` implement.
- Adds `WebSocketWrapper` that uses an async receive loop and a circular buffer to match tcp socket synchronous behaviour.
- NetClient now checks the `ip` for a `ws://` or `wss://` scheme and sets up the appropriate socket type.
- New settings.json property `ignore_relay_ip` enables ignoring the Login Server's relay packet address and forces connecting to the `ip`/`port` from the settings. The relay packet doesn't support sending a string hostname, so this allows shards to use a singular domain in the `ip`.
- Added alternative to the above is shards can alter their relay packet to return `0`, causing the settings ip/port to be used instead. This allows them to hide their game server IP from the packet.
- New websocket proxy nodejs tool `tools/ws/proxy.mjs`, simply proxies a local shard for testing.

# Things to be aware of
- If using WebSockets for DDoS protection **it's critical that your Login Server does not leak the shard IP via the relay packet**, you should modify your [Server Relay packet](https://docs.polserver.com/packets/index.php?Packet=0x8C) to send `0` as the game server IP. This will also trigger CUO to only connect on the domain you set as the `ip` in settings.json.

# How to test
https://github.com/ClassicUO/ClassicUO/blob/b577cb15ff97487e2ec68db26af59fdac73737c8/tools/ws/README.md?plain=1#L1-L18