### PR TITLE
Add missing Verdata.Load call

### DIFF
--- a/src/ClassicUO.Assets/UOFileManager.cs
+++ b/src/ClassicUO.Assets/UOFileManager.cs
@@ -164,6 +164,7 @@ namespace ClassicUO.Assets
             MultiMaps.Load();
             TileArt.Load();
             StringDictionary.Load();
+            Verdata.Load();
 
             ReadArtDefFile();
 


### PR DESCRIPTION
I'm trying to get an old shard to work that uses `verdata.mul` and noticed that `Verdata.Load()` is never actually called. Without this, the file is never processed, even with `use_verdata=true`. I scoured the commit history but couldn't find any reason why this is missing. 

Feel free to close if there's a reason, but after this change, it works great for the old shard I'm working with.

Might also fix https://github.com/ClassicUO/ClassicUO/issues/1787.