### PR TITLE
The client now allows pathfinding to an object that is not a surface

### DIFF
--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -934,6 +934,16 @@ namespace ClassicUO.Game
                 return false;
             }
 
+            if (distance == 0 && IsBlocked(x, y, z))
+            {
+                // Don't do time-consuming computations and freeze the client if the final field is not reachable
+                // instead we should just move to a field beside it
+                // This is only one edge case but it should be one of the most common ones that we can catch early and cheaply
+
+                // For example pathfinding to a tree, to a treasure chest, to a rock, etc.
+                distance = 1;
+            }
+
             for (int i = 0; i < PATHFINDER_MAX_NODES; i++)
             {
                 if (_openList[i] == null)
@@ -983,6 +993,13 @@ namespace ClassicUO.Game
             }
 
             return _pathSize != 0;
+        }
+
+        private bool IsBlocked(int x, int y, int z)
+        {
+            sbyte tempZ = (sbyte)z;
+
+            return !CalculateNewZ(x, y, ref tempZ, (byte)Direction.North);
         }
 
         public void ProcessAutoWalk()

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -870,11 +870,9 @@ namespace ClassicUO.Game.Scenes
                 {
                     if (obj is Static || obj is Multi || obj is Item)
                     {
-                        ref StaticTiles itemdata = ref Client.Game.UO.FileManager.TileData.StaticData[
-                            obj.Graphic
-                        ];
-
-                        if (itemdata.IsSurface && _world.Player.Pathfinder.WalkTo(obj.X, obj.Y, obj.Z, 0))
+                        // previously we only triggered the pathfinder if the target was a surface
+                        // now we trigger it always and the pathfinder decides if the target is blocked and then only walks next to it
+                        if (_world.Player.Pathfinder.WalkTo(obj.X, obj.Y, obj.Z, 0))
                         {
                             _world.Player.AddMessage(
                                 MessageType.Label,


### PR DESCRIPTION
We are now catching up to assistants, which have always allowed this but froze the client for a second or two on an impossible pathfinding quest if the distance was left to 0

We still try and navigate to the target as usual but it the field is impassable and the distance is set to 0, we set it to 1, which is very, very simple but should catch the majority of cases that were broken previously.

https://github.com/user-attachments/assets/2a98588a-2a5e-4bed-9331-7c45d7e71c8b