### PR TITLE
Add StatusGumpBarMutuallyExclusive option to allow disabling mutual exclusiveness

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -102,6 +102,7 @@ namespace ClassicUO.Configuration
         public bool EnableStatReport { get; set; } = true;
         public bool EnableSkillReport { get; set; } = true;
         public bool UseOldStatusGump { get; set; }
+        public bool StatusGumpBarMutuallyExclusive { get; set; } = true;
         public int BackpackStyle { get; set; }
         public bool HighlightGameObjects { get; set; }
         public bool HighlightMobilesByParalize { get; set; } = true;

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -699,7 +699,8 @@ namespace ClassicUO.Game.Managers
                                     {
                                         if (status != null)
                                         {
-                                            status.Dispose();
+                                            if (ProfileManager.CurrentProfile.StatusGumpBarMutuallyExclusive)
+                                                status.Dispose();
 
                                             if (ProfileManager.CurrentProfile.CustomBarsToggled)
                                             {

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -1073,7 +1073,7 @@ namespace ClassicUO.Game.Scenes
                             );
                             customgump?.Dispose();
 
-                            if (obj == _world.Player)
+                            if (obj == _world.Player && ProfileManager.CurrentProfile.StatusGumpBarMutuallyExclusive)
                             {
                                 StatusGumpBase.GetStatusGump()?.Dispose();
                             }

--- a/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
@@ -245,8 +245,11 @@ namespace ClassicUO.Game.UI.Gumps
                 }
                 else
                 {
-                    UIManager.Add(StatusGumpBase.AddStatusGump(World, ScreenCoordinateX, ScreenCoordinateY));
-                    Dispose();
+                    if(StatusGumpBase.GetStatusGump() is null)
+                        UIManager.Add(StatusGumpBase.AddStatusGump(World, ScreenCoordinateX, ScreenCoordinateY));
+
+                    if (ProfileManager.CurrentProfile.StatusGumpBarMutuallyExclusive)
+                        Dispose();
                 }
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -223,7 +223,7 @@ namespace ClassicUO.Game.UI.Gumps
                 BaseHealthBarGump gump = UIManager.GetGump<BaseHealthBarGump>(LocalSerial);
                 gump?.Dispose();
 
-                if (entity == World.Player)
+                if (entity == World.Player && ProfileManager.CurrentProfile.StatusGumpBarMutuallyExclusive)
                 {
                     StatusGumpBase.GetStatusGump()?.Dispose();
                 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -136,7 +136,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _dragSelectAsAnchor;
 
         // video
-        private Checkbox _use_old_status_gump, _windowBorderless, _enableDeathScreen, _enableBlackWhiteEffect, _altLights, _enableLight, _enableShadows, _enableShadowsStatics, _auraMouse, _runMouseInSeparateThread, _useColoredLights, _darkNights, _partyAura, _hideChatGradient, _animatedWaterEffect;
+        private Checkbox _use_old_status_gump, _statusGumpBarMutuallyExclusive, _windowBorderless, _enableDeathScreen, _enableBlackWhiteEffect, _altLights, _enableLight, _enableShadows, _enableShadowsStatics, _auraMouse, _runMouseInSeparateThread, _useColoredLights, _darkNights, _partyAura, _hideChatGradient, _animatedWaterEffect;
         private Combobox _lightLevelType;
         private Checkbox _use_smooth_boat_movement;
         private HSliderBar _terrainShadowLevel;
@@ -959,6 +959,20 @@ namespace ClassicUO.Game.UI.Gumps
             );
 
             _use_old_status_gump.IsVisible = true;
+            
+            section3.Add
+            (
+                _statusGumpBarMutuallyExclusive = AddCheckBox
+                (
+                    null,
+                    ResGumps.StatusGumpBarMutuallyExclusive,
+                    _currentProfile.StatusGumpBarMutuallyExclusive,
+                    startX,
+                    startY
+                )
+            );
+            
+            _statusGumpBarMutuallyExclusive.IsVisible = true;
 
             section3.Add
             (
@@ -3491,6 +3505,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _use_smooth_boat_movement.IsChecked = false;
                     _hideScreenshotStoredInMessage.IsChecked = false;
                     _use_old_status_gump.IsChecked = false;
+                    _statusGumpBarMutuallyExclusive.IsChecked = true;
                     _auraType.SelectedIndex = 0;
                     _fieldsType.SelectedIndex = 0;
 
@@ -3837,9 +3852,18 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (status != null)
                 {
-                    status.Dispose();
+                    if (_currentProfile.StatusGumpBarMutuallyExclusive)
+                        status.Dispose();
                     UIManager.Add(StatusGumpBase.AddStatusGump(World, status.ScreenCoordinateX, status.ScreenCoordinateY));
                 }
+            }
+            
+            if (_statusGumpBarMutuallyExclusive.IsChecked != _currentProfile.StatusGumpBarMutuallyExclusive)
+            {
+                var active = _currentProfile.StatusGumpBarMutuallyExclusive = _statusGumpBarMutuallyExclusive.IsChecked;
+
+                if (active && StatusGumpBase.GetStatusGump() != null && UIManager.GetGump<BaseHealthBarGump>(World.Player) is {} bar)
+                    bar.Dispose();
             }
 
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/StatusGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/StatusGump.cs
@@ -23,8 +23,11 @@ namespace ClassicUO.Game.UI.Gumps
 
         protected StatusGumpBase(World world) : base(world, 0, 0)
         {
-            // sanity check
-            UIManager.GetGump<HealthBarGump>(World.Player)?.Dispose();
+            if (ProfileManager.CurrentProfile.StatusGumpBarMutuallyExclusive)
+            {
+                // sanity check
+                UIManager.GetGump<HealthBarGump>(World.Player)?.Dispose();
+            }
 
             CanCloseWithRightClick = true;
             CanMove = true;
@@ -77,15 +80,12 @@ namespace ClassicUO.Game.UI.Gumps
                         UIManager.GetGump<BaseHealthBarGump>(World.Player)?.Dispose();
 
                         if (ProfileManager.CurrentProfile.CustomBarsToggled)
-                        {
                             UIManager.Add(new HealthBarGumpCustom(World, World.Player) { X = ScreenCoordinateX, Y = ScreenCoordinateY });
-                        }
                         else
-                        {
                             UIManager.Add(new HealthBarGump(World, World.Player) { X = ScreenCoordinateX, Y = ScreenCoordinateY });
-                        }
 
-                        Dispose();
+                        if (ProfileManager.CurrentProfile.StatusGumpBarMutuallyExclusive)
+                            Dispose();
                     }
                 }
             }
@@ -1308,7 +1308,8 @@ namespace ClassicUO.Game.UI.Gumps
                     p.Y,
                     16,
                     16,
-                    ResGumps.Minimize,
+                    ProfileManager.CurrentProfile.StatusGumpBarMutuallyExclusive 
+                        ? ResGumps.Minimize : ResGumps.StatusGumpOpenBar,
                     0
                 ) { CanMove = true }
             );

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -2984,5 +2984,17 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("WorldMapChangeMap0", resourceCulture);
             }
         }
+        
+        public static string StatusGumpBarMutuallyExclusive {
+            get {
+                return ResourceManager.GetString("StatusGumpBarMutuallyExclusive", resourceCulture);
+            }
+        }
+        
+        public static string StatusGumpOpenBar {
+            get {
+                return ResourceManager.GetString("StatusGumpOpenBar", resourceCulture);
+            }
+        }
     }
 }

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1597,4 +1597,10 @@ Client version: '{0}'</value>
   <data name="WorldMapChangeMap0" xml:space="preserve">
     <value>Map {0}</value>
   </data>
+  <data name="StatusGumpBarMutuallyExclusive" xml:space="preserve">
+    <value>Status Gump and Health Bar are mutually exclusive</value>
+  </data>
+  <data name="StatusGumpOpenBar" xml:space="preserve">
+    <value>Open Health Bar</value>
+  </data>
 </root>


### PR DESCRIPTION
Allows players to disable the mutually exclusiveness of the status gump so they can have both the `StatusGump` and `HealthBarGump` open at the same time. Defaults to `true` keeping existing behaviour.

![image](https://github.com/user-attachments/assets/1cfe7aac-ca6b-4557-b6c3-5789aa15a709)
