### PR TITLE
Update world map when receiving terrain or static packets from Ultima…

### DIFF
--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -111,7 +111,8 @@ namespace ClassicUO.Game.Map
                 }
             }
 
-            if (im.StaticAddress != 0 && im.StaticCount > 0)
+            //If Ultima Live is on, the statics of the first map block explored could be saved to StaticAdress 0, because the static file could be empty, so we can't check StaticAdress != 0
+            if (im.StaticAddress >= 0 && im.StaticCount > 0)
             {
                 var staticsBlockBuffer = ArrayPool<StaticsBlock>.Shared.Rent((int)im.StaticCount);
                 var staticsSpan = staticsBlockBuffer.AsSpan(0, (int)im.StaticCount);

--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -159,46 +159,56 @@ namespace ClassicUO.Game.Map
                 const float MAG_0 = 80f / 100f;
                 const float MAG_1 = 100f / 80f;
 
-                for (int i = 0; i < bufferBlock.Length - 1; i++)
+                for (int y = 0; y < 8; ++y)
                 {
-                    sbyte z0 = bufferBlockZ[i];
-                    sbyte z1 = z0;
-                    if (i < bufferBlock.Length - 1)
-                        z1 = bufferBlockZ[i + 1];
-
-                    if (z0 == z1)
+                    for (int x = 0; x < 8; ++x)
                     {
-                        continue;
-                    }
+                        int blockCurrent = y * 8 + x;
+                        int blockNext = (y + 1) * 8 + x;
 
-                    ref uint cc = ref bufferBlock[i];
-
-                    if (cc == 0)
-                    {
-                        continue;
-                    }
-
-                    byte r = (byte)(cc & 0xFF);
-                    byte g = (byte)((cc >> 8) & 0xFF);
-                    byte b = (byte)((cc >> 16) & 0xFF);
-                    byte a = (byte)((cc >> 24) & 0xFF);
-
-                    if (r != 0 || g != 0 || b != 0)
-                    {
-                        if (z0 < z1)
+                        //Reached last line, nothing to compare with
+                        if (y == 7)
                         {
-                            r = (byte)Math.Min(0xFF, r * MAG_0);
-                            g = (byte)Math.Min(0xFF, g * MAG_0);
-                            b = (byte)Math.Min(0xFF, b * MAG_0);
-                        }
-                        else
-                        {
-                            r = (byte)Math.Min(0xFF, r * MAG_1);
-                            g = (byte)Math.Min(0xFF, g * MAG_1);
-                            b = (byte)Math.Min(0xFF, b * MAG_1);
+                            break;
                         }
 
-                        cc = (uint)(r | (g << 8) | (b << 16) | (a << 24));
+                        sbyte z0 = bufferBlockZ[++blockCurrent];
+                        sbyte z1 = bufferBlockZ[blockNext];
+
+                        if (z0 == z1)
+                        {
+                            continue;
+                        }
+
+                        ref uint cc = ref bufferBlock[blockCurrent];
+
+                        if (cc == 0)
+                        {
+                            continue;
+                        }
+
+                        byte r = (byte)(cc & 0xFF);
+                        byte g = (byte)((cc >> 8) & 0xFF);
+                        byte b = (byte)((cc >> 16) & 0xFF);
+                        byte a = (byte)((cc >> 24) & 0xFF);
+
+                        if (r != 0 || g != 0 || b != 0)
+                        {
+                            if (z0 < z1)
+                            {
+                                r = (byte)Math.Min(0xFF, r * MAG_0);
+                                g = (byte)Math.Min(0xFF, g * MAG_0);
+                                b = (byte)Math.Min(0xFF, b * MAG_0);
+                            }
+                            else
+                            {
+                                r = (byte)Math.Min(0xFF, r * MAG_1);
+                                g = (byte)Math.Min(0xFF, g * MAG_1);
+                                b = (byte)Math.Min(0xFF, b * MAG_1);
+                            }
+
+                            cc = (uint)(r | (g << 8) | (b << 16) | (a << 24));
+                        }
                     }
                 }
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -394,6 +394,8 @@ namespace ClassicUO.Game.Scenes
                                 NetClient.Socket.Disconnect();
                                 Client.Game.SetScene(new LoginScene(_world));
                             }
+
+                            WorldMapGump.ClearMapCache();
                         }
                     }
                 )

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -1370,7 +1370,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public unsafe Task UpdateWorldMapChunk(int mapBlockX, int mapBlockY, uint[] bufferBlock)
         {
-            if (_mapLoading == 1)
+            if (_mapLoading == 1 || _mapTexture == null)
             {
                 return Task.CompletedTask;
             }

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -1368,6 +1368,32 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
+        public unsafe Task UpdateWorldMapChunk(int mapBlockX, int mapBlockY, uint[] bufferBlock)
+        {
+            if (_mapLoading == 1)
+            {
+                return Task.CompletedTask;
+            }
+
+            return Task.Run
+            (
+                () =>
+                {
+                    // Adjust map coordinates based on the block to reload
+                    int startMapX = mapBlockX << 3;  // Multiply by 8 to get the actual map coordinate
+                    int startMapY = mapBlockY << 3;  // Multiply by 8 to get the actual map coordinate
+
+                    int blockWidth = 8;
+                    int blockHeight = 8;
+
+                    fixed (uint* pixels = &bufferBlock[0])
+                    {
+                        _mapTexture.SetDataPointerEXT(0, new Rectangle(startMapX, startMapY, blockWidth, blockHeight), (IntPtr)pixels, sizeof(uint) * blockWidth * blockHeight);
+                    }
+                }
+            );
+        }
+
         internal class ZonesFileZoneData
         {
             public string Label { get; set; }

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -1127,6 +1127,9 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (!_mapCache.TryGetValue(mapFile.FilePath, out var fileMapPath))
                 {
+                    //Delete old map cache files
+                    Directory.GetFiles(_mapsCachePath, "map" + mapIndex + "_*.png").ForEach(s => File.Delete(s));
+
                     using var mapReader = new BinaryReader(File.Open(mapFile.FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
                     using var staticsReader = new BinaryReader(File.Open(staticFile.FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
 
@@ -1379,9 +1382,13 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 () =>
                 {
-                    // Adjust map coordinates based on the block to reload
-                    int startMapX = mapBlockX << 3;  // Multiply by 8 to get the actual map coordinate
-                    int startMapY = mapBlockY << 3;  // Multiply by 8 to get the actual map coordinate
+                    const int OFFSET_PIX = 2;
+                    const int OFFSET_PIX_HALF = OFFSET_PIX / 2;
+
+                    //Adjust map coordinates based on the block to reload
+                    //Multiply by 8 to get the actual map coordinate
+                    int startMapX = (mapBlockX << 3) + OFFSET_PIX_HALF;
+                    int startMapY = (mapBlockY << 3) + OFFSET_PIX_HALF;
 
                     int blockWidth = 8;
                     int blockHeight = 8;
@@ -1392,6 +1399,11 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                 }
             );
+        }
+
+        public static void ClearMapCache()
+        {
+            _mapCache?.Clear();
         }
 
         internal class ZonesFileZoneData

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -1128,7 +1128,8 @@ namespace ClassicUO.Game.UI.Gumps
                 if (!_mapCache.TryGetValue(mapFile.FilePath, out var fileMapPath))
                 {
                     //Delete old map cache files
-                    Directory.GetFiles(_mapsCachePath, "map" + mapIndex + "_*.png").ForEach(s => File.Delete(s));
+                    if (Directory.Exists(_mapsCachePath))
+                        Directory.GetFiles(_mapsCachePath, "map" + mapIndex + "_*.png").ForEach(s => File.Delete(s));
 
                     using var mapReader = new BinaryReader(File.Open(mapFile.FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
                     using var staticsReader = new BinaryReader(File.Open(staticFile.FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -292,7 +292,7 @@ namespace ClassicUO.Game
 
                             mapChunk.Clear();
                             _UL._ULMap.ReloadBlock(mapId, block);
-                            mapChunk.Load(mapId);
+                            mapChunk.Load(mapId, true);
 
                             //linkedList?.AddLast(c.Node);
 
@@ -512,7 +512,7 @@ namespace ClassicUO.Game
                         }
 
                         mapChunk.Clear();
-                        mapChunk.Load(mapId);
+                        mapChunk.Load(mapId, true);
 
                         foreach (GameObject obj in gameObjects)
                         {


### PR DESCRIPTION
… Live

The only issue that I've found is the following. 
If the WorldMapGump is updated from UltimaLive, you logout and login again, without closing the client, the WorldMapGump loads the old map from the cached PNG image.
Instead if you close the client and launch it again, the WorldMapGump is reloaded correctly.