### PR TITLE
[Fix] Correctly handle play midi music packet (0x6D, 0x10, muisc_index)

### DIFF
--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -2240,9 +2240,26 @@ namespace ClassicUO.Network
 
         private static void PlayMusic(World world, ref StackDataReader p)
         {
-            ushort index = p.ReadUInt16BE();
+            if (p.Length == 3) // Play Midi Music packet (0x6D, 0x10, index)
+            {
+                byte cmd = p.ReadUInt8();
+                byte index = p.ReadUInt8();
 
-            Client.Game.Audio.PlayMusic(index);
+                // Check for stop music packet (6D 1F FF)
+                if (cmd == 0x1F && index == 0xFF)
+                {
+                    Client.Game.Audio.StopMusic();
+                }
+                else
+                {
+                    Client.Game.Audio.PlayMusic(index);
+                }
+            }
+            else
+            {
+                ushort index = p.ReadUInt16BE();
+                Client.Game.Audio.PlayMusic(index);
+            }
         }
 
         private static void LoginComplete(World world, ref StackDataReader p)


### PR DESCRIPTION
# Implement MIDI Music Packet (0x6D) Handler

This PR implements proper handling of the MIDI music packet (0x6D) which is used for background music changes in-game, including Dawn's Music Box and some scene transitions.

# Changes

Added support for the standard 3-byte MIDI music packet format:

```cs
BYTE[1] cmd    - Command byte
BYTE[2] musicID - Music index to play
```

Implemented special case handling for the stop music command (6D 1F FF)
Preserved existing packet handling for backwards compatibility

The implementation can be found in the PlayMusic handler:

```cs
        private static void PlayMusic(World world, ref StackDataReader p)
        {
            if (p.Length == 3) // Play Midi Music packet (0x6D, 0x10, index)
            {
                byte cmd = p.ReadUInt8();
                byte index = p.ReadUInt8();

                // Check for stop music packet (6D 1F FF)
                if (cmd == 0x1F && index == 0xFF)
                {
                    Client.Game.Audio.StopMusic();
                }
                else
                {
                    Client.Game.Audio.PlayMusic(index);
                }
            }
            else
            {
                ushort index = p.ReadUInt16BE();
                Client.Game.Audio.PlayMusic(index);
            }
        }
```

# Technical Details

When the server sends packet 0x6D:

If packet length is 3 bytes:
Check for stop music command (cmd=0x1F, index=0xFF)

If stop command, call StopMusic()
Otherwise play music with given index

If longer packet length:
Use existing packet handling logic

# References

- [UO Packet Documentation](https://www.download.uo98.org/Documents/Packet%20Guides/2006-06-20%20PacketGuide_MuadDib.html#0x6D)