### PR TITLE
Player Feedback: Additional features/improvements for the counter bar

### DIFF
--- a/src/ClassicUO.Bootstrap/src/Program.cs
+++ b/src/ClassicUO.Bootstrap/src/Program.cs
@@ -39,7 +39,7 @@ AppDomain.CurrentDomain.UnhandledException += (s, e) =>
     if (!Directory.Exists(path))
         Directory.CreateDirectory(path);
 
-    File.WriteAllText(Path.Combine(path, $"{dt:yyyy-MM-dd_hh-mm-ss}_crash.txt"), s.ToString());
+    File.WriteAllText(Path.Combine(path, $"{dt:yyyy-MM-dd_hh-mm-ss}_crash.txt"), sb.ToString());
 };
 #endif
 

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -4,8 +4,6 @@ using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
-using ClassicUO.Game.Scenes;
-using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Network;
 using ClassicUO.Utility;
@@ -231,15 +229,19 @@ namespace ClassicUO.Game.GameObjects
                 item = (Item)item.Next
             )
             {
-                if (
-                    item.ItemData.IsContainer
-                    && !item.IsEmpty
-                    && item.Layer >= Layer.OneHanded
-                    && item.Layer <= Layer.Legs
-                )
+                if (item.Layer < Layer.OneHanded || item.Layer > Layer.Legs)
+                {
+                    continue;
+                }
+                if (item.ItemData.IsContainer && !item.IsEmpty)
                 {
                     item.GetTotalAmount(graphic, hue, ref _amount);
                 }
+                else if (item.Graphic == graphic && (!hue.HasValue || item.Hue == hue.Value))
+                {
+                    _amount += item.Amount;
+                }
+
             }
 
             return _amount;

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.CounterItem.cs
@@ -10,7 +10,6 @@ using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
@@ -141,14 +140,7 @@ namespace ClassicUO.Game.UI.Gumps
                     return;
                 }
 
-                Item backpack = _gump.World.Player.FindItemByLayer(Layer.Backpack);
-
-                if (backpack == null)
-                {
-                    return;
-                }
-
-                Item item = Hue == null ? backpack.FindItem(Graphic): backpack.FindItem(Graphic, Hue.Value);
+                Item item = _gump.World.Player.FindItem(Graphic, Hue ?? 0xFFFF);
 
                 if (item != null)
                 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.DraggableGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.DraggableGump.cs
@@ -1,11 +1,6 @@
 ﻿using ClassicUO.Game.Managers;
-using ClassicUO.Game.UI.Controls;
 using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ClassicUO.Game.UI.Gumps
 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -4,13 +4,10 @@ using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Renderer.Gumps;
 using ClassicUO.Resources;
 using Microsoft.Xna.Framework;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
 using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -934,6 +934,16 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Drop an item here to
+        ///start your first counter.
+        /// </summary>
+        public static string CounterEmptyHelpText {
+            get {
+                return ResourceManager.GetString("CounterEmptyHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Counter Bar: Slot number &apos;{0}&apos; could not be found.
         /// </summary>
         public static string CounterErrorSlotNotFound {

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1651,4 +1651,8 @@ Client version: '{0}'</value>
   <data name="CounterReadonlyOff" xml:space="preserve">
     <value>Read-only mode (OFF)</value>
   </data>
+  <data name="CounterEmptyHelpText" xml:space="preserve">
+    <value>Drop an item here to
+start your first counter</value>
+  </data>
 </root>


### PR DESCRIPTION
1. If a dagger was moved into the paperdoll, it disappeared from the counter bar. Now it is still counted and can be used through the macro or the double click function. This applies to all worn/carried items.
2. Automatically adds a helpful text to get people started with the counter bar while it is empty

https://github.com/user-attachments/assets/55e4e389-4b9a-42f9-8a5c-0c275656cf6f

