### PR TITLE
The character subfolder for profiles now contains the serial of the loaded character

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
@@ -37,7 +37,7 @@ namespace ClassicUO.Game.UI.Gumps
         private const int MAX_MESSAGE_LENGTH = 100;
         private const int TEXTBOX_LENGTH = 500;
         private const int CHAT_X_OFFSET = 3;
-        private const int CHAT_HEIGHT = 15;
+        private const int CHAT_HEIGHT = 16;
         private static readonly List<Tuple<ChatMode, string>> _messageHistory = new List<Tuple<ChatMode, string>>();
         private static int _messageHistoryIndex = -1;
 

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -201,7 +201,7 @@ namespace ClassicUO.Game
             if (ProfileManager.CurrentProfile == null)
             {
                 string lastChar = LastCharacterManager.GetLastCharacter(LoginScene.Account, ServerName);
-                ProfileManager.Load(ServerName, LoginScene.Account, lastChar);
+                ProfileManager.Load(ServerName, LoginScene.Account, lastChar, serial);
             }
 
             if (Player != null)

--- a/src/ClassicUO.Utility/FileSystemHelper.cs
+++ b/src/ClassicUO.Utility/FileSystemHelper.cs
@@ -15,14 +15,9 @@ namespace ClassicUO.Utility
                 Directory.CreateDirectory(path);
             }
 
-            char[] invalid = Path.GetInvalidFileNameChars();
-
             for (int i = 0; i < parts.Length; i++)
             {
-                for (int j = 0; j < invalid.Length; j++)
-                {
-                    parts[i] = parts[i].Replace(invalid[j].ToString(), "");
-                }
+                ReplaceInvalidPathCharacters(parts[i]);
             }
 
             StringBuilder sb = new StringBuilder();
@@ -40,6 +35,17 @@ namespace ClassicUO.Utility
 
                 path = r;
                 sb.Clear();
+            }
+
+            return path;
+        }
+
+        public static string ReplaceInvalidPathCharacters(string path)
+        {
+            char[] invalid = Path.GetInvalidFileNameChars();
+            for (int j = 0; j < invalid.Length; j++)
+            {
+                path = path.Replace(invalid[j].ToString(), "");
             }
 
             return path;


### PR DESCRIPTION
That way even if the name changes temporarily (incognito, morph, etc.) we can still load the correct profile. Legacy folders are automatically renamed when the modern folder does not exist, but a folder with only the character name is found.