### PR TITLE
Overhead party messages

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -347,6 +347,8 @@ namespace ClassicUO.Configuration
             }
         };
 
+        public bool OverheadPartyMessages { get; set; }
+
         public void Save(World world, string path)
         {
             Log.Trace($"Saving path:\t\t{path}");

--- a/src/ClassicUO.Client/Game/Managers/MessageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MessageManager.cs
@@ -103,7 +103,7 @@ namespace ClassicUO.Game.Managers
                                 }
                     }
 
-                    if (type != MessageType.Spell && _world.IgnoreManager.IgnoredCharsList.Contains(parent.Name))
+                    if (type != MessageType.Spell && parent != null && _world.IgnoreManager.IgnoredCharsList.Contains(parent.Name))
                         break;
 
                     //Add null check in case parent was not found above.

--- a/src/ClassicUO.Client/Game/Managers/MessageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MessageManager.cs
@@ -85,6 +85,40 @@ namespace ClassicUO.Game.Managers
                 case MessageType.Encoded:
                 case MessageType.System:
                 case MessageType.Party:
+                    if (!currentProfile.OverheadPartyMessages)
+                        break;
+
+                    if (parent == null)
+                    {
+                        bool handled = false;
+                        foreach (PartyMember member in _world.Party.Members)
+                            if (member != null)
+                                if (member.Name == name)
+                                {
+                                    Mobile m = _world.Mobiles.Get(member.Serial);
+                                    if (m != null)
+                                    {
+                                        parent = m;
+                                        handled = true;
+                                        break;
+                                    }
+
+                                }
+                        if (!handled) break;
+                    }
+
+                    if (_world.IgnoreManager.IgnoredCharsList.Contains(parent.Name) && type != MessageType.Spell)
+                        break;
+
+                    parent.AddMessage(CreateMessage
+                    (
+                        text,
+                        hue,
+                        font,
+                        unicode,
+                        type,
+                        textType
+                    ));
                     break;
 
                 case MessageType.Guild:

--- a/src/ClassicUO.Client/Game/Managers/MessageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MessageManager.cs
@@ -88,29 +88,26 @@ namespace ClassicUO.Game.Managers
                     if (!currentProfile.OverheadPartyMessages)
                         break;
 
-                    if (parent == null)
+                    if (parent == null) //No parent entity, need to check party members by name
                     {
-                        bool handled = false;
                         foreach (PartyMember member in _world.Party.Members)
                             if (member != null)
-                                if (member.Name == name)
+                                if (member.Name == name) //Name matches message from server
                                 {
                                     Mobile m = _world.Mobiles.Get(member.Serial);
-                                    if (m != null)
+                                    if (m != null) //Mobile exists
                                     {
                                         parent = m;
-                                        handled = true;
                                         break;
                                     }
-
                                 }
-                        if (!handled) break;
                     }
 
-                    if (_world.IgnoreManager.IgnoredCharsList.Contains(parent.Name) && type != MessageType.Spell)
+                    if (type != MessageType.Spell && _world.IgnoreManager.IgnoredCharsList.Contains(parent.Name))
                         break;
 
-                    parent.AddMessage(CreateMessage
+                    //Add null check in case parent was not found above.
+                    parent?.AddMessage(CreateMessage
                     (
                         text,
                         hue,

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -121,7 +121,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _showHouseContent;
         private Checkbox _showInfoBar;
         private Checkbox _ignoreAllianceMessages;
-        private Checkbox _ignoreGuildMessages, _useAlternateJournal;
+        private Checkbox _ignoreGuildMessages, _useAlternateJournal, _partyMessagesOverhead;
 
         // general
         private HSliderBar _sliderFPS, _circleOfTranspRadius;
@@ -2513,6 +2513,17 @@ namespace ClassicUO.Game.UI.Gumps
                 startY
             );
 
+            startY += _useAlternateJournal.Height + 2;
+
+            _partyMessagesOverhead = AddCheckBox
+            (
+                rightArea,
+                ResGumps.OverheadPartyMessages,
+                _currentProfile.OverheadPartyMessages,
+                startX,
+                startY
+            );
+
             startY += 35;
 
             _randomizeColorsButton = new NiceButton
@@ -3659,6 +3670,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _ignoreGuildMessages.IsChecked = false;
                     _ignoreAllianceMessages.IsChecked = false;
                     _useAlternateJournal.IsChecked = false;
+                    _partyMessagesOverhead.IsChecked = false;
 
                     break;
 
@@ -3890,6 +3902,7 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.ActivateChatAdditionalButtons = _chatAdditionalButtonsCheckbox.IsChecked;
             _currentProfile.ActivateChatShiftEnterSupport = _chatShiftEnterCheckbox.IsChecked;
             _currentProfile.SaveJournalToFile = _saveJournalCheckBox.IsChecked;
+            _currentProfile.OverheadPartyMessages = _partyMessagesOverhead.IsChecked;
 
             // video
             _currentProfile.EnableDeathScreen = _enableDeathScreen.IsChecked;

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -2891,6 +2891,15 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show party messages overhead.
+        /// </summary>
+        public static string OverheadPartyMessages {
+            get {
+                return ResourceManager.GetString("OverheadPartyMessages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Override container gump location.
         /// </summary>
         public static string OverrideContainerGumpLocation {

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1617,5 +1617,7 @@ Client version: '{0}'</value>
   </data>
   <data name="StayActive" xml:space="preserve">
     <value>Stay active</value>
+  <data name="OverheadPartyMessages" xml:space="preserve">
+    <value>Show party messages overhead</value>
   </data>
 </root>

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1617,6 +1617,7 @@ Client version: '{0}'</value>
   </data>
   <data name="StayActive" xml:space="preserve">
     <value>Stay active</value>
+  </data>
   <data name="OverheadPartyMessages" xml:space="preserve">
     <value>Show party messages overhead</value>
   </data>


### PR DESCRIPTION
## This PR adds an option to display **party** messages over head

Since party messages don't display overhead, and usually for parties you are working with each other fairly closely this is helpful to easily see messages similar to if they were chatting normally.


Default is off  

![image](https://github.com/user-attachments/assets/e7f146d5-d298-454e-a6c3-40bb7c9ef2f0)
