### PR TITLE
Allow to set externaly IsUOPInstallation

### DIFF
--- a/src/ClassicUO.Assets/UOFileManager.cs
+++ b/src/ClassicUO.Assets/UOFileManager.cs
@@ -49,7 +49,7 @@ namespace ClassicUO.Assets
 
         public ClientVersion Version { get; }
         public string BasePath { get; }
-        public bool IsUOPInstallation { get; private set; }
+        public bool IsUOPInstallation { get; set; }
 
         public AnimationsLoader Animations { get; }
         public AnimDataLoader AnimData { get; }


### PR DESCRIPTION
I need this for CentrED#. 
I dont call UOFileManager.Load() and instead I directly call Load on only these loaders that are needed.
Due to this I also manually set if client is UOP