### PR TITLE
Picked up stale branch new-counterbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,4 @@ paket.lock
 __pycache__/
 *.pyc
 /.svn
+Data

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -221,8 +221,6 @@ namespace ClassicUO.Configuration
         public int CounterBarAbbreviatedAmount { get; set; } = 1000;
         public int CounterBarHighlightAmount { get; set; } = 5;
         public int CounterBarCellSize { get; set; } = 40;
-        public int CounterBarRows { get; set; } = 1;
-        public int CounterBarColumns { get; set; } = 1;
 
         public bool ShowSkillsChangedMessage { get; set; } = true;
         public int ShowSkillsChangedDeltaValue { get; set; } = 1;

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -215,7 +215,7 @@ namespace ClassicUO.Configuration
         public int InfoBarHighlightType { get; set; } // 0 = text colour changes, 1 = underline
 
         public bool CounterBarEnabled { get; set; }
-        public bool CounterBarHighlightOnUse { get; set; }
+        public bool CounterBarHighlightOnChange { get; set; } = true;
         public bool CounterBarHighlightOnAmount { get; set; }
         public bool CounterBarDisplayAbbreviatedAmount { get; set; }
         public int CounterBarAbbreviatedAmount { get; set; } = 1000;

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -543,5 +543,21 @@ namespace ClassicUO.Game.GameObjects
                 LastAnimationChangeTime = Time.Ticks + Constants.CHARACTER_ANIMATION_DELAY;
             }
         }
+
+        public void GetTotalAmount(ushort graphic, ushort? hue, ref int amount)
+        {
+            for (LinkedObject i = Items; i != null; i = i.Next)
+            {
+                if (i is Item item)
+                {
+                    item.GetTotalAmount(graphic, hue, ref amount);
+
+                    if (item.Graphic == graphic && (hue == null || item.Hue == hue.Value) && item.Exists)
+                    {
+                        amount += item.Amount;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
-using System.Linq;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.Gumps;
-using ClassicUO.Assets;
 using ClassicUO.Network;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
-using ClassicUO.Game.Scenes;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -219,6 +219,30 @@ namespace ClassicUO.Game.GameObjects
             }
 
             return item;
+        }
+
+        public int GetTotalAmountOfItem(ushort graphic, ushort? hue)
+        {
+            int _amount = 0;
+
+            for (
+                Item item = (Item)World.Player.Items;
+                item != null;
+                item = (Item)item.Next
+            )
+            {
+                if (
+                    item.ItemData.IsContainer
+                    && !item.IsEmpty
+                    && item.Layer >= Layer.OneHanded
+                    && item.Layer <= Layer.Legs
+                )
+                {
+                    item.GetTotalAmount(graphic, hue, ref _amount);
+                }
+            }
+
+            return _amount;
         }
 
         public void AddBuff(BuffIconType type, ushort graphic, uint time, string text)

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -1778,6 +1778,16 @@ namespace ClassicUO.Game.Managers
                 case MacroType.LookAtMouse:
                     // handle in gamesceneinput
                     break;
+
+                case MacroType.UseCounterBarSlot:
+                    {
+                        MacroObjectString objectString = (MacroObjectString)macro;
+                        string slotString = objectString.Text;
+
+                        CounterBarGump gump = UIManager.Gumps.First(gump => gump is CounterBarGump) as CounterBarGump;
+                        gump?.UseSlot(slotString);
+                        break;
+                    }
             }
 
 
@@ -2033,6 +2043,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.SetUpdateRange:
                 case MacroType.ModifyUpdateRange:
                 case MacroType.RazorMacro:
+                case MacroType.UseCounterBarSlot:
                     obj = new MacroObjectString(code, MacroSubType.MSC_NONE);
 
                     break;
@@ -2207,6 +2218,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.SetUpdateRange:
                 case MacroType.ModifyUpdateRange:
                 case MacroType.RazorMacro:
+                case MacroType.UseCounterBarSlot:
                     SubMenuType = 2;
 
                     break;
@@ -2323,7 +2335,8 @@ namespace ClassicUO.Game.Managers
         CloseInactiveHealthBars,
         CloseCorpses,
         UseObject,
-        LookAtMouse
+        LookAtMouse,
+        UseCounterBarSlot
     }
 
     internal enum MacroSubType

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -1784,8 +1784,10 @@ namespace ClassicUO.Game.Managers
                         MacroObjectString objectString = (MacroObjectString)macro;
                         string slotString = objectString.Text;
 
-                        CounterBarGump gump = UIManager.Gumps.First(gump => gump is CounterBarGump) as CounterBarGump;
-                        gump?.UseSlot(slotString);
+                        if (UIManager.GetGump<CounterBarGump>() is { } bar)
+                        {
+                            bar.UseSlot(slotString);
+                        }
                         break;
                     }
             }

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -523,7 +523,7 @@ namespace ClassicUO.Game.Managers
         /// </summary>
         /// <param name="allowedGumps">Gumps for which hovered controls should be returned</param>
         /// <returns>Read-only enumerable with the desired controls.</returns>
-        public static IEnumerable<Control> GetAllMouseOverControls(IEnumerable<Type> allowedGumps)
+        public static IEnumerable<Control> GetAllMouseOverControlsOfType<T>() where T : Control
         {
             List<Control> results = new List<Control>();
 
@@ -537,7 +537,7 @@ namespace ClassicUO.Game.Managers
             {
                 Control c = first.Value;
 
-                if (IsModalOpen && !c.IsModal || !c.IsVisible || !c.IsEnabled || !allowedGumps.Contains(c.GetType()))
+                if (IsModalOpen && !c.IsModal || !c.IsVisible || !c.IsEnabled || c is not T)
                 {
                     continue;
                 }

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
@@ -510,6 +514,46 @@ namespace ClassicUO.Game.Managers
 
             return null;
         }
+
+        /// <summary>
+        ///     Returns all controls which are part of a Gump from the provided list,
+        ///     as long as they are below the current mouse cursor position.
+        ///     
+        ///     Never returns null, but an empty enumerable instead.
+        /// </summary>
+        /// <param name="allowedGumps">Gumps for which hovered controls should be returned</param>
+        /// <returns>Read-only enumerable with the desired controls.</returns>
+        public static IEnumerable<Control> GetAllMouseOverControls(IEnumerable<Type> allowedGumps)
+        {
+            List<Control> results = new List<Control>();
+
+            Point position = Mouse.Position;
+
+            Control control = null;
+
+            IsModalOpen = IsModalControlOpen();
+
+            for (LinkedListNode<Gump> first = Gumps.First; first != null; first = first.Next)
+            {
+                Control c = first.Value;
+
+                if (IsModalOpen && !c.IsModal || !c.IsVisible || !c.IsEnabled || !allowedGumps.Contains(c.GetType()))
+                {
+                    continue;
+                }
+
+                c.HitTest(position, ref control);
+
+                if (control != null)
+                {
+                    results.Add(control);
+                }
+            }
+
+            return results.AsReadOnly();
+        }
+
+
 
         public static void MakeTopMostGump(Control control)
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+using ClassicUO.Configuration;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Input;
+using ClassicUO.Renderer;
+using ClassicUO.Resources;
+using ClassicUO.Utility;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClassicUO.Game.UI.Gumps
+{
+    internal partial class CounterBarGump
+    {
+        private class CounterItem : Control
+        {
+            private int _amount;
+            private readonly ImageWithText _image;
+            private uint _time;
+            private readonly CounterBarGump _gump;
+
+            public CounterItem(CounterBarGump gump, ushort graphic, ushort hue, int compareTo)
+            {
+                _gump = gump;
+                CompareTo = compareTo;
+                
+                AcceptMouseInput = true;
+                WantUpdateSize = false;
+                CanMove = true;
+                CanCloseWithRightClick = false;
+
+                _image = new ImageWithText();
+                Add(_image);
+
+                SetGraphic(graphic, hue);
+            }
+
+            public ushort Graphic { get; private set; }
+
+            public ushort Hue { get; private set; }
+
+            public int CompareTo { get; private set; }
+
+            public void SetGraphic(ushort graphic, ushort hue)
+            {
+                _image.ChangeGraphic(graphic, hue);
+
+                Graphic = graphic;
+                Hue = hue;
+
+                ContextMenu = new ContextMenuControl(_gump);
+                if (graphic != 0)
+                {
+                    ContextMenu.Add(ResGumps.UseObject, Use);
+                    ContextMenu.Add(ResGumps.CounterCompareTo, CompareToSelected);
+                }
+            }
+
+            private void CompareToSelected()
+            {
+                UIManager.Add(new EntryDialog(_gump.World, 250, 160,
+                    string.Format("{0}\n{1}", ResGumps.CounterCompareToDialogText1, ResGumps.CounterCompareToDialogText2),
+                    CompareToDialogClosed, _amount.ToString()));
+            }
+
+            private void CompareToDialogClosed(string newValue)
+            {
+                if (string.IsNullOrEmpty(newValue))
+                {
+                    CompareTo = 0;
+                }
+                else if (int.TryParse(newValue, out int parsedValue))
+                {
+                    CompareTo = parsedValue;
+                }
+                else
+                {
+                    UIManager.Add(new EntryDialog(_gump.World, 250, 180,
+                        string.Format("{0}\n{1}\n\n{2}", ResGumps.CounterCompareToDialogText1, ResGumps.CounterCompareToDialogText2, ResGumps.CounterCompareToDialogInvalid),
+                        CompareToDialogClosed, newValue));
+                }
+            }
+
+            public void RemoveItem()
+            {
+                _image?.ChangeGraphic(0, 0);
+                _amount = 0;
+                Graphic = 0;
+
+                Dispose();
+
+                if (RootParent is CounterBarGump g)
+                {
+                    g.SetupLayout();
+                }
+            }
+
+            public void Use()
+            {
+                if (Graphic == 0)
+                {
+                    return;
+                }
+
+                Item backpack = _gump.World.Player.FindItemByLayer(Layer.Backpack);
+
+                if (backpack == null)
+                {
+                    return;
+                }
+
+                Item item = backpack.FindItem(Graphic, Hue);
+
+                if (item != null)
+                {
+                    GameActions.DoubleClick(_gump.World, item);
+                }
+            }
+
+            protected override void OnMouseOver(int x, int y)
+            {
+                base.OnMouseOver(x, y);
+
+                if (_gump.World.Player.FindItemByLayer(Layer.Backpack)?.FindItem(Graphic, Hue) is {} item)
+                    SetTooltip(item);
+            }
+
+            protected override void OnMouseExit(int x, int y)
+            {
+                base.OnMouseExit(x, y);
+                ClearTooltip();
+            }
+
+            protected override void OnDragBegin(int x, int y)
+            {
+                DraggableGump gump = new DraggableGump(_gump.World)
+                {
+                    X = Mouse.LClickPosition.X - 22,
+                    Y = Mouse.LClickPosition.Y - 22
+                };
+                gump.Add(this);
+                X = 0;
+                Y = 0;
+
+                UIManager.Add(gump);
+
+                UIManager.AttemptDragControl(gump, true);
+
+                _gump.SetupLayout();
+            }
+
+            protected override void OnDragEnd(int x, int y)
+            {
+                Control oldParent = this.Parent;
+                if (oldParent is DraggableGump)
+                {
+                    FinalizeDragDrop(oldParent, UIManager.GetAllMouseOverControls([typeof(CounterBarGump)]));
+                }
+
+                base.OnDragEnd(x, y);
+            }
+
+            private void FinalizeDragDrop(Control oldParent, IEnumerable<Control> hoveredControls)
+            {
+                if (hoveredControls.Any())
+                {
+                    int desiredIndex = Math.Min(hoveredControls.Count() - 1, 1);
+
+                    CounterItem item = hoveredControls.First() as CounterItem;
+                    CounterBarGump bar = hoveredControls.First().RootParent as CounterBarGump;
+
+                    if (bar != null)
+                    {
+                        if (item != null)
+                        {
+                            bar._dataBox.Insert(bar._dataBox.Children.IndexOf(item), this);
+                            bar.SetupLayout();
+                        }
+                        else
+                        {
+                            bar._dataBox.Add(this);
+                            bar.SetupLayout();
+                        }
+                            
+                    }
+
+                }
+                oldParent.Dispose();
+            }
+
+            protected override void OnMouseUp(int x, int y, MouseButtonType button)
+            {
+                if (button == MouseButtonType.Left)
+                {
+                    if (Client.Game.UO.GameCursor.ItemHold.Enabled)
+                    {
+                        SetGraphic(
+                            Client.Game.UO.GameCursor.ItemHold.Graphic,
+                            Client.Game.UO.GameCursor.ItemHold.Hue
+                        );
+
+                        GameActions.DropItem(
+                            Client.Game.UO.GameCursor.ItemHold.Serial,
+                            Client.Game.UO.GameCursor.ItemHold.X,
+                            Client.Game.UO.GameCursor.ItemHold.Y,
+                            0,
+                            Client.Game.UO.GameCursor.ItemHold.Container
+                        );
+                    }
+                    else if (ProfileManager.CurrentProfile.CastSpellsByOneClick)
+                    {
+                        Use();
+                    }
+                }
+                else if (button == MouseButtonType.Right && Keyboard.Alt )
+                {
+                    RemoveItem();
+                }
+                else if (button == MouseButtonType.Right)
+                {
+                    base.OnMouseUp(x, y, button);
+                }
+                else if (Graphic != 0)
+                {
+                    base.OnMouseUp(x, y, button);
+                }
+            }
+
+            protected override bool OnMouseDoubleClick(int x, int y, MouseButtonType button)
+            {
+                if (
+                    button == MouseButtonType.Left
+                    && !ProfileManager.CurrentProfile.CastSpellsByOneClick
+                )
+                {
+                    Use();
+                }
+
+                return true;
+            }
+
+            private int CalculateDisplayAmount()
+            {
+                return _amount - CompareTo;
+            }
+
+            public override void Update()
+            {
+                base.Update();
+
+                if (!IsDisposed)
+                {
+                    _image.Width = Width;
+                    _image.Height = Height;
+                }
+
+                if (Parent != null && Parent.IsEnabled && _time < Time.Ticks)
+                {
+                    _time = Time.Ticks + 100;
+
+                    if (Graphic == 0)
+                    {
+                        _image.SetAmount(string.Empty);
+                    }
+                    else
+                    {
+                        _amount = 0;
+
+                        for (
+                            Item item = (Item)_gump.World.Player.Items;
+                            item != null;
+                            item = (Item)item.Next
+                        )
+                        {
+                            if (
+                                item.ItemData.IsContainer
+                                && !item.IsEmpty
+                                && item.Layer >= Layer.OneHanded
+                                && item.Layer <= Layer.Legs
+                            )
+                            {
+                                GetAmount(item, Graphic, Hue, ref _amount);
+                            }
+                        }
+
+                        int displayAmount = CalculateDisplayAmount();
+                        string prefix;
+                        if (CompareTo == 0)
+                        {
+                            prefix = "";
+                        }
+                        else if (displayAmount == 0)
+                        {
+                            prefix = "±";
+                        }
+                        else if (displayAmount > 0)
+                        {
+                            prefix = "+";
+                        }
+                        else
+                        {
+                            prefix = "";  // a negative number already comes with its prefix
+                        }
+
+                        if (ProfileManager.CurrentProfile.CounterBarDisplayAbbreviatedAmount)
+                        {
+                            if (
+                                displayAmount >= ProfileManager.CurrentProfile.CounterBarAbbreviatedAmount
+                            )
+                            {
+                                _image.SetAmount(prefix + StringHelper.IntToAbbreviatedString(displayAmount));
+
+                                return;
+                            }
+                        }
+
+                        _image.SetAmount(prefix + displayAmount.ToString());
+                    }
+                }
+            }
+
+            private static void GetAmount(Item parent, ushort graphic, ushort hue, ref int amount)
+            {
+                if (parent == null)
+                {
+                    return;
+                }
+
+                for (LinkedObject i = parent.Items; i != null; i = i.Next)
+                {
+                    Item item = (Item)i;
+
+                    GetAmount(item, graphic, hue, ref amount);
+
+                    if (item.Graphic == graphic && item.Hue == hue && item.Exists)
+                    {
+                        amount += item.Amount;
+                    }
+                }
+            }
+
+            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            {
+                base.Draw(batcher, x, y);
+
+                Texture2D color = SolidColorTextureCache.GetTexture(
+                    MouseIsOver
+                        ? Color.Yellow
+                        : ProfileManager.CurrentProfile.CounterBarHighlightOnAmount
+                        && CalculateDisplayAmount() < ProfileManager.CurrentProfile.CounterBarHighlightAmount
+                        && Graphic != 0
+                            ? Color.Red
+                            : Color.Gray
+                );
+
+                Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
+
+                batcher.DrawRectangle(color, x, y, Width, Height, hueVector);
+
+                return true;
+            }
+
+            private class ImageWithText : Control
+            {
+                private readonly Label _label;
+                private ushort _graphic;
+                private ushort _hue;
+                private bool _partial;
+
+                public ImageWithText()
+                {
+                    CanMove = true;
+                    WantUpdateSize = true;
+                    AcceptMouseInput = false;
+
+                    _label = new Label("", true, 0x35, 0, 1, FontStyle.BlackBorder)
+                    {
+                        X = 2,
+                        Y = Height - 15
+                    };
+
+                    Add(_label);
+                }
+
+                public void ChangeGraphic(ushort graphic, ushort hue)
+                {
+                    if (graphic != 0)
+                    {
+                        _graphic = graphic;
+                        _hue = hue;
+                        _partial = Client.Game.UO.FileManager.TileData.StaticData[graphic].IsPartialHue;
+                    }
+                    else
+                    {
+                        _graphic = 0;
+                    }
+                }
+
+                public override void Update()
+                {
+                    base.Update();
+
+                    if (Parent != null)
+                    {
+                        Width = Parent.Width;
+                        Height = Parent.Height;
+                        _label.Y = Parent.Height - 15;
+                    }
+                }
+
+                public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+                {
+                    if (_graphic != 0)
+                    {
+                        ref readonly var artInfo = ref Client.Game.UO.Arts.GetArt(_graphic);
+                        var rect = Client.Game.UO.Arts.GetRealArtBounds(_graphic);
+
+                        Vector3 hueVector = ShaderHueTranslator.GetHueVector(_hue, _partial, 1f);
+
+                        Point originalSize = new Point(Width, Height);
+                        Point point = new Point();
+
+                        if (rect.Width < Width)
+                        {
+                            originalSize.X = rect.Width;
+                            point.X = (Width >> 1) - (originalSize.X >> 1);
+                        }
+
+                        if (rect.Height < Height)
+                        {
+                            originalSize.Y = rect.Height;
+                            point.Y = (Height >> 1) - (originalSize.Y >> 1);
+                        }
+
+                        batcher.Draw(
+                            artInfo.Texture,
+                            new Rectangle(x + point.X, y + point.Y, originalSize.X, originalSize.Y),
+                            new Rectangle(
+                                artInfo.UV.X + rect.X,
+                                artInfo.UV.Y + rect.Y,
+                                rect.Width,
+                                rect.Height
+                            ),
+                            hueVector
+                        );
+                    }
+
+                    return base.Draw(batcher, x, y);
+                }
+
+                public void SetAmount(string amount)
+                {
+                    _label.Text = amount;
+                }
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
@@ -312,7 +312,7 @@ namespace ClassicUO.Game.UI.Gumps
                         if (ProfileManager.CurrentProfile.CounterBarDisplayAbbreviatedAmount)
                         {
                             if (
-                                displayAmount >= ProfileManager.CurrentProfile.CounterBarAbbreviatedAmount
+                                Math.Abs(displayAmount) >= ProfileManager.CurrentProfile.CounterBarAbbreviatedAmount
                             )
                             {
                                 _image.SetAmount(prefix + StringHelper.IntToAbbreviatedString(displayAmount));

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
@@ -56,12 +56,21 @@ namespace ClassicUO.Game.UI.Gumps
                 Graphic = graphic;
                 Hue = hue;
 
+                ConfigureContextMenu();
+            }
+
+            internal void ConfigureContextMenu()
+            {
                 ContextMenu = new ContextMenuControl(_gump);
-                if (graphic != 0)
+                if (Graphic != 0)
                 {
                     ContextMenu.Add(ResGumps.UseObject, Use);
                     ContextMenu.Add(ResGumps.CounterCompareTo, CompareToSelected);
                     ContextMenu.Add(Hue != null ? ResGumps.CounterIgnoreHueOff : ResGumps.CounterIgnoreHueOn, ToggleIgnoreHue);
+                }
+                else
+                {
+                    _gump.ConfigureContextMenu(ContextMenu); // Placeholders receive context menu from parent
                 }
             }
 
@@ -163,6 +172,12 @@ namespace ClassicUO.Game.UI.Gumps
 
             protected override void OnDragBegin(int x, int y)
             {
+                if (!_gump.ShowBorder)
+                {
+                    // in read-only mode
+                    return;
+                }
+
                 DraggableGump gump = new DraggableGump(_gump.World)
                 {
                     X = Mouse.LClickPosition.X - 22,
@@ -181,6 +196,12 @@ namespace ClassicUO.Game.UI.Gumps
 
             protected override void OnDragEnd(int x, int y)
             {
+                if (!_gump.ShowBorder)
+                {
+                    // in read-only mode
+                    return;
+                }
+
                 Control oldParent = this.Parent;
                 if (oldParent is DraggableGump)
                 {
@@ -224,10 +245,14 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     if (Client.Game.UO.GameCursor.ItemHold.Enabled)
                     {
-                        SetGraphic(
-                            Client.Game.UO.GameCursor.ItemHold.Graphic,
-                            Client.Game.UO.GameCursor.ItemHold.Hue
-                        );
+                        if (_gump.ShowBorder)
+                        {
+                            // not in read-only mode
+                            SetGraphic(
+                                Client.Game.UO.GameCursor.ItemHold.Graphic,
+                                Client.Game.UO.GameCursor.ItemHold.Hue
+                            );
+                        }
 
                         GameActions.DropItem(
                             Client.Game.UO.GameCursor.ItemHold.Serial,
@@ -244,7 +269,11 @@ namespace ClassicUO.Game.UI.Gumps
                 }
                 else if (button == MouseButtonType.Right && Keyboard.Alt )
                 {
-                    RemoveItem();
+                    if (_gump.ShowBorder)
+                    {
+                        // not in read-only mode
+                        RemoveItem();
+                    }
                 }
                 else if (button == MouseButtonType.Right)
                 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
@@ -23,8 +23,10 @@ namespace ClassicUO.Game.UI.Gumps
         private class CounterItem : Control
         {
             private int _amount;
+            private uint _lastChangeTime;
             private readonly ImageWithText _image;
             private uint _time;
+            private AlphaBlendControl _background;
             private readonly CounterBarGump _gump;
 
             public CounterItem(CounterBarGump gump, ushort graphic, ushort? hue, int compareTo)
@@ -37,8 +39,8 @@ namespace ClassicUO.Game.UI.Gumps
                 CanMove = true;
                 CanCloseWithRightClick = false;
 
-                _image = new ImageWithText();
-                Add(_image);
+                Add(_background = new AlphaBlendControl(0.0f) { X = 0, Y = 0 });
+                Add(_image = new ImageWithText());
 
                 SetGraphic(graphic, hue);
             }
@@ -311,6 +313,9 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     _image.Width = Width;
                     _image.Height = Height;
+
+                    _background.Width = Width;
+                    _background.Height = Height;
                 }
 
                 if (Parent != null && Parent.IsEnabled && _time < Time.Ticks)
@@ -323,6 +328,7 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                     else
                     {
+                        int previousAmount = _amount;
                         _amount = 0;
 
                         for (
@@ -340,6 +346,22 @@ namespace ClassicUO.Game.UI.Gumps
                             {
                                 GetAmount(item, Graphic, Hue, ref _amount);
                             }
+                        }
+
+                        if (ProfileManager.CurrentProfile.CounterBarHighlightOnUse)
+                        {
+                            if (_amount > previousAmount)
+                            {
+                                _background.Hue = 1165; //icelight
+                                _lastChangeTime = Time.Ticks;
+                            }
+                            else if (_amount < previousAmount)
+                            {
+                                _background.Hue = 1166; //firelight
+                                _lastChangeTime = Time.Ticks;
+                            }
+
+                            _background.Alpha = Math.Min(1, 1 - (Time.Ticks - _lastChangeTime) / 5000f);
                         }
 
                         int displayAmount = CalculateDisplayAmount();

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
@@ -361,7 +361,7 @@ namespace ClassicUO.Game.UI.Gumps
                                 _lastChangeTime = Time.Ticks;
                             }
 
-                            _background.Alpha = Math.Min(1, 1 - (Time.Ticks - _lastChangeTime) / 5000f);
+                            _background.Alpha = Math.Max(0, 1 - (Time.Ticks - _lastChangeTime) / 5000f);
                         }
 
                         int displayAmount = CalculateDisplayAmount();

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.DraggableGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.DraggableGump.cs
@@ -1,0 +1,37 @@
+﻿using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ClassicUO.Game.UI.Gumps
+{
+    internal partial class CounterBarGump
+    {
+        private class DraggableGump : Gump
+        {
+            public DraggableGump(World world) : base(world, 0, 0)
+            {
+                CanMove = true;
+            }
+
+            protected override void OnDragBegin(int x, int y)
+            {
+                base.OnDragBegin(x, y);
+            }
+
+            protected override void OnDragEnd(int x, int y)
+            {
+                if (UIManager.MouseOverControl == this || UIManager.MouseOverControl?.RootParent == this)
+                {
+                    Children.First()?.InvokeDragEnd(new Point(x, y));
+                }
+
+                base.OnDragEnd(x, y);
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -1,25 +1,18 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 using ClassicUO.Configuration;
-using ClassicUO.Game.Data;
-using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Renderer;
 using ClassicUO.Resources;
-using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.Linq;
 using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
-    internal class CounterBarGump : ResizableGump
+    internal partial class CounterBarGump : ResizableGump
     {
         private AlphaBlendControl _background;
 
@@ -94,6 +87,26 @@ namespace ClassicUO.Game.UI.Gumps
             OnResize();
         }
 
+        protected override void OnDragBegin(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragBegin(new Point(x, y));
+            }
+
+            base.OnDragBegin(x, y);
+        }
+
+        protected override void OnDragEnd(int x, int y)
+        {
+            if (UIManager.MouseOverControl?.RootParent == this)
+            {
+                UIManager.MouseOverControl.InvokeDragEnd(new Point(x, y));
+            }
+
+            base.OnDragEnd(x, y);
+        }
+
         public override void OnResize()
         {
             base.OnResize();
@@ -127,8 +140,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             for (int i = 0; i < _dataBox.Children.Count; i++)
             {
-                CounterItem c = (CounterItem)_dataBox.Children[i];
-                if (!c.IsDisposed)
+                CounterItem c = _dataBox.Children[i] as CounterItem;
+                if ( c != null && !c.IsDisposed)
                 {
                     c.X = x;
                     c.Y = y;
@@ -142,6 +155,8 @@ namespace ClassicUO.Game.UI.Gumps
                         x = 2;
                         y += _rectSize + 2;
                     }
+
+                    continue;
                 }
             }
         }
@@ -188,7 +203,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             writer.WriteStartElement("controls");
 
-            foreach (CounterItem control in _dataBox.Children.Cast<CounterItem>())
+            foreach (CounterItem control in _dataBox.Children.FindAll(c => c is CounterItem).Cast<CounterItem>())
             {
                 if (control.Graphic != 0)
                 {
@@ -242,6 +257,7 @@ namespace ClassicUO.Game.UI.Gumps
                         CounterItem c = new CounterItem(this, graphic, ushort.Parse(controlXml.GetAttribute("hue")), compareTo);
 
                         _dataBox.Add(c);
+                        
                     }
                 }
             }
@@ -249,393 +265,6 @@ namespace ClassicUO.Game.UI.Gumps
             IsEnabled = IsVisible = ProfileManager.CurrentProfile.CounterBarEnabled;
 
             SetupLayout();
-        }
-
-        private class CounterItem : Control
-        {
-            private int _amount;
-            private readonly ImageWithText _image;
-            private uint _time;
-            private readonly CounterBarGump _gump;
-
-            public CounterItem(CounterBarGump gump, ushort graphic, ushort hue, int compareTo)
-            {
-                _gump = gump;
-                CompareTo = compareTo;
-                
-                AcceptMouseInput = true;
-                WantUpdateSize = false;
-                CanMove = true;
-                CanCloseWithRightClick = false;
-
-                _image = new ImageWithText();
-                Add(_image);
-
-                SetGraphic(graphic, hue);
-            }
-
-            public ushort Graphic { get; private set; }
-
-            public ushort Hue { get; private set; }
-
-            public int CompareTo { get; private set; }
-
-            public void SetGraphic(ushort graphic, ushort hue)
-            {
-                _image.ChangeGraphic(graphic, hue);
-
-                Graphic = graphic;
-                Hue = hue;
-
-                ContextMenu = new ContextMenuControl(_gump);
-                if (graphic != 0)
-                {
-                    ContextMenu.Add(ResGumps.UseObject, Use);
-                    ContextMenu.Add(ResGumps.CounterCompareTo, CompareToSelected);
-                }
-                ContextMenu.Add(ResGumps.Remove, RemoveItem);
-            }
-
-            private void CompareToSelected()
-            {
-                UIManager.Add(new EntryDialog(_gump.World, 250, 160,
-                    string.Format("{0}\n{1}", ResGumps.CounterCompareToDialogText1, ResGumps.CounterCompareToDialogText2),
-                    CompareToDialogClosed, _amount.ToString()));
-            }
-
-            private void CompareToDialogClosed(string newValue)
-            {
-                if (string.IsNullOrEmpty(newValue))
-                {
-                    CompareTo = 0;
-                }
-                else if (int.TryParse(newValue, out int parsedValue))
-                {
-                    CompareTo = parsedValue;
-                }
-                else
-                {
-                    UIManager.Add(new EntryDialog(_gump.World, 250, 180,
-                        string.Format("{0}\n{1}\n\n{2}", ResGumps.CounterCompareToDialogText1, ResGumps.CounterCompareToDialogText2, ResGumps.CounterCompareToDialogInvalid),
-                        CompareToDialogClosed, newValue));
-                }
-            }
-
-            public void RemoveItem()
-            {
-                _image?.ChangeGraphic(0, 0);
-                _amount = 0;
-                Graphic = 0;
-
-                Dispose();
-
-                if (RootParent is CounterBarGump g)
-                {
-                    g.SetupLayout();
-                }
-            }
-
-            public void Use()
-            {
-                if (Graphic == 0)
-                {
-                    return;
-                }
-
-                Item backpack = _gump.World.Player.FindItemByLayer(Layer.Backpack);
-
-                if (backpack == null)
-                {
-                    return;
-                }
-
-                Item item = backpack.FindItem(Graphic, Hue);
-
-                if (item != null)
-                {
-                    GameActions.DoubleClick(_gump.World, item);
-                }
-            }
-
-            protected override void OnMouseOver(int x, int y)
-            {
-                base.OnMouseOver(x, y);
-
-                if (_gump.World.Player.FindItemByLayer(Layer.Backpack)?.FindItem(Graphic, Hue) is {} item)
-                    SetTooltip(item);
-            }
-
-            protected override void OnMouseExit(int x, int y)
-            {
-                base.OnMouseExit(x, y);
-                ClearTooltip();
-            }
-
-            protected override void OnMouseUp(int x, int y, MouseButtonType button)
-            {
-                if (button == MouseButtonType.Left)
-                {
-                    if (Client.Game.UO.GameCursor.ItemHold.Enabled)
-                    {
-                        SetGraphic(
-                            Client.Game.UO.GameCursor.ItemHold.Graphic,
-                            Client.Game.UO.GameCursor.ItemHold.Hue
-                        );
-
-                        GameActions.DropItem(
-                            Client.Game.UO.GameCursor.ItemHold.Serial,
-                            Client.Game.UO.GameCursor.ItemHold.X,
-                            Client.Game.UO.GameCursor.ItemHold.Y,
-                            0,
-                            Client.Game.UO.GameCursor.ItemHold.Container
-                        );
-                    }
-                    else if (ProfileManager.CurrentProfile.CastSpellsByOneClick)
-                    {
-                        Use();
-                    }
-                }
-                else if (button == MouseButtonType.Right && Keyboard.Alt )
-                {
-                    RemoveItem();
-                }
-                else if (button == MouseButtonType.Right)
-                {
-                    base.OnMouseUp(x, y, button);
-                }
-                else if (Graphic != 0)
-                {
-                    base.OnMouseUp(x, y, button);
-                }
-            }
-
-            protected override bool OnMouseDoubleClick(int x, int y, MouseButtonType button)
-            {
-                if (
-                    button == MouseButtonType.Left
-                    && !ProfileManager.CurrentProfile.CastSpellsByOneClick
-                )
-                {
-                    Use();
-                }
-
-                return true;
-            }
-
-            private int CalculateDisplayAmount()
-            {
-                return _amount - CompareTo;
-            }
-
-            public override void Update()
-            {
-                base.Update();
-
-                if (!IsDisposed)
-                {
-                    _image.Width = Width;
-                    _image.Height = Height;
-                }
-
-                if (Parent != null && Parent.IsEnabled && _time < Time.Ticks)
-                {
-                    _time = Time.Ticks + 100;
-
-                    if (Graphic == 0)
-                    {
-                        _image.SetAmount(string.Empty);
-                    }
-                    else
-                    {
-                        _amount = 0;
-
-                        for (
-                            Item item = (Item)_gump.World.Player.Items;
-                            item != null;
-                            item = (Item)item.Next
-                        )
-                        {
-                            if (
-                                item.ItemData.IsContainer
-                                && !item.IsEmpty
-                                && item.Layer >= Layer.OneHanded
-                                && item.Layer <= Layer.Legs
-                            )
-                            {
-                                GetAmount(item, Graphic, Hue, ref _amount);
-                            }
-                        }
-
-                        int displayAmount = CalculateDisplayAmount();
-                        string prefix;
-                        if (CompareTo == 0)
-                        {
-                            prefix = "";
-                        }
-                        else if (displayAmount == 0)
-                        {
-                            prefix = "±";
-                        }
-                        else if (displayAmount > 0)
-                        {
-                            prefix = "+";
-                        }
-                        else
-                        {
-                            prefix = "";  // a negative number already comes with its prefix
-                        }
-
-                        if (ProfileManager.CurrentProfile.CounterBarDisplayAbbreviatedAmount)
-                        {
-                            if (
-                                displayAmount >= ProfileManager.CurrentProfile.CounterBarAbbreviatedAmount
-                            )
-                            {
-                                _image.SetAmount(prefix + StringHelper.IntToAbbreviatedString(displayAmount));
-
-                                return;
-                            }
-                        }
-
-                        _image.SetAmount(prefix + displayAmount.ToString());
-                    }
-                }
-            }
-
-            private static void GetAmount(Item parent, ushort graphic, ushort hue, ref int amount)
-            {
-                if (parent == null)
-                {
-                    return;
-                }
-
-                for (LinkedObject i = parent.Items; i != null; i = i.Next)
-                {
-                    Item item = (Item)i;
-
-                    GetAmount(item, graphic, hue, ref amount);
-
-                    if (item.Graphic == graphic && item.Hue == hue && item.Exists)
-                    {
-                        amount += item.Amount;
-                    }
-                }
-            }
-
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
-            {
-                base.Draw(batcher, x, y);
-
-                Texture2D color = SolidColorTextureCache.GetTexture(
-                    MouseIsOver
-                        ? Color.Yellow
-                        : ProfileManager.CurrentProfile.CounterBarHighlightOnAmount
-                        && CalculateDisplayAmount() < ProfileManager.CurrentProfile.CounterBarHighlightAmount
-                        && Graphic != 0
-                            ? Color.Red
-                            : Color.Gray
-                );
-
-                Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
-
-                batcher.DrawRectangle(color, x, y, Width, Height, hueVector);
-
-                return true;
-            }
-
-            private class ImageWithText : Control
-            {
-                private readonly Label _label;
-                private ushort _graphic;
-                private ushort _hue;
-                private bool _partial;
-
-                public ImageWithText()
-                {
-                    CanMove = true;
-                    WantUpdateSize = true;
-                    AcceptMouseInput = false;
-
-                    _label = new Label("", true, 0x35, 0, 1, FontStyle.BlackBorder)
-                    {
-                        X = 2,
-                        Y = Height - 15
-                    };
-
-                    Add(_label);
-                }
-
-                public void ChangeGraphic(ushort graphic, ushort hue)
-                {
-                    if (graphic != 0)
-                    {
-                        _graphic = graphic;
-                        _hue = hue;
-                        _partial = Client.Game.UO.FileManager.TileData.StaticData[graphic].IsPartialHue;
-                    }
-                    else
-                    {
-                        _graphic = 0;
-                    }
-                }
-
-                public override void Update()
-                {
-                    base.Update();
-
-                    if (Parent != null)
-                    {
-                        Width = Parent.Width;
-                        Height = Parent.Height;
-                        _label.Y = Parent.Height - 15;
-                    }
-                }
-
-                public override bool Draw(UltimaBatcher2D batcher, int x, int y)
-                {
-                    if (_graphic != 0)
-                    {
-                        ref readonly var artInfo = ref Client.Game.UO.Arts.GetArt(_graphic);
-                        var rect = Client.Game.UO.Arts.GetRealArtBounds(_graphic);
-
-                        Vector3 hueVector = ShaderHueTranslator.GetHueVector(_hue, _partial, 1f);
-
-                        Point originalSize = new Point(Width, Height);
-                        Point point = new Point();
-
-                        if (rect.Width < Width)
-                        {
-                            originalSize.X = rect.Width;
-                            point.X = (Width >> 1) - (originalSize.X >> 1);
-                        }
-
-                        if (rect.Height < Height)
-                        {
-                            originalSize.Y = rect.Height;
-                            point.Y = (Height >> 1) - (originalSize.Y >> 1);
-                        }
-
-                        batcher.Draw(
-                            artInfo.Texture,
-                            new Rectangle(x + point.X, y + point.Y, originalSize.X, originalSize.Y),
-                            new Rectangle(
-                                artInfo.UV.X + rect.X,
-                                artInfo.UV.Y + rect.Y,
-                                rect.Width,
-                                rect.Height
-                            ),
-                            hueVector
-                        );
-                    }
-
-                    return base.Draw(batcher, x, y);
-                }
-
-                public void SetAmount(string amount)
-                {
-                    _label.Text = amount;
-                }
-            }
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -31,6 +31,24 @@ namespace ClassicUO.Game.UI.Gumps
         public CounterBarGump(World world) : base(world, 0, 0, 50, 50, 0, 0, 0)
         {
             ContextMenu = ConfigureContextMenu(new ContextMenuControl(this));
+
+            ResizeCompleted += CounterBarGump_ResizeCompleted;
+        }
+
+        private void CounterBarGump_ResizeCompleted(object sender, ResizeCompletedEventArgs e)
+        {
+            SnapToGrid();
+        }
+
+        private void SnapToGrid()
+        {
+            int tooWide = (Width - BoderSize * 2) % _rectSize;
+            int tooHigh = (Height - BoderSize * 2) % _rectSize;
+
+            if (tooWide > 0 || tooHigh > 0)
+            {
+                ResizeWindow(new Point(Width - tooWide, Height - tooHigh));
+            }
         }
 
         private ContextMenuControl ConfigureContextMenu(ContextMenuControl control)
@@ -91,6 +109,7 @@ namespace ClassicUO.Game.UI.Gumps
                     size = 80;
                 }
                 _rectSize = size;
+                SnapToGrid();
                 SetupLayout();
             }
         }
@@ -115,6 +134,7 @@ namespace ClassicUO.Game.UI.Gumps
             _dataBox.WantUpdateSize = true;
 
             ResizeWindow(new Point(Width, Height));
+            SnapToGrid();
             OnResize();
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -191,6 +191,28 @@ namespace ClassicUO.Game.UI.Gumps
             base.OnMouseUp(x, y, button);
         }
 
+        internal void UseSlot(string slotString)
+        {
+            if (!string.IsNullOrEmpty(slotString) && ushort.TryParse(slotString, out ushort slot))
+            {
+                // slot index is 1-based since we have to assume the average user is non-technical
+                // everything else would be confusing
+
+                if (_dataBox.Children.Skip(slot - 1).FirstOrDefault() is CounterItem item)
+                {
+                    item.Use();
+                }
+                else
+                {
+                    GameActions.Print(World, string.Format(ResGumps.CounterErrorSlotNotFound, slotString));
+                }
+            }
+            else
+            {
+                GameActions.Print(World, string.Format(ResGumps.CounterErrorSlotNotValid, slotString));
+            }
+        }
+
         public override void Save(XmlTextWriter writer)
         {
             base.Save(writer);

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -17,6 +17,8 @@ namespace ClassicUO.Game.UI.Gumps
 {
     internal partial class CounterBarGump : ResizableGump
     {
+        private const int MIN_SIZE = 30;
+        private const int MAX_SIZE = 80;
         private static readonly int BORDER_LEFT = 2;
         private static readonly int BORDER_RIGHT = 2;
         private static readonly int BORDER_TOP = 2;
@@ -27,6 +29,8 @@ namespace ClassicUO.Game.UI.Gumps
         private DataBox _dataBox;
         private int _rectSize;
         private ScissorControl _scissor;
+
+        public bool ReadOnly { get => !ShowBorder; set => ShowBorder = !value; }
 
         public CounterBarGump(World world) : base(world, 0, 0, 50, 50, 0, 0, 0)
         {
@@ -54,13 +58,13 @@ namespace ClassicUO.Game.UI.Gumps
         private ContextMenuControl ConfigureContextMenu(ContextMenuControl control)
         {
             control.Add(ResGumps.Add, AddPlaceholder);
-            if (ShowBorder)
+            if (ReadOnly)
             {
-                control.Add(ResGumps.CounterReadonlyOff, ToggleReadOnly);
+                control.Add(ResGumps.CounterReadonlyOn, ToggleReadOnly);
             }
             else
             {
-                control.Add(ResGumps.CounterReadonlyOn, ToggleReadOnly);
+                control.Add(ResGumps.CounterReadonlyOff, ToggleReadOnly);
             }
 
             return control;
@@ -68,7 +72,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         private void ToggleReadOnly()
         {
-            ShowBorder = !ShowBorder;
+            ReadOnly = !ReadOnly;
 
             ContextMenu = ConfigureContextMenu(new ContextMenuControl(this));
 
@@ -79,7 +83,7 @@ namespace ClassicUO.Game.UI.Gumps
             World world,
             int x,
             int y,
-            int rectSize = 30
+            int rectSize = MIN_SIZE
         ) : this(world)
         {
             X = x;
@@ -100,13 +104,13 @@ namespace ClassicUO.Game.UI.Gumps
         {
             if (size != _rectSize)
             {
-                if (size < 30)
+                if (size < MIN_SIZE)
                 {
-                    size = 30;
+                    size = MIN_SIZE;
                 }
-                else if (size > 80)
+                else if (size > MAX_SIZE)
                 {
-                    size = 80;
+                    size = MAX_SIZE;
                 }
                 _rectSize = size;
                 SnapToGrid();
@@ -229,9 +233,8 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 if (Client.Game.UO.GameCursor.ItemHold.Enabled && Client.Game.UO.GameCursor.ItemHold.Graphic != 0)
                 {
-                    if (ShowBorder)
+                    if (!ReadOnly)
                     {
-                        // not in read-only mode
                         CounterItem item = new CounterItem(this, Client.Game.UO.GameCursor.ItemHold.Graphic, Client.Game.UO.GameCursor.ItemHold.Hue, 0);
                         _dataBox.Add(item);
                     }
@@ -275,7 +278,7 @@ namespace ClassicUO.Game.UI.Gumps
             writer.WriteAttributeString("rectsize", _rectSize.ToString());
             writer.WriteAttributeString("width", Width.ToString());
             writer.WriteAttributeString("height", Height.ToString());
-            writer.WriteAttributeString("readonly", (!ShowBorder).ToString());
+            writer.WriteAttributeString("readonly", ReadOnly.ToString());
 
             IEnumerable<CounterItem> controls = FindControls<CounterItem>();
 
@@ -323,13 +326,13 @@ namespace ClassicUO.Game.UI.Gumps
                 }
                 else
                 {
-                    height = 80;
+                    height = MAX_SIZE;
                 }
             }
 
             if (bool.TryParse(xml.GetAttribute("readonly"), out bool isReadOnly))
             {
-                ShowBorder = !isReadOnly;
+                ReadOnly = isReadOnly;
             }
 
             Width = width;

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -209,7 +209,10 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     writer.WriteStartElement("control");
                     writer.WriteAttributeString("graphic", control.Graphic.ToString());
-                    writer.WriteAttributeString("hue", control.Hue.ToString());
+                    if (control.Hue != null)
+                    {
+                        writer.WriteAttributeString("hue", control.Hue.Value.ToString());
+                    }
                     writer.WriteAttributeString("compareto", control.CompareTo.ToString());
                     writer.WriteEndElement();
                 }
@@ -254,7 +257,9 @@ namespace ClassicUO.Game.UI.Gumps
                             compareTo = 0;
                         }
 
-                        CounterItem c = new CounterItem(this, graphic, ushort.Parse(controlXml.GetAttribute("hue")), compareTo);
+                        string hue = controlXml.GetAttribute("hue");
+
+                        CounterItem c = new(this, graphic, string.IsNullOrEmpty(hue) ? null : ushort.Parse(controlXml.GetAttribute("hue")), compareTo);
 
                         _dataBox.Add(c);
                         

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
@@ -9,11 +8,9 @@ using ClassicUO.Input;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
-using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Xml;
 
@@ -27,14 +24,18 @@ namespace ClassicUO.Game.UI.Gumps
         private int _rectSize;
         private ScissorControl _scissor;
 
-        public CounterBarGump(World world) : base(world, 0, 0, 50, 50, 0, 0, 0) { }
+        public CounterBarGump(World world) : base(world, 0, 0, 50, 50, 0, 0, 0)
+        {
+            ContextMenu = new ContextMenuControl(this);
+            ContextMenu.Add(ResGumps.Add, AddPlaceholder);
+        }
 
         public CounterBarGump(
             World world,
             int x,
             int y,
             int rectSize = 30
-        ) : base(world, 0, 0, 50, 50, 0, 0, 0)
+        ) : this(world)
         {
             X = x;
             Y = y;
@@ -42,6 +43,12 @@ namespace ClassicUO.Game.UI.Gumps
             SetCellSize(rectSize);
 
             BuildGump();
+        }
+
+        private void AddPlaceholder()
+        {
+            _dataBox.Add(new CounterItem(this, 0, 0));
+            SetupLayout();
         }
 
         public void SetCellSize(int size)
@@ -254,10 +261,6 @@ namespace ClassicUO.Game.UI.Gumps
                 Add(_image);
 
                 SetGraphic(graphic, hue);
-
-                ContextMenu = new ContextMenuControl(_gump);
-                ContextMenu.Add(ResGumps.UseObject, Use);
-                ContextMenu.Add(ResGumps.Remove, RemoveItem);
             }
 
             public ushort Graphic { get; private set; }
@@ -268,13 +271,15 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 _image.ChangeGraphic(graphic, hue);
 
-                if (graphic == 0)
-                {
-                    return;
-                }
-
                 Graphic = graphic;
                 Hue = hue;
+
+                ContextMenu = new ContextMenuControl(_gump);
+                if (graphic != 0)
+                {
+                    ContextMenu.Add(ResGumps.UseObject, Use);
+                }
+                ContextMenu.Add(ResGumps.Remove, RemoveItem);
             }
 
             public void RemoveItem()
@@ -351,9 +356,13 @@ namespace ClassicUO.Game.UI.Gumps
                         Use();
                     }
                 }
-                else if (button == MouseButtonType.Right && Keyboard.Alt && Graphic != 0)
+                else if (button == MouseButtonType.Right && Keyboard.Alt )
                 {
                     RemoveItem();
+                }
+                else if (button == MouseButtonType.Right)
+                {
+                    base.OnMouseUp(x, y, button);
                 }
                 else if (Graphic != 0)
                 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/MessageBoxGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MessageBoxGump.cs
@@ -150,7 +150,7 @@ namespace ClassicUO.Game.UI.Gumps
         private readonly Action<string> _action;
         private readonly StbTextBox _textBox;
 
-        public EntryDialog(World world, int w, int h, string message, Action<string> action) : base(world, 0, 0)
+        public EntryDialog(World world, int w, int h, string message, Action<string> action, string initialValue = "") : base(world, 0, 0)
         {
             CanMove = false;
             CanCloseWithRightClick = false;
@@ -217,7 +217,8 @@ namespace ClassicUO.Game.UI.Gumps
                 X = 42,
                 Y = 45 + l.Height + 7,
                 Width = ww,
-                Height = 25
+                Height = 25,
+                Text = initialValue
             };
 
             Add(_textBox);

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -51,7 +51,7 @@ namespace ClassicUO.Game.UI.Gumps
 
 
         //counters
-        private Checkbox _enableCounters, _highlightOnUse, _highlightOnAmount, _enableAbbreviatedAmount;
+        private Checkbox _enableCounters, _highlightOnChange, _highlightOnAmount, _enableAbbreviatedAmount;
         private Checkbox _enableDragSelect, _dragSelectHumanoidsOnly, _dragSelectHostileOnly;
 
         // sounds
@@ -2938,16 +2938,16 @@ namespace ClassicUO.Game.UI.Gumps
             startX += 40;
             startY += _enableCounters.Height + 2;
 
-            _highlightOnUse = AddCheckBox
+            _highlightOnChange = AddCheckBox
             (
                 rightArea,
-                ResGumps.HighlightOnUse,
-                _currentProfile.CounterBarHighlightOnUse,
+                ResGumps.HighlightOnChange,
+                _currentProfile.CounterBarHighlightOnChange,
                 startX,
                 startY
             );
 
-            startY += _highlightOnUse.Height + 2;
+            startY += _highlightOnChange.Height + 2;
 
             _enableAbbreviatedAmount = AddCheckBox
             (
@@ -3657,7 +3657,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 case 9: // counters
                     _enableCounters.IsChecked = false;
-                    _highlightOnUse.IsChecked = false;
+                    _highlightOnChange.IsChecked = false;
                     _enableAbbreviatedAmount.IsChecked = false;
                     _columns.SetText("1");
                     _rows.SetText("1");
@@ -4045,7 +4045,7 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.CounterBarEnabled = _enableCounters.IsChecked;
             _currentProfile.CounterBarCellSize = _cellSize.Value;
 
-            _currentProfile.CounterBarHighlightOnUse = _highlightOnUse.IsChecked;
+            _currentProfile.CounterBarHighlightOnChange = _highlightOnChange.IsChecked;
 
             if (!int.TryParse(_highlightAmount.Text, out int v))
             {

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -3018,7 +3018,6 @@ namespace ClassicUO.Game.UI.Gumps
             startY += text.Height + 2;
             text = AddLabel(rightArea, ResGumps.CellSize, startX, startY);
 
-            int initialX = startX;
             startX += text.Width + 5;
 
             _cellSize = AddHSlider
@@ -3031,46 +3030,6 @@ namespace ClassicUO.Game.UI.Gumps
                 startY,
                 80
             );
-
-
-            startX = initialX;
-            startY += text.Height + 2 + 15;
-
-            _rows = AddInputField
-            (
-                rightArea,
-                startX,
-                startY,
-                50,
-                30,
-                ResGumps.Counter_Rows,
-                50,
-                false,
-                true,
-                30
-            );
-
-            _rows.SetText(_currentProfile.CounterBarRows.ToString());
-
-
-            startX += _rows.Width + 5 + 100;
-
-            _columns = AddInputField
-            (
-                rightArea,
-                startX,
-                startY,
-                50,
-                30,
-                ResGumps.Counter_Columns,
-                50,
-                false,
-                true,
-                30
-            );
-
-            _columns.SetText(_currentProfile.CounterBarColumns.ToString());
-
 
             Add(rightArea, PAGE);
         }
@@ -4086,23 +4045,9 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.CounterBarEnabled = _enableCounters.IsChecked;
             _currentProfile.CounterBarCellSize = _cellSize.Value;
 
-            if (!int.TryParse(_rows.Text, out int v))
-            {
-                v = 1;
-                _rows.SetText("1");
-            }
-
-            _currentProfile.CounterBarRows = v;
-
-            if (!int.TryParse(_columns.Text, out v))
-            {
-                v = 1;
-                _columns.SetText("1");
-            }
-            _currentProfile.CounterBarColumns = v;
             _currentProfile.CounterBarHighlightOnUse = _highlightOnUse.IsChecked;
 
-            if (!int.TryParse(_highlightAmount.Text, out v))
+            if (!int.TryParse(_highlightAmount.Text, out int v))
             {
                 v = 5;
                 _highlightAmount.SetText("5");
@@ -4120,9 +4065,6 @@ namespace ClassicUO.Game.UI.Gumps
 
             CounterBarGump counterGump = UIManager.GetGump<CounterBarGump>();
 
-            counterGump?.SetLayout(_currentProfile.CounterBarCellSize, _currentProfile.CounterBarRows, _currentProfile.CounterBarColumns);
-
-
             if (before != _currentProfile.CounterBarEnabled)
             {
                 if (counterGump == null)
@@ -4136,9 +4078,7 @@ namespace ClassicUO.Game.UI.Gumps
                                 World,
                                 200,
                                 200,
-                                _currentProfile.CounterBarCellSize,
-                                _currentProfile.CounterBarRows,
-                                _currentProfile.CounterBarColumns
+                                _currentProfile.CounterBarCellSize
                             )
                         );
                     }

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableGump.cs
@@ -69,6 +69,10 @@ namespace ClassicUO.Game.UI.Gumps
             set => _borderControl.IsVisible = _button.IsVisible = value;
         }
 
+        public int BoderSize
+        {
+            get => _borderControl.BorderSize;
+        }
 
         public Point ResizeWindow(Point newSize)
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableGump.cs
@@ -11,10 +11,19 @@ namespace ClassicUO.Game.UI.Gumps
         private readonly BorderControl _borderControl;
         private readonly Button _button;
         private bool _clicked;
-        private Point _lastSize, _savedSize;
+        private Point _lastSize, _savedSize, _beforeResizeSize;
         private readonly int _minH;
         private readonly int _minW;
 
+        public class ResizeCompletedEventArgs(Point beforeResize)
+        {
+            public Point BeforeResize { get; } = beforeResize; // readonly
+        }
+
+        // Declare the delegate (if using non-generic pattern).
+        public delegate void ResizeCompletedHandler(object sender, ResizeCompletedEventArgs e);
+
+        public event ResizeCompletedHandler ResizeCompleted;
 
         protected ResizableGump
         (
@@ -43,12 +52,16 @@ namespace ClassicUO.Game.UI.Gumps
             _button = new Button(0, 0x837, 0x838, 0x838);
             Add(_button);
 
-            _button.MouseDown += (sender, e) => { _clicked = true; };
+            _button.MouseDown += (sender, e) => { 
+                _clicked = true;
+                _beforeResizeSize = _savedSize;
+            };
 
             _button.MouseUp += (sender, e) =>
             {
                 ResizeWindow(_lastSize);
                 _clicked = false;
+                ResizeCompleted?.Invoke(this, new(_beforeResizeSize));
             };
 
             WantUpdateSize = false;

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
@@ -284,7 +284,7 @@ namespace ClassicUO.Game.UI.Gumps
 
     internal class BorderControl : Control
     {
-        private readonly int _borderSize;
+        public int BorderSize { get; internal set; }
 
         const ushort H_BORDER = 0x0A8C;
         const ushort V_BORDER = 0x0A8D;
@@ -295,7 +295,7 @@ namespace ClassicUO.Game.UI.Gumps
             Y = y;
             Width = w;
             Height = h;
-            _borderSize = borderSize;
+            BorderSize = borderSize;
             CanMove = true;
             AcceptMouseInput = true;
         }
@@ -317,7 +317,7 @@ namespace ClassicUO.Game.UI.Gumps
             // sopra
             batcher.DrawTiled(
                 gumpInfo.Texture,
-                new Rectangle(x, y, Width, _borderSize),
+                new Rectangle(x, y, Width, BorderSize),
                 gumpInfo.UV,
                 hueVector
             );
@@ -325,7 +325,7 @@ namespace ClassicUO.Game.UI.Gumps
             // sotto
             batcher.DrawTiled(
                 gumpInfo.Texture,
-                new Rectangle(x, y + Height - _borderSize, Width, _borderSize),
+                new Rectangle(x, y + Height - BorderSize, Width, BorderSize),
                 gumpInfo.UV,
                 hueVector
             );
@@ -334,7 +334,7 @@ namespace ClassicUO.Game.UI.Gumps
             //sx
             batcher.DrawTiled(
                 gumpInfo.Texture,
-                new Rectangle(x, y, _borderSize, Height),
+                new Rectangle(x, y, BorderSize, Height),
                 gumpInfo.UV,
                 hueVector
             );
@@ -343,10 +343,10 @@ namespace ClassicUO.Game.UI.Gumps
             batcher.DrawTiled(
                 gumpInfo.Texture,
                 new Rectangle(
-                    x + Width - _borderSize,
+                    x + Width - BorderSize,
                     y + (gumpInfo.UV.Width >> 1),
-                    _borderSize,
-                    Height - _borderSize
+                    BorderSize,
+                    Height - BorderSize
                 ),
                 gumpInfo.UV,
                 hueVector

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -979,6 +979,24 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Read-only mode (OFF).
+        /// </summary>
+        public static string CounterReadonlyOff {
+            get {
+                return ResourceManager.GetString("CounterReadonlyOff", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Read-only mode (ON).
+        /// </summary>
+        public static string CounterReadonlyOn {
+            get {
+                return ResourceManager.GetString("CounterReadonlyOn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Counters.
         /// </summary>
         public static string Counters {

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -1934,11 +1934,11 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Highlight On Use.
+        ///   Looks up a localized string similar to Highlight On Change.
         /// </summary>
-        public static string HighlightOnUse {
+        public static string HighlightOnChange {
             get {
-                return ResourceManager.GetString("HighlightOnUse", resourceCulture);
+                return ResourceManager.GetString("HighlightOnChange", resourceCulture);
             }
         }
         

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -898,6 +898,42 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Compare to....
+        /// </summary>
+        public static string CounterCompareTo {
+            get {
+                return ResourceManager.GetString("CounterCompareTo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value must be a valid number!.
+        /// </summary>
+        public static string CounterCompareToDialogInvalid {
+            get {
+                return ResourceManager.GetString("CounterCompareToDialogInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Compare to value.
+        /// </summary>
+        public static string CounterCompareToDialogText1 {
+            get {
+                return ResourceManager.GetString("CounterCompareToDialogText1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (leave empty to reset).
+        /// </summary>
+        public static string CounterCompareToDialogText2 {
+            get {
+                return ResourceManager.GetString("CounterCompareToDialogText2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Counter Layout:.
         /// </summary>
         public static string CounterLayout {

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -934,6 +934,24 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Counter Bar: Slot number &apos;{0}&apos; could not be found.
+        /// </summary>
+        public static string CounterErrorSlotNotFound {
+            get {
+                return ResourceManager.GetString("CounterErrorSlotNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Counter Bar: Slot &apos;{0}&apos; is not a valid number.
+        /// </summary>
+        public static string CounterErrorSlotNotValid {
+            get {
+                return ResourceManager.GetString("CounterErrorSlotNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Compare Hue (ON).
         /// </summary>
         public static string CounterIgnoreHueOff {

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -898,7 +898,7 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Compare to....
+        ///   Looks up a localized string similar to Compare amount to....
         /// </summary>
         public static string CounterCompareTo {
             get {
@@ -930,6 +930,24 @@ namespace ClassicUO.Resources {
         public static string CounterCompareToDialogText2 {
             get {
                 return ResourceManager.GetString("CounterCompareToDialogText2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Compare Hue (ON).
+        /// </summary>
+        public static string CounterIgnoreHueOff {
+            get {
+                return ResourceManager.GetString("CounterIgnoreHueOff", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Compare Hue (OFF).
+        /// </summary>
+        public static string CounterIgnoreHueOn {
+            get {
+                return ResourceManager.GetString("CounterIgnoreHueOn", resourceCulture);
             }
         }
         

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1621,4 +1621,16 @@ Client version: '{0}'</value>
   <data name="OverheadPartyMessages" xml:space="preserve">
     <value>Show party messages overhead</value>
   </data>
+  <data name="CounterCompareTo" xml:space="preserve">
+    <value>Compare to...</value>
+  </data>
+  <data name="CounterCompareToDialogText1" xml:space="preserve">
+    <value>Compare to value</value>
+  </data>
+  <data name="CounterCompareToDialogText2" xml:space="preserve">
+    <value>(leave empty to reset)</value>
+  </data>
+  <data name="CounterCompareToDialogInvalid" xml:space="preserve">
+    <value>The value must be a valid number!</value>
+  </data>
 </root>

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1622,7 +1622,7 @@ Client version: '{0}'</value>
     <value>Show party messages overhead</value>
   </data>
   <data name="CounterCompareTo" xml:space="preserve">
-    <value>Compare to...</value>
+    <value>Compare amount to...</value>
   </data>
   <data name="CounterCompareToDialogText1" xml:space="preserve">
     <value>Compare to value</value>
@@ -1632,5 +1632,11 @@ Client version: '{0}'</value>
   </data>
   <data name="CounterCompareToDialogInvalid" xml:space="preserve">
     <value>The value must be a valid number!</value>
+  </data>
+  <data name="CounterIgnoreHueOff" xml:space="preserve">
+    <value>Compare Hue (ON)</value>
+  </data>
+  <data name="CounterIgnoreHueOn" xml:space="preserve">
+    <value>Compare Hue (OFF)</value>
   </data>
 </root>

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1639,4 +1639,10 @@ Client version: '{0}'</value>
   <data name="CounterIgnoreHueOn" xml:space="preserve">
     <value>Compare Hue (OFF)</value>
   </data>
+  <data name="CounterErrorSlotNotFound" xml:space="preserve">
+    <value>Counter Bar: Slot number '{0}' could not be found</value>
+  </data>
+  <data name="CounterErrorSlotNotValid" xml:space="preserve">
+    <value>Counter Bar: Slot '{0}' is not a valid number</value>
+  </data>
 </root>

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1645,4 +1645,10 @@ Client version: '{0}'</value>
   <data name="CounterErrorSlotNotValid" xml:space="preserve">
     <value>Counter Bar: Slot '{0}' is not a valid number</value>
   </data>
+  <data name="CounterReadonlyOn" xml:space="preserve">
+    <value>Read-only mode (ON)</value>
+  </data>
+  <data name="CounterReadonlyOff" xml:space="preserve">
+    <value>Read-only mode (OFF)</value>
+  </data>
 </root>

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -638,8 +638,8 @@ Murderers, Criminals, Grays (Monsters/Animals)</value>
   <data name="EnableCounters" xml:space="preserve">
     <value>Enable Counters</value>
   </data>
-  <data name="HighlightOnUse" xml:space="preserve">
-    <value>Highlight On Use</value>
+  <data name="HighlightOnChange" xml:space="preserve">
+    <value>Highlight On Change</value>
   </data>
   <data name="EnableAbbreviatedAmountCountrs" xml:space="preserve">
     <value>Enable abbreviated amount values

--- a/src/ClassicUO.Utility/StringHelper.cs
+++ b/src/ClassicUO.Utility/StringHelper.cs
@@ -272,12 +272,12 @@ namespace ClassicUO.Utility
 
         public static string IntToAbbreviatedString(int num)
         {
-            if (num > 999999)
+            if (num > 999999 || num < -999999)
             {
                 return string.Format("{0}M+", num / 1000000);
             }
 
-            if (num > 999)
+            if (num > 999 || num < -999)
             {
                 return string.Format("{0}K+", num / 1000);
             }


### PR DESCRIPTION
This replaces #1245

Previous features:

1. doubleclick on empty space will enable/disable resizing
2. drag & drop items over empty space to add items in sequence [replace of the awful & useless grid system]
3. auto item arrange

Added Features:

4. Placeholders can be added/removed to help with organizing the items in a certain way for those who wish to replicate the previous grid layout

https://github.com/user-attachments/assets/52e9225e-c3d2-4911-b378-491c0fe81fdf

6. it is now possible to show each value as a relative amount instead of an absolute; just set it before a crafting session or a dungeon run and continuously see how the amount in reagents, bandages, gold, etc. changed compared to the start

https://github.com/user-attachments/assets/a94413c8-9565-40a0-ad94-68e8bb090ca5

7. allow rearranging items through drag and drop; if that's too complex to implement, there needs to be some other option

https://github.com/user-attachments/assets/75db3430-3210-4963-9278-cd72b100230e

8. allowing an entry to ignore hues; on most shards bandages are the same, no matter the hue, for example

https://github.com/user-attachments/assets/e2bfbaf9-16fa-4865-858b-73bb91fea7df

9. Adding the ability to set macros to use slots in the counter bar, no matter what item it's currently set to

<img width="326" height="214" alt="image" src="https://github.com/user-attachments/assets/55d8a993-9356-4c38-924c-33ce7150020e" />

10. Making sure that restoring from the previous counter bar XML will produce the exact same layout including placeholders in the new one

11. When resizing is disabled, adding and reordering entries should also be disabled. Basically the bar should be in a read-only and use-only mode.

https://github.com/user-attachments/assets/44cd3283-b795-4e2f-8751-006c518bf2b9

12. Fix highlight on use (closes #1216 )

https://github.com/user-attachments/assets/ab10a1e6-8e8e-45f5-8d6d-e44462482100

13. Counter Bar should snap to grid, so that it always only takes up the optimal space and does not waste any

https://github.com/user-attachments/assets/fcfda158-b225-4ad9-b2e6-f1abba094bc7

14. Testing and Polishing :-)
