### PR TITLE
refactor/GameController-constructor

### DIFF
--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -64,7 +64,24 @@ namespace ClassicUO
         
         public GameController(IPluginHost pluginHost)
         {
-            GameController();
+            GraphicManager = new GraphicsDeviceManager(this);
+
+            GraphicManager.PreparingDeviceSettings += (sender, e) =>
+            {
+                e.GraphicsDeviceInformation.PresentationParameters.RenderTargetUsage =
+                    RenderTargetUsage.DiscardContents;
+            };
+
+            GraphicManager.PreferredDepthStencilFormat = DepthFormat.Depth24Stencil8;
+            SetVSync(false);
+
+            Window.ClientSizeChanged += WindowOnClientSizeChanged;
+            Window.AllowUserResizing = true;
+            Window.Title = $"ClassicUO - {CUOEnviroment.Version}";
+            IsMouseVisible = Settings.GlobalSettings.RunMouseInASeparateThread;
+
+            IsFixedTimeStep = false; // Settings.GlobalSettings.FixedTimeStep;
+            TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / 250.0);
             
             PluginHost = pluginHost;
         }

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -42,10 +42,6 @@ namespace ClassicUO
         public GameController()
         {
             // an easily accessible constructor is needed when accessing via reflection
-        }
-        
-        public GameController(IPluginHost pluginHost)
-        {
             GraphicManager = new GraphicsDeviceManager(this);
 
             GraphicManager.PreparingDeviceSettings += (sender, e) =>
@@ -64,6 +60,12 @@ namespace ClassicUO
 
             IsFixedTimeStep = false; // Settings.GlobalSettings.FixedTimeStep;
             TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0 / 250.0);
+        }
+        
+        public GameController(IPluginHost pluginHost)
+        {
+            GameController();
+            
             PluginHost = pluginHost;
         }
 

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -39,6 +39,11 @@ namespace ClassicUO
         private Texture2D _background;
         private bool _pluginsInitialized = false;
 
+        public GameController()
+        {
+            // an easily accessible constructor is needed when accessing via reflection
+        }
+        
         public GameController(IPluginHost pluginHost)
         {
             GraphicManager = new GraphicsDeviceManager(this);


### PR DESCRIPTION
After the CUO "net8 porting," some commands in ClassicAssist started to throw errors. Upon investigation, I found that the `GameController.cs` class, which was previously defined as:

```csharp
public GameController()
```

was changed to:

```csharp
public GameController(IPluginHost pluginHost)
```

After this change, it seems that ClassicAssist is no longer able to access it via reflection. So, I modified the structure there.