### PR TITLE
The system chat will now break into multiple lines to show how the text will be sent as multiple parts

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/StbTextBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/StbTextBox.cs
@@ -146,7 +146,7 @@ namespace ClassicUO.Game.UI.Controls
 
         public bool AllowTAB { get; set; }
         public bool NoSelection { get; set; }
-        public bool PassEnterToParent { get; set; } = false;
+        public bool PassEnterToParent { get; set; }
 
         public int CaretIndex
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
@@ -679,7 +679,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 base.OnTextInput(c);
             }
 
-            protected override void OnTextChanged()
+            protected override void OnTextChanged(string previousText)
             {
                 if (Text.Length > 0)
                 {
@@ -690,7 +690,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
                     _rendererText.Text = string.Empty;
                 }
 
-                base.OnTextChanged();
+                base.OnTextChanged(previousText);
                 UpdateCaretScreenPosition();
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
@@ -763,7 +763,7 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
-            protected override void OnTextChanged()
+            protected override void OnTextChanged(string previousText)
             {
                 _is_writing = true;
 
@@ -836,7 +836,7 @@ namespace ClassicUO.Game.UI.Gumps
                     UpdatePageCoords();
                 }
 
-                base.OnTextChanged();
+                base.OnTextChanged(previousText);
                 _is_writing = false;
             }
 


### PR DESCRIPTION
also, Ctrl + Backspace now handles the caret not being at the end of the line correctly


https://github.com/user-attachments/assets/8063f2d1-0dcf-4603-8a9f-b3cc150d4a97

> This is a particularly long text. It will cover more than the allowed one hundred characters and
thus will be split up into separate lines at the last possible space character. With each press of
the ENTER key, one of the lines will be sent to the server. That way you're always in full control
over how quickly you wish to send the messages or how much time you would like to give others to
read first!
