### PR TITLE
Fix login music, initialize audio after version is set

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/AudioManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AudioManager.cs
@@ -64,7 +64,12 @@ namespace ClassicUO.Game.Managers
                 _canReproduceAudio = false;
             }
 
-            LoginMusicIndex = Client.Game.UO.Version >= ClientVersion.CV_7000 ? 78 : Client.Game.UO.Version > ClientVersion.CV_308Z ? 0 : 8;
+            LoginMusicIndex = Client.Game.UO.Version switch
+            {
+                >= ClientVersion.CV_7000 => 78, // LoginLoop
+                > ClientVersion.CV_308Z => 0,
+                _ => 8 // stones2
+            };
 
             Client.Game.Activated += OnWindowActivated;
             Client.Game.Deactivated += OnWindowDeactivated;

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -131,7 +131,6 @@ namespace ClassicUO
             Fonts.Initialize(GraphicsDevice);
             SolidColorTextureCache.Initialize(GraphicsDevice);
             Audio = new AudioManager();
-            Audio.Initialize();
 
             var bytes = Loader.GetBackgroundImage().ToArray();
             using var ms = new MemoryStream(bytes);
@@ -141,6 +140,7 @@ namespace ClassicUO
             SetScene(new MainScene(this));
 #else
             UO.Load(this);
+            Audio.Initialize();
             // TODO: temporary fix to avoid crash when laoding plugins
             Settings.GlobalSettings.Encryption = (byte) NetClient.Socket.Load(UO.FileManager.Version, (EncryptionType) Settings.GlobalSettings.Encryption);
 


### PR DESCRIPTION
Fixes the LoginMusicIndex being always set to index `8` aka `stones2` as the AudioManager was initialized prior to the version data being read.