### PR TITLE
override ws version in proxy.mjs

### DIFF
--- a/tools/ws/package-lock.json
+++ b/tools/ws/package-lock.json
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
-      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },

--- a/tools/ws/package.json
+++ b/tools/ws/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "@maximegris/node-websockify": "^1.0.7"
+  },
+  "overrides": {
+    "ws": "^7.5.10"
   }
 }


### PR DESCRIPTION
Solves warnings from NPM peer dependency in the local development tool for websocket testing

- https://github.com/ClassicUO/ClassicUO/security/dependabot/1
- https://github.com/ClassicUO/ClassicUO/security/dependabot/2