### PR TITLE
Add Alternate Journal Hue customization feature

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -96,7 +96,6 @@ namespace ClassicUO.Configuration
         public ushort PoisonHue { get; set; } = 0x0044;
         public ushort ParalyzedHue { get; set; } = 0x014C;
         public ushort InvulnerableHue { get; set; } = 0x0030;
-        public ushort AlternateJournalHue { get; set; } = 0x0000;
 
         // visual
         public bool EnabledCriminalActionQuery { get; set; } = true;
@@ -294,7 +293,7 @@ namespace ClassicUO.Configuration
         public bool WorldMapFlipMap { get; set; } = true;
         public bool WorldMapTopMost { get; set; }
         public bool WorldMapFreeView { get; set; }
-        public bool WorldMapShowParty { get; set; } = true;
+        public bool WorldMapShowParty { get; set; } = false;
         public int WorldMapZoomIndex { get; set; } = 4;
         public bool WorldMapShowCoordinates { get; set; } = true;
         public bool WorldMapShowMouseCoordinates { get; set; } = true;
@@ -317,6 +316,10 @@ namespace ClassicUO.Configuration
 
         //Alternate Journal
         public bool UseAlternateJournal { get; set; }
+        public ushort AlternateJournalHue { get; set; }
+        public int AlternateJournalTransparency { get; set; }
+        public bool AlternateJournalTransparencyToggle { get; set; }
+
         public Dictionary<string, MessageType[]> JournalTabs { get; } = new Dictionary<string, MessageType[]>()
         {
             { "All", new MessageType[] {

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -96,6 +96,7 @@ namespace ClassicUO.Configuration
         public ushort PoisonHue { get; set; } = 0x0044;
         public ushort ParalyzedHue { get; set; } = 0x014C;
         public ushort InvulnerableHue { get; set; } = 0x0030;
+        public ushort AlternateJournalHue { get; set; } = 0x0000;
 
         // visual
         public bool EnabledCriminalActionQuery { get; set; } = true;

--- a/src/ClassicUO.Client/Game/Managers/WorldMapEntityManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/WorldMapEntityManager.cs
@@ -57,7 +57,7 @@ namespace ClassicUO.Game.Managers
             {
                 return ((_world.ClientFeatures.Flags & CharacterListFlags.CLF_NEW_MOVEMENT_SYSTEM) == 0 || _ackReceived) &&
                         (NetClient.Socket.Encryption == null || NetClient.Socket.Encryption.EncryptionType == 0) &&
-                        ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.WorldMapShowParty &&
+                        ProfileManager.CurrentProfile != null && //ProfileManager.CurrentProfile.WorldMapShowParty &&
                         UIManager.GetGump<WorldMapGump>() != null; // horrible, but works
             }
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -122,6 +122,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _showInfoBar;
         private Checkbox _ignoreAllianceMessages;
         private Checkbox _ignoreGuildMessages, _useAlternateJournal, _partyMessagesOverhead;
+        private ClickableColorBox _AlternateJournalHue;
 
         // general
         private HSliderBar _sliderFPS, _circleOfTranspRadius;
@@ -2515,6 +2516,17 @@ namespace ClassicUO.Game.UI.Gumps
 
             startY += _useAlternateJournal.Height + 2;
 
+            _AlternateJournalHue = AddColorBox
+            (
+                rightArea,
+                startX,
+                startY,
+                _currentProfile.AlternateJournalHue,
+                ResGumps.AlternateJournalHue
+            );
+
+            startY += _AlternateJournalHue.Height + 15;
+
             _partyMessagesOverhead = AddCheckBox
             (
                 rightArea,
@@ -3670,6 +3682,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _ignoreGuildMessages.IsChecked = false;
                     _ignoreAllianceMessages.IsChecked = false;
                     _useAlternateJournal.IsChecked = false;
+                    _AlternateJournalHue.Hue = 0x0000;
                     _partyMessagesOverhead.IsChecked = false;
 
                     break;
@@ -4043,6 +4056,7 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.IgnoreGuildMessages = _ignoreGuildMessages.IsChecked;
             _currentProfile.IgnoreAllianceMessages = _ignoreAllianceMessages.IsChecked;
             _currentProfile.UseAlternateJournal = _useAlternateJournal.IsChecked;
+            _currentProfile.AlternateJournalHue = _AlternateJournalHue.Hue;
 
             // fonts
             _currentProfile.ForceUnicodeJournal = _forceUnicodeJournal.IsChecked;

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -122,7 +122,6 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _showInfoBar;
         private Checkbox _ignoreAllianceMessages;
         private Checkbox _ignoreGuildMessages, _useAlternateJournal, _partyMessagesOverhead;
-        private ClickableColorBox _AlternateJournalHue;
 
         // general
         private HSliderBar _sliderFPS, _circleOfTranspRadius;
@@ -147,6 +146,11 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _useStandardSkillsGump, _showMobileNameIncoming, _showCorpseNameIncoming;
         private Checkbox _showStatsMessage, _showSkillsMessage;
         private HSliderBar _showSkillsMessageDelta;
+
+        // experimental wotsc
+        private ClickableColorBox _AlternateJournalHue;
+        private Checkbox _AlternateJournalTransparencyToggle;
+        private HSliderBar _AlternateJournalTransparency;
 
 
         private Profile _currentProfile = ProfileManager.CurrentProfile;
@@ -2525,7 +2529,33 @@ namespace ClassicUO.Game.UI.Gumps
                 ResGumps.AlternateJournalHue
             );
 
-            startY += _AlternateJournalHue.Height + 15;
+            startY += _AlternateJournalHue.Height + 5;
+
+            _AlternateJournalTransparencyToggle = AddCheckBox
+            (
+                rightArea,
+                ResGumps.AlternateJournalTransparency,
+                _currentProfile.AlternateJournalTransparencyToggle,
+                startX,
+                startY
+            );
+
+            startX += _AlternateJournalTransparencyToggle.Width + 5;
+
+            _AlternateJournalTransparency = AddHSlider
+            (
+                rightArea,
+                1,
+                10,
+                _currentProfile.AlternateJournalTransparency,
+                startX,
+                startY,
+                180
+            );
+
+            startX = 5;
+
+            startY += _AlternateJournalTransparency.Height + 10;
 
             _partyMessagesOverhead = AddCheckBox
             (
@@ -3681,8 +3711,10 @@ namespace ClassicUO.Game.UI.Gumps
                     _hideChatGradient.IsChecked = false;
                     _ignoreGuildMessages.IsChecked = false;
                     _ignoreAllianceMessages.IsChecked = false;
-                    _useAlternateJournal.IsChecked = false;
+                    _useAlternateJournal.IsChecked = true;
                     _AlternateJournalHue.Hue = 0x0000;
+                    _AlternateJournalTransparency.Value = 7;
+                    _AlternateJournalTransparencyToggle.IsChecked = true;
                     _partyMessagesOverhead.IsChecked = false;
 
                     break;
@@ -4057,6 +4089,8 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.IgnoreAllianceMessages = _ignoreAllianceMessages.IsChecked;
             _currentProfile.UseAlternateJournal = _useAlternateJournal.IsChecked;
             _currentProfile.AlternateJournalHue = _AlternateJournalHue.Hue;
+            _currentProfile.AlternateJournalTransparencyToggle = _AlternateJournalTransparencyToggle.IsChecked; 
+            _currentProfile.AlternateJournalTransparency = _AlternateJournalTransparency.Value;
 
             // fonts
             _currentProfile.ForceUnicodeJournal = _forceUnicodeJournal.IsChecked;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
@@ -62,7 +62,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             #region Background
             _background = new AlphaBlendControl(0.7f);
-            _background.Hue = 0x0000;
+            _background.Hue = ProfileManager.CurrentProfile.AlternateJournalHue;
             _background.Width = Width - (BORDER_WIDTH * 2);
             _background.Height = Height - (BORDER_WIDTH * 2);
             _background.X = BORDER_WIDTH;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
@@ -61,8 +61,11 @@ namespace ClassicUO.Game.UI.Gumps
 
 
             #region Background
-            _background = new AlphaBlendControl(0.7f);
-            _background.Hue = ProfileManager.CurrentProfile.AlternateJournalHue;
+            if(ProfileManager.CurrentProfile.AlternateJournalTransparencyToggle)    
+                _background = new AlphaBlendControl((float)ProfileManager.CurrentProfile.AlternateJournalTransparency/10);
+            else
+                _background = new AlphaBlendControl(1.0f);
+            _background.Hue = ProfileManager.CurrentProfile.AlternateJournalHue;            // default _background.Hue = 0x0000;
             _background.Width = Width - (BORDER_WIDTH * 2);
             _background.Height = Height - (BORDER_WIDTH * 2);
             _background.X = BORDER_WIDTH;
@@ -367,8 +370,12 @@ namespace ClassicUO.Game.UI.Gumps
 
                     foreach (JournalData _ in journalDatas)
                     {
-                        _.EntryText.Width = Width - BORDER_WIDTH - _.TimeStamp.Width;
-                        _.EntryText.Update();
+                        {
+                            _.EntryText.Width = Width - BORDER_WIDTH - _.TimeStamp.Width;
+                            _.EntryText = new Label(_.EntryText.Text, _.EntryText.Unicode, _.EntryText.Hue, Width - BORDER_WIDTH - _.TimeStamp.Width, font: _.EntryText.Font);
+                            _.EntryText.Update();
+                            _.EntryText.Update();
+                        }
                     }
 
                     CalculateScrollBarMaxValue();
@@ -418,7 +425,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 journalDatas.AddToBack(
                     new JournalData(
-                        new Label($"{e.Name}: {e.Text}", e.IsUnicode, e.Hue, font: e.Font),
+                        new Label($"{e.Name}: {e.Text}", e.IsUnicode, e.Hue, Width - BORDER_WIDTH - timeS.Width, font: e.Font),
                         timeS,
                         e.TextType,
                         e.MessageType
@@ -485,7 +492,7 @@ namespace ClassicUO.Game.UI.Gumps
                     TimeStamp?.Dispose();
                 }
 
-                public Label EntryText { get; }
+                public Label EntryText { get; set; }
                 public Label TimeStamp { get; }
                 public TextType TextType { get; }
                 public MessageType MessageType { get; }

--- a/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
@@ -60,14 +60,13 @@ namespace ClassicUO.Game.UI.Gumps
                 new[] { 1, (int)Buttons.Paperdoll },
                 new[] { 1, (int)Buttons.Inventory },
                 new[] { 1, (int)Buttons.Journal },
-                new[] { 0, (int)Buttons.Chat },
+                //new[] { 0, (int)Buttons.Chat },
                 new[] { 0, (int)Buttons.Help },
                 new[] { 1, (int)Buttons.WorldMap },
-                new[] { 0, (int)Buttons.Info },
+                //new[] { 0, (int)Buttons.Info },
                 new[] { 0, (int)Buttons.Debug },
-                new[] { 1, (int)Buttons.NetStats },
-                new[] { 1, (int)Buttons.UOStore },
-                new[] { 1, (int)Buttons.GlobalChat }
+                new[] { 1, (int)Buttons.NetStats }
+                //new[] { 1, (int)Buttons.GlobalChat }
             };
 
             var cliloc = Client.Game.UO.FileManager.Clilocs;
@@ -78,17 +77,17 @@ namespace ClassicUO.Game.UI.Gumps
                 cliloc.GetString(3000133, ResGumps.Paperdoll),
                 cliloc.GetString(3000431, ResGumps.Inventory),
                 cliloc.GetString(3000129, ResGumps.Journal),
-                cliloc.GetString(3000131, ResGumps.Chat),
+                //cliloc.GetString(3000131, ResGumps.Chat),
                 cliloc.GetString(3000134, ResGumps.Help),
                 StringHelper.CapitalizeAllWords(cliloc.GetString(1015233, ResGumps.WorldMap)),
-                cliloc.GetString(1079449, ResGumps.Info),
+                //cliloc.GetString(1079449, ResGumps.Info),
                 cliloc.GetString(1042237, ResGumps.Debug),
                 cliloc.GetString(3000169, ResGumps.NetStats),
-                cliloc.GetString(1158008, ResGumps.UOStore),
-                cliloc.GetString(1158390, ResGumps.GlobalChat)
+                cliloc.GetString(1158008, ResGumps.UOStore)
+                //cliloc.GetString(1158390, ResGumps.GlobalChat)
             };
 
-            bool hasUOStore = Client.Game.UO.Version >= ClientVersion.CV_706400;
+            bool hasUOStore = false;// Client.Game.UO.Version >= ClientVersion.CV_706400;
 
             ResizePic background;
 
@@ -227,7 +226,7 @@ namespace ClassicUO.Game.UI.Gumps
                     GameActions.OpenJournal(World);
 
                     break;
-
+                /*
                 case Buttons.Chat:
                     GameActions.OpenChat(World);
 
@@ -251,7 +250,7 @@ namespace ClassicUO.Game.UI.Gumps
                     }
 
                     break;
-
+                */
                 case Buttons.Help:
                     GameActions.RequestHelp();
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -80,7 +80,7 @@ namespace ClassicUO.Game.UI.Gumps
         private bool _showMarkers = true;
         private bool _showMobiles = true;
         private bool _showMultis = true;
-        private bool _showPartyMembers = true;
+        private bool _showPartyMembers = false;
         private bool _showPlayerBar = true;
         private bool _showPlayerName = true;
         private int _zoomIndex = 4;
@@ -181,7 +181,7 @@ namespace ClassicUO.Game.UI.Gumps
             ResizeWindow(new Point(Width, Height));
 
             _flipMap = ProfileManager.CurrentProfile.WorldMapFlipMap;
-            _showPartyMembers = ProfileManager.CurrentProfile.WorldMapShowParty;
+            _showPartyMembers = false;//ProfileManager.CurrentProfile.WorldMapShowParty;
 
             World.WMapManager.SetEnable(_showPartyMembers);
 
@@ -224,7 +224,7 @@ namespace ClassicUO.Game.UI.Gumps
             ProfileManager.CurrentProfile.WorldMapFlipMap = _flipMap;
             ProfileManager.CurrentProfile.WorldMapTopMost = TopMost;
             ProfileManager.CurrentProfile.WorldMapFreeView = FreeView;
-            ProfileManager.CurrentProfile.WorldMapShowParty = _showPartyMembers;
+            ProfileManager.CurrentProfile.WorldMapShowParty = false; // _showPartyMembers;
 
             ProfileManager.CurrentProfile.WorldMapZoomIndex = _zoomIndex;
 
@@ -291,6 +291,7 @@ namespace ClassicUO.Game.UI.Gumps
                 );
             }
 
+            /* Removed due to server not handling the request
             _options["show_party_members"] = new ContextMenuItemEntry
             (
                 ResGumps.ShowPartyMembers,
@@ -304,6 +305,7 @@ namespace ClassicUO.Game.UI.Gumps
                 true,
                 _showPartyMembers
             );
+            */
 
             _options["show_mobiles"] = new ContextMenuItemEntry(ResGumps.ShowMobiles, () => { _showMobiles = !_showMobiles; SaveSettings(); }, true, _showMobiles);
 
@@ -422,7 +424,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             ContextMenu?.Dispose();
             ContextMenu = new ContextMenuControl(this);
-
+            /*
             ContextMenuItemEntry markerFontEntry = new ContextMenuItemEntry(ResGumps.FontStyle);
             markerFontEntry.Add(new ContextMenuItemEntry(string.Format(ResGumps.Style0, 1), () => { SetFont(1); }));
             markerFontEntry.Add(new ContextMenuItemEntry(string.Format(ResGumps.Style0, 2), () => { SetFont(2); }));
@@ -484,12 +486,12 @@ namespace ClassicUO.Game.UI.Gumps
             ContextMenu.Add(markersEntry);
 
             BuildContextMenuForZones(ContextMenu);
-
+            */
             ContextMenuItemEntry namesHpBarEntry = new ContextMenuItemEntry(ResGumps.NamesHealthbars);
             namesHpBarEntry.Add(_options["show_your_name"]);
             namesHpBarEntry.Add(_options["show_your_healthbar"]);
-            namesHpBarEntry.Add(_options["show_party_name"]);
-            namesHpBarEntry.Add(_options["show_party_healthbar"]);
+            //namesHpBarEntry.Add(_options["show_party_name"]);
+            //namesHpBarEntry.Add(_options["show_party_healthbar"]);
 
             ContextMenu.Add(namesHpBarEntry);
 
@@ -497,26 +499,29 @@ namespace ClassicUO.Game.UI.Gumps
             ContextMenu.Add(_options["goto_location"]);
             ContextMenu.Add(_options["flip_map"]);
             ContextMenu.Add(_options["top_most"]);
-
+            /*
             ContextMenuItemEntry freeView = new ContextMenuItemEntry(ResGumps.FreeView);
             freeView.Add(_options["free_view"]);
 
             for (int i = 0; i < MapLoader.MAPS_COUNT; i++)
                 freeView.Add(_options[$"free_view_map_{i}"]);
 
-            ContextMenu.Add(freeView);
+            ContextMenu.Add(freeView);*/
+            ContextMenu.Add(_options["free_view"]);
 
             ContextMenu.Add("", null);
-            ContextMenu.Add(_options["show_party_members"]);
+            //ContextMenu.Add(_options["show_party_members"]);
             ContextMenu.Add(_options["show_mobiles"]);
             ContextMenu.Add(_options["show_multis"]);
             ContextMenu.Add(_options["show_coordinates"]);
             ContextMenu.Add(_options["show_sextant_coordinates"]);
             ContextMenu.Add(_options["show_mouse_coordinates"]);
+            /*
             ContextMenu.Add(_options["allow_positional_target"]);
             ContextMenu.Add("", null);
             ContextMenu.Add(_options["markers_manager"]);
             ContextMenu.Add(_options["add_marker_on_player"]);
+            */
             ContextMenu.Add("", null);
             ContextMenu.Add(_options["reset_map_cache"]);
             ContextMenu.Add(_options["saveclose"]);
@@ -537,7 +542,7 @@ namespace ClassicUO.Game.UI.Gumps
             if (_map.Index != World.MapIndex && !_freeView)
                 ChangeMap(World.MapIndex);
 
-            World.WMapManager.RequestServerPartyGuildInfo();
+            //World.WMapManager.RequestServerPartyGuildInfo(); disabled due to server not handling the request
         }
 
         public void ChangeMap(int index)
@@ -2185,6 +2190,8 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
+            //Show party members disabled
+            /*
             if (_showPartyMembers)
             {
                 for (int i = 0; i < 10; i++)
@@ -2243,6 +2250,10 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                 }
             }
+            */
+            
+
+
 
             DrawMobile
             (

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -232,11 +232,20 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Alternative Journal Hue.
+        ///   Looks up a localized string similar to Alternative journal hue.
         /// </summary>
         public static string AlternateJournalHue {
             get {
                 return ResourceManager.GetString("AlternateJournalHue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Alternative journal Transparency.
+        /// </summary>
+        public static string AlternateJournalTransparency {
+            get {
+                return ResourceManager.GetString("AlternateJournalTransparency", resourceCulture);
             }
         }
         

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -232,6 +232,15 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Alternative Journal Hue.
+        /// </summary>
+        public static string AlternateJournalHue {
+            get {
+                return ResourceManager.GetString("AlternateJournalHue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Alternative lights.
         /// </summary>
         public static string AlternativeLights {

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1616,7 +1616,10 @@ Client version: '{0}'</value>
     <value>Use alternative journal</value>
   </data>
   <data name="AlternateJournalHue" xml:space="preserve">
-    <value>Alternative Journal Hue</value>
+    <value>Alternative journal hue</value>
+  </data>
+  <data name="AlternateJournalTransparency" xml:space="preserve">
+    <value>Alternative journal Transparency</value>
   </data>
   <data name="StayActive" xml:space="preserve">
     <value>Stay active</value>

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1615,6 +1615,9 @@ Client version: '{0}'</value>
   <data name="UseAlternateJournal" xml:space="preserve">
     <value>Use alternative journal</value>
   </data>
+  <data name="AlternateJournalHue" xml:space="preserve">
+    <value>Alternative Journal Hue</value>
+  </data>
   <data name="StayActive" xml:space="preserve">
     <value>Stay active</value>
   </data>


### PR DESCRIPTION
- Introduced `AlternateJournalHue` property in `Profile` class for hue customization.
- Added `_AlternateJournalHue` field in `OptionsGump` for UI color selection.
- Updated UI layout to include color box for alternative journal hue.
- Initialized `_AlternateJournalHue` to `0x0000` and saved user selections.
- Changed journal background hue to use `AlternateJournalHue` from profile.
- Added label for `AlternateJournalHue` in resource files.