### PR TITLE
One of the reflection shims seem to have been forgotten in the bootstrapper

### DIFF
--- a/src/ClassicUO.Bootstrap/src/CuoInternal.cs
+++ b/src/ClassicUO.Bootstrap/src/CuoInternal.cs
@@ -61,6 +61,11 @@ namespace ClassicUO.Game
             get => Global.Host.ReflectionAutowalking(-1);
             set => Global.Host.ReflectionAutowalking((sbyte)(value ? 1 : 0));
         }
+
+        public static bool WalkTo(int x, int y, int z, int distance)
+        {
+            return Global.Host.ReflectionWalkTo(x, y, z, distance);
+        }
     }
 
     public sealed class MacroManager : LinkedObject

--- a/src/ClassicUO.Bootstrap/src/Program.cs
+++ b/src/ClassicUO.Bootstrap/src/Program.cs
@@ -3,15 +3,15 @@ using CUO_API;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
-
 
 #if !DEBUG
+using System.IO;
+using System.Reflection;
+using System.Threading;
+
 AppDomain.CurrentDomain.UnhandledException += (s, e) =>
 {
     var dt = DateTime.Now;
@@ -415,7 +415,6 @@ sealed class ClassicUOHost : IPluginHandler
         var f = (3, walking);
         var result = SendReflectionCmd((IntPtr)(&f));
         var toBool = Unsafe.AsRef<bool>(result.ToPointer());
-        Console.WriteLine("bool: {0} [{1}]", toBool, result);
         return toBool;
     }
 
@@ -424,7 +423,6 @@ sealed class ClassicUOHost : IPluginHandler
         var f = (4, x, y, z, distance);
         var result = SendReflectionCmd((IntPtr)(&f));
         var toBool = Unsafe.AsRef<bool>(result.ToPointer());
-        Console.WriteLine("bool: {0} [{1}]", toBool, result);
         return toBool;
     }
 

--- a/src/ClassicUO.Bootstrap/src/Program.cs
+++ b/src/ClassicUO.Bootstrap/src/Program.cs
@@ -419,6 +419,15 @@ sealed class ClassicUOHost : IPluginHandler
         return toBool;
     }
 
+    public unsafe bool ReflectionWalkTo(int x, int y, int z, int distance)
+    {
+        var f = (4, x, y, z, distance);
+        var result = SendReflectionCmd((IntPtr)(&f));
+        var toBool = Unsafe.AsRef<bool>(result.ToPointer());
+        Console.WriteLine("bool: {0} [{1}]", toBool, result);
+        return toBool;
+    }
+
     IntPtr SendReflectionCmd(IntPtr ptr)
     {
         return _reflectionCmd?.Delegate?.Invoke(ptr) ?? IntPtr.Zero;

--- a/src/ClassicUO.Client/PluginHost.cs
+++ b/src/ClassicUO.Client/PluginHost.cs
@@ -258,7 +258,10 @@ namespace ClassicUO
                     }
 
                     break;
-
+                case 4:
+                    var args = Unsafe.AsRef<(int, int, int, int, int)>(cmd.ToPointer());
+                    bool started = Client.Game.UO?.World?.Player?.Pathfinder?.WalkTo(args.Item2, args.Item3, args.Item4, args.Item5) ?? false;
+                    return (IntPtr)Unsafe.AsPointer(ref started);
             }
 
             return IntPtr.Zero;


### PR DESCRIPTION
ClassicAssist was broken for quite some time but degraded gracefully by sending the pathfind packet to the client instead. That packet does not allow setting the distance however and breaks when trying to pathfind to a location that is impassable (for example pathfinding to a blocking item, like a loom or a spinning wheel). This makes pathfinding from ClassicAssist in those cases impossible