### PR TITLE
Allow setting your current profile as the default for new characters

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -360,6 +360,11 @@ namespace ClassicUO.Configuration
             Log.Trace("Saving done!");
         }
 
+        public void SaveAs(string path, string filename = "default.json")
+        {
+            ConfigurationResolver.Save(this, Path.Combine(path, filename), ProfileJsonContext.DefaultToUse.Profile);
+        }
+
         private void SaveGumps(World world, string path)
         {
             string gumpsXmlPath = Path.Combine(path, "gumps.xml");

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -134,6 +134,7 @@ namespace ClassicUO.Game.UI.Gumps
         private FontSelector _tooltip_font_selector;
         private HSliderBar _dragSelectStartX, _dragSelectStartY;
         private Checkbox _dragSelectAsAnchor;
+        private NiceButton _setAsNewDefault;
 
         // video
         private Checkbox _use_old_status_gump, _statusGumpBarMutuallyExclusive, _windowBorderless, _enableDeathScreen, _enableBlackWhiteEffect, _altLights, _enableLight, _enableShadows, _enableShadowsStatics, _auraMouse, _runMouseInSeparateThread, _useColoredLights, _darkNights, _partyAura, _hideChatGradient, _animatedWaterEffect;
@@ -1297,6 +1298,25 @@ namespace ClassicUO.Game.UI.Gumps
             );
 
             section4.PopIndent();
+
+            section4.Add
+            (
+                _setAsNewDefault = new NiceButton
+                (
+                    startX, 
+                    startY,
+                    section4.Width - 18,
+                    25,
+                    ButtonAction.Default,
+                    ResGumps.SetAsNewDefault
+                )
+                { IsSelectable = true, IsSelected = true } //For styling, easier to distinguish as a button.
+            );
+            _setAsNewDefault.MouseUp += (s, e) => 
+            {
+                ProfileManager.SetProfileAsDefault(_currentProfile);
+                GameActions.Print(World, ResGeneral.DefaultProfileSet);
+            };
 
 
             SettingsSection section5 = AddSettingsSection(box, "Terrain & Statics");

--- a/src/ClassicUO.Client/Resources/ResGeneral.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGeneral.Designer.cs
@@ -305,6 +305,15 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Current profile has been set as the default for new characters..
+        /// </summary>
+        public static string DefaultProfileSet {
+            get {
+                return ResourceManager.GetString("DefaultProfileSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to dexterity.
         /// </summary>
         public static string Dexterity {

--- a/src/ClassicUO.Client/Resources/ResGeneral.resx
+++ b/src/ClassicUO.Client/Resources/ResGeneral.resx
@@ -518,4 +518,7 @@ Ultima Online?</value>
   <data name="Czech" xml:space="preserve">
     <value>Czech</value>
   </data>
+  <data name="DefaultProfileSet" xml:space="preserve">
+    <value>Current profile has been set as the default for new characters.</value>
+  </data>
 </root>

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -3423,7 +3423,7 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set current profile as default for new characters.
+        ///   Looks up a localized string similar to Save current settings as defaults for new users.
         /// </summary>
         public static string SetAsNewDefault {
             get {

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1610,7 +1610,7 @@ Client version: '{0}'</value>
     <value>Show DPS with damage numbers</value>
   </data>
   <data name="SetAsNewDefault" xml:space="preserve">
-    <value>Set current profile as default for new characters</value>
+    <value>Save current settings as defaults for new users</value>
   </data>
   <data name="UseAlternateJournal" xml:space="preserve">
     <value>Use alternative journal</value>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6245f600-ef41-4ec8-85c1-676bcf205198)

This allows players to set their current profile as the default for new characters so they don't need to redo all the settings they usually set up.

Resolves #1675 