### PR TITLE
More flexibility in UOFileManager 

### DIFF
--- a/src/ClassicUO.Assets/UOFileManager.cs
+++ b/src/ClassicUO.Assets/UOFileManager.cs
@@ -26,7 +26,6 @@ namespace ClassicUO.Assets
             BasePath = uoPath;
 
             _overrideMap = overrideMap;
-            _overrideMap.Load();
             IsUOPInstallation = Version >= ClientVersion.CV_7000 && File.Exists(GetUOFilePath("MainMisc.uop"));
 
             Animations = new AnimationsLoader(this);

--- a/src/ClassicUO.Assets/UOFileManager.cs
+++ b/src/ClassicUO.Assets/UOFileManager.cs
@@ -26,6 +26,7 @@ namespace ClassicUO.Assets
             BasePath = uoPath;
 
             _overrideMap = overrideMap;
+            _overrideMap.Load();
             IsUOPInstallation = Version >= ClientVersion.CV_7000 && File.Exists(GetUOFilePath("MainMisc.uop"));
 
             Animations = new AnimationsLoader(this);

--- a/src/ClassicUO.Assets/UOFileManager.cs
+++ b/src/ClassicUO.Assets/UOFileManager.cs
@@ -5,12 +5,10 @@ using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
 using ClassicUO.Utility.Platforms;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace ClassicUO.Assets
 {
@@ -18,10 +16,17 @@ namespace ClassicUO.Assets
     {
         private readonly UOFilesOverrideMap _overrideMap;
 
-        public UOFileManager(ClientVersion clientVersion, string uoPath)
+        public UOFileManager(ClientVersion clientVersion, string uoPath) : this(clientVersion, uoPath, new UOFilesOverrideMap())
+        {
+        }
+        
+        public UOFileManager(ClientVersion clientVersion, string uoPath, UOFilesOverrideMap overrideMap)
         {
             Version = clientVersion;
             BasePath = uoPath;
+
+            _overrideMap = overrideMap;
+            IsUOPInstallation = Version >= ClientVersion.CV_7000 && File.Exists(GetUOFilePath("MainMisc.uop"));
 
             Animations = new AnimationsLoader(this);
             AnimData = new AnimDataLoader(this);
@@ -43,8 +48,6 @@ namespace ClassicUO.Assets
             Professions = new ProfessionLoader(this);
             TileArt = new TileArtLoader(this);
             StringDictionary = new StringDictionaryLoader(this);
-
-            _overrideMap = new UOFilesOverrideMap();
         }
 
         public ClientVersion Version { get; }
@@ -138,11 +141,7 @@ namespace ClassicUO.Assets
         public void Load(bool useVerdata, string lang, string mapsLayouts = "")
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
-
-            _overrideMap.Load(); // need to load this first so that it manages can perform the file overrides if needed
-
-            IsUOPInstallation = Version >= ClientVersion.CV_7000 && File.Exists(GetUOFilePath("MainMisc.uop"));
-
+            
             Maps.MapsLayouts = mapsLayouts;
 
             Animations.Load();

--- a/src/ClassicUO.Client/Client.cs
+++ b/src/ClassicUO.Client/Client.cs
@@ -187,7 +187,9 @@ namespace ClassicUO
             Log.Trace($"Client version: {clientVersion}");
             Log.Trace($"Protocol: {Protocol}");
 
-            FileManager = new UOFileManager(clientVersion, clientPath, new UOFilesOverrideMap(Settings.GlobalSettings.OverrideFile));
+            var filesOverride = new UOFilesOverrideMap(Settings.GlobalSettings.OverrideFile);
+            filesOverride.Load();
+            FileManager = new UOFileManager(clientVersion, clientPath, filesOverride);
             FileManager.Load(Settings.GlobalSettings.UseVerdata, Settings.GlobalSettings.Language, Settings.GlobalSettings.MapsLayouts);
 
             StaticFilters.Load(FileManager.TileData);

--- a/src/ClassicUO.Client/Client.cs
+++ b/src/ClassicUO.Client/Client.cs
@@ -187,7 +187,7 @@ namespace ClassicUO
             Log.Trace($"Client version: {clientVersion}");
             Log.Trace($"Protocol: {Protocol}");
 
-            FileManager = new UOFileManager(clientVersion, clientPath);
+            FileManager = new UOFileManager(clientVersion, clientPath, new UOFilesOverrideMap(Settings.GlobalSettings.OverrideFile));
             FileManager.Load(Settings.GlobalSettings.UseVerdata, Settings.GlobalSettings.Language, Settings.GlobalSettings.MapsLayouts);
 
             StaticFilters.Load(FileManager.TileData);

--- a/src/ClassicUO.Client/Configuration/Settings.cs
+++ b/src/ClassicUO.Client/Configuration/Settings.cs
@@ -87,6 +87,8 @@ namespace ClassicUO.Configuration
         [JsonPropertyName("encryption")] public byte Encryption { get; set; }
 
         [JsonPropertyName("plugins")] public string[] Plugins { get; set; } = { @"./Assistant/Razor.dll" };
+        
+        [JsonPropertyName("files_override")] public string OverrideFile { get; set; }
 
         public static string GetSettingsFilepath()
         {

--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -290,7 +290,7 @@ namespace ClassicUO
 
                     case "filesoverride":
                     case "uofilesoverride":
-                        UOFilesOverrideMap.OverrideFile = value;
+                        Settings.GlobalSettings.OverrideFile = value;
 
                         break;
 

--- a/src/ClassicUO.IO/UOFilesOverrideMap.cs
+++ b/src/ClassicUO.IO/UOFilesOverrideMap.cs
@@ -7,21 +7,23 @@ namespace ClassicUO.IO
 {
     public sealed class UOFilesOverrideMap : Dictionary<string, string>
     {
-        public UOFilesOverrideMap()
+        private readonly string _OverrideFile;
+        public UOFilesOverrideMap(string overrideFile = "")
         {
+            _OverrideFile = overrideFile;
         }
         
-        public UOFilesOverrideMap(string overrideFile)
+        public void Load()
         {
-            if (!File.Exists(overrideFile))
+            if (!File.Exists(_OverrideFile))
             {
                 Log.Trace($"No Override File found, ignoring.");
                 return; // if the file doesn't exist then we ignore
             }
 
-            Log.Trace($"Loading Override File:\t\t{overrideFile}");
+            Log.Trace($"Loading Override File:\t\t{_OverrideFile}");
 
-            using (FileStream stream = new FileStream(overrideFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (FileStream stream = new FileStream(_OverrideFile, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (StreamReader reader = new StreamReader(stream))
             {
                 // we will gracefully ignore any failures when trying to read

--- a/src/ClassicUO.IO/UOFilesOverrideMap.cs
+++ b/src/ClassicUO.IO/UOFilesOverrideMap.cs
@@ -7,23 +7,21 @@ namespace ClassicUO.IO
 {
     public sealed class UOFilesOverrideMap : Dictionary<string, string>
     {
-        public static string OverrideFile { get; set; }
-
-        public UOFilesOverrideMap() : base()
+        public UOFilesOverrideMap()
         {
         }
-
-        public void Load()
+        
+        public UOFilesOverrideMap(string overrideFile)
         {
-            if (!File.Exists(OverrideFile))
+            if (!File.Exists(overrideFile))
             {
                 Log.Trace($"No Override File found, ignoring.");
                 return; // if the file doesn't exist then we ignore
             }
 
-            Log.Trace($"Loading Override File:\t\t{OverrideFile}");
+            Log.Trace($"Loading Override File:\t\t{overrideFile}");
 
-            using (FileStream stream = new FileStream(OverrideFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (FileStream stream = new FileStream(overrideFile, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (StreamReader reader = new StreamReader(stream))
             {
                 // we will gracefully ignore any failures when trying to read


### PR DESCRIPTION
Housekeeping around UOFilesOverrideMap
UOFilesOverrideMap will be loaded outside of UOFileManager.
UOFileManager.IsUOPInstallation will be initialized in constructor

My only concern is if 2nd ctor of UOFilesOverrideMap shouldn't be in fact a factory method