### PR TITLE
SystemChatControl extended to 500 characters. It will send the first …

### DIFF
--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -1223,19 +1223,20 @@ namespace ClassicUO.Game.Scenes
                     {
                         if (ProfileManager.CurrentProfile.ActivateChatAfterEnter)
                         {
-                            UIManager.SystemChat.Mode = ChatMode.Default;
-
-                            if (
-                                !(
-                                    Keyboard.Shift
-                                    && ProfileManager.CurrentProfile.ActivateChatShiftEnterSupport
-                                )
-                            )
+                            if (UIManager.SystemChat.IsActive && Keyboard.Shift && ProfileManager.CurrentProfile.ActivateChatShiftEnterSupport)
                             {
-                                UIManager.SystemChat.ToggleChatVisibility();
+                                // Shift+Enter keeps the chat the way it is
+                                return;
                             }
-                        }
 
+                            if (UIManager.SystemChat.IsComposing)
+                            {
+                                // still text left to be sent, do nothing
+                                return;
+                            }
+                            UIManager.SystemChat.ToggleChatVisibility();
+                        }
+                        // everything else is handled in the system chat control
                         return;
                     }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -370,9 +370,6 @@ namespace ClassicUO.Game.UI.Gumps
                 ReadOnly = isReadOnly;
             }
 
-            Width = width;
-            Height = height;
-
             BuildGump();
 
             XmlElement controlsXml = xml["controls"];
@@ -402,6 +399,10 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             IsEnabled = IsVisible = ProfileManager.CurrentProfile.CounterBarEnabled;
+
+            // resize only after items have been added
+            // because an empty counter bar will always receive a minimum width for the help text
+            ResizeWindow(new Point(width, height));
 
             SetupLayout();
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
@@ -549,7 +549,47 @@ namespace ClassicUO.Game.UI.Gumps
 
                     break;
 
+                case SDL.SDL_Keycode.SDLK_BACKSPACE when Keyboard.Ctrl && !Keyboard.Alt && !Keyboard.Shift:
+                    {
+                        if (!IsActive)
+                        {
+                            return;
+                        }
+
+                        String text = TextBoxControl.Text;
+
+                        if (string.IsNullOrEmpty(text))
+                        {
+                            Mode = ChatMode.Default;
+                            break;
+                        }
+
+                        // ignore the final character since that's a space if we press Ctrl + Backspace multiple times
+                        int index = text.LastIndexOf(' ', text.Length - 2);
+
+                        if (index >= 0)
+                        {
+                            // do not remove the final space since we assume the user wants to continue writing
+                            TextBoxControl.SetText(text[..(index + 1)]);
+                        }
+                        else
+                        {
+                            TextBoxControl.ClearText();
+                        }
+
+                        if (string.IsNullOrEmpty(TextBoxControl.Text))
+                        {
+                            Mode = ChatMode.Default;
+                        }
+                        break;
+                    }
+
                 case SDL.SDL_Keycode.SDLK_BACKSPACE when !Keyboard.Ctrl && !Keyboard.Alt && !Keyboard.Shift && string.IsNullOrEmpty(TextBoxControl.Text):
+                    if (!IsActive)
+                    {
+                        return;
+                    }
+
                     Mode = ChatMode.Default;
 
                     break;


### PR DESCRIPTION
…100 characters, breaking at the last possible space character and keep the mode and remaining text to be sent with the next press of the enter button until the text box is exhausted

Thirty years! Thirty years players were annoyed by the character limit of only 100 characters. Especially in the heat of role playing, one may not notice that the limit was exhausted and type a few words into the void, never to be seen again. Today we enter the 21st century. The text box now takes up to 500 characters of text. On each successive press of the `enter` key it will send the first 100 characters to the server (breaking at the latest possible space character), keeping the remaining text and the text mode. Only after all the text is exhausted, will the text box reset its mode.