### PR TITLE
Added Journal file options to give players a bit more control

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -20,6 +20,7 @@ using Microsoft.Xna.Framework;
 namespace ClassicUO.Configuration
 {
     //[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified)]
+    [JsonSerializable(typeof(GlobalProfile), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(Profile), GenerationMode = JsonSourceGenerationMode.Metadata)]
     sealed partial class ProfileJsonContext : JsonSerializerContext
     {
@@ -45,7 +46,11 @@ namespace ClassicUO.Configuration
         public static ProfileJsonContext DefaultToUse { get; } = new ProfileJsonContext(_jsonOptions.Value);
     }
 
-
+    internal sealed class GlobalProfile
+    {
+        public int MaxJournalFiles { get; set; } = 100;
+        public bool JournalFileWithSerial { get; set; } = false;
+    }
 
     internal sealed class Profile
     {
@@ -67,8 +72,6 @@ namespace ClassicUO.Configuration
         public int SpeechDelay { get; set; } = 100;
         public bool ScaleSpeechDelay { get; set; } = true;
         public bool SaveJournalToFile { get; set; } = true;
-        public int MaxJournalFiles { get; set; } = 100;
-        public bool JournalFileWithSerial { get; set; } = false;
         public bool ForceUnicodeJournal { get; set; }
         public bool IgnoreAllianceMessages { get; set; }
         public bool IgnoreGuildMessages { get; set; }
@@ -353,18 +356,12 @@ namespace ClassicUO.Configuration
         {
             Log.Trace($"Saving path:\t\t{path}");
 
-            // Save profile settings
-            ConfigurationResolver.Save(this, Path.Combine(path, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
+            ProfileManager.Save(this, path);
 
             // Save opened gumps
             SaveGumps(world, path);
 
             Log.Trace("Saving done!");
-        }
-
-        public void SaveAs(string path, string filename = "default.json")
-        {
-            ConfigurationResolver.Save(this, Path.Combine(path, filename), ProfileJsonContext.DefaultToUse.Profile);
         }
 
         private void SaveGumps(World world, string path)

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -67,6 +67,8 @@ namespace ClassicUO.Configuration
         public int SpeechDelay { get; set; } = 100;
         public bool ScaleSpeechDelay { get; set; } = true;
         public bool SaveJournalToFile { get; set; } = true;
+        public int MaxJournalFiles { get; set; } = 100;
+        public bool JournalFileWithSerial { get; set; } = false;
         public bool ForceUnicodeJournal { get; set; }
         public bool IgnoreAllianceMessages { get; set; }
         public bool IgnoreGuildMessages { get; set; }

--- a/src/ClassicUO.Client/Configuration/ProfileManager.cs
+++ b/src/ClassicUO.Client/Configuration/ProfileManager.cs
@@ -103,7 +103,10 @@ namespace ClassicUO.Configuration
         internal static void Save(Profile profile, string path, string filename = "profile.json")
         {
             ConfigurationResolver.Save(profile, Path.Combine(path, filename), ProfileJsonContext.DefaultToUse.Profile);
-            ConfigurationResolver.Save(GlobalProfile, Path.Combine(RootPath, "globalprofile.json"), ProfileJsonContext.DefaultToUse.GlobalProfile);
+            if (GlobalProfile != null)
+            {
+                ConfigurationResolver.Save(GlobalProfile, Path.Combine(RootPath, "globalprofile.json"), ProfileJsonContext.DefaultToUse.GlobalProfile);
+            }
         }
     }
 }

--- a/src/ClassicUO.Client/Configuration/ProfileManager.cs
+++ b/src/ClassicUO.Client/Configuration/ProfileManager.cs
@@ -1,5 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using System;
 using System.IO;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
@@ -8,6 +9,7 @@ namespace ClassicUO.Configuration
 {
     internal static class ProfileManager
     {
+        public static GlobalProfile GlobalProfile { get; private set; }
         public static Profile CurrentProfile { get; private set; }
         public static string ProfilePath { get; private set; }
 
@@ -34,6 +36,8 @@ namespace ClassicUO.Configuration
 
         public static void Load(string servername, string username, string charactername)
         {
+            GlobalProfile = ConfigurationResolver.Load<GlobalProfile>(Path.Combine(RootPath, "globalprofile.json"), ProfileJsonContext.DefaultToUse.GlobalProfile) ?? new GlobalProfile();
+
             string path = FileSystemHelper.CreateFolderIfNotExists(RootPath, username, servername, charactername);
             string fileToLoad = Path.Combine(path, "profile.json");
 
@@ -49,7 +53,7 @@ namespace ClassicUO.Configuration
 
         public static void SetProfileAsDefault(Profile profile)
         {
-            profile.SaveAs(RootPath, "default.json");
+            Save(profile, RootPath, "default.json");
         }
 
         public static Profile NewFromDefault()
@@ -92,7 +96,14 @@ namespace ClassicUO.Configuration
 
         public static void UnLoadProfile()
         {
+            GlobalProfile = null;
             CurrentProfile = null;
+        }
+
+        internal static void Save(Profile profile, string path, string filename = "profile.json")
+        {
+            ConfigurationResolver.Save(profile, Path.Combine(path, filename), ProfileJsonContext.DefaultToUse.Profile);
+            ConfigurationResolver.Save(GlobalProfile, Path.Combine(RootPath, "globalprofile.json"), ProfileJsonContext.DefaultToUse.GlobalProfile);
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/JournalManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalManager.cs
@@ -58,7 +58,7 @@ namespace ClassicUO.Game.Managers
             }
 
             bool saveSerial = ProfileManager.GlobalProfile != null && ProfileManager.GlobalProfile.JournalFileWithSerial;
-            string serialText = saveSerial && serial.HasValue ? $"<0x{serial:X8}> " : string.Empty;
+            string serialText = saveSerial && serial.HasValue ? $"<0x{serial.Value:X8}> " : string.Empty;
 
             string output = $"[{timeNow:G}]  {serialText}{name}: {text}";
 

--- a/src/ClassicUO.Client/Game/Managers/JournalManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalManager.cs
@@ -57,7 +57,7 @@ namespace ClassicUO.Game.Managers
                 CreateWriter();
             }
 
-            bool saveSerial = ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.JournalFileWithSerial;
+            bool saveSerial = ProfileManager.GlobalProfile != null && ProfileManager.GlobalProfile.JournalFileWithSerial;
             string serialText = saveSerial && serial.HasValue ? $"<0x{serial:X8}> " : string.Empty;
 
             string output = $"[{timeNow:G}]  {serialText}{name}: {text}";
@@ -83,7 +83,7 @@ namespace ClassicUO.Game.Managers
                         AutoFlush = true
                     };
 
-                    int maxJournalFiles = ProfileManager.CurrentProfile.MaxJournalFiles;
+                    int maxJournalFiles = ProfileManager.GlobalProfile?.MaxJournalFiles ?? -1;
 
                     if (maxJournalFiles < 0)
                     {

--- a/src/ClassicUO.Client/Game/Managers/JournalManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalManager.cs
@@ -78,32 +78,31 @@ namespace ClassicUO.Game.Managers
                 {
                     string path = FileSystemHelper.CreateFolderIfNotExists(Path.Combine(CUOEnviroment.ExecutablePath, "Data"), "Client", "JournalLogs");
 
+                    int maxJournalFiles = ProfileManager.GlobalProfile?.MaxJournalFiles ?? -1;
+
+                    if (maxJournalFiles >= 0)
+                    {
+                        try
+                        {
+                            string[] files = Directory.GetFiles(path, "*_journal.txt");
+                            Array.Sort(files);
+                            Array.Reverse(files);
+
+                            for (int i = files.Length - 1; i >= maxJournalFiles; --i)
+                            {
+                                File.Delete(files[i]);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error($"Failed to delete old journal files. Original Error: {ex.Message}");
+                        }
+                    }
+
                     _fileWriter = new StreamWriter(File.Open(Path.Combine(path, $"{DateTime.Now:yyyy_MM_dd_HH_mm_ss}_journal.txt"), FileMode.Create, FileAccess.Write, FileShare.Read))
                     {
                         AutoFlush = true
                     };
-
-                    int maxJournalFiles = ProfileManager.GlobalProfile?.MaxJournalFiles ?? -1;
-
-                    if (maxJournalFiles < 0)
-                    {
-                        return;
-                    }
-
-                    try
-                    {
-                        string[] files = Directory.GetFiles(path, "*_journal.txt");
-                        Array.Sort(files);
-                        Array.Reverse(files);
-
-                        for (int i = files.Length - 1; i >= maxJournalFiles; --i)
-                        {
-                            File.Delete(files[i]);
-                        }
-                    }
-                    catch
-                    {
-                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -266,7 +266,7 @@ namespace ClassicUO.Game.Scenes
 
             if (!string.IsNullOrEmpty(text))
             {
-                _world.Journal.Add(text, hue, name, e.TextType, e.IsUnicode, e.Type);
+                _world.Journal.Add(text, hue, name, e.Parent?.Serial, e.TextType, e.IsUnicode, e.Type);
             }
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ColorPickerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ColorPickerGump.cs
@@ -15,6 +15,7 @@ namespace ClassicUO.Game.UI.Gumps
         private const int SLIDER_MAX = 4;
         private readonly ColorPickerBox _box;
         private readonly StaticPic _dyeTybeImage;
+        private readonly HSliderBar _slider;
 
         private readonly ushort _graphic;
         private readonly Action<ushort> _okClicked;
@@ -47,11 +48,9 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             );
 
-            HSliderBar slider;
-
             Add
             (
-                slider = new HSliderBar
+                _slider = new HSliderBar
                 (
                     39,
                     142,
@@ -63,7 +62,7 @@ namespace ClassicUO.Game.UI.Gumps
                 )
             );
 
-            slider.ValueChanged += (sender, e) => { _box.Graduation = slider.Value; };
+            _slider.ValueChanged += (sender, e) => { _box.Graduation = _slider.Value; };
             Add(_box = new ColorPickerBox(World, 34, 34));
             _box.ColorSelectedIndex += (sender, e) => { _dyeTybeImage.Hue = _box.SelectedHue; };
             
@@ -114,9 +113,14 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 _box.SelectedHue = obj.Hue;
 
-                // If the hue is not valid (rejected by the setter), send a message to the user
-                if (_box.SelectedHue != obj.Hue)
+                if (_box.SelectedHue == obj.Hue)
                 {
+                    _slider.Value = _box.Graduation;
+                }
+                else
+                {
+                    // If the hue is not valid (rejected by the setter), send a message to the user
+
                     string badHueMessage = Client.Game.UO.FileManager.Clilocs.GetString(1042295);
 
                     World.MessageManager.HandleMessage(

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -61,6 +61,9 @@ namespace ClassicUO.Game.UI.Gumps
         private FontSelector _fontSelectorChat;
         private Checkbox _forceUnicodeJournal;
         private InputField _gameWindowHeight;
+        private Checkbox _maxJournalFilesEnabled;
+        private InputField _maxJournalFiles;
+        private Checkbox _journalFileWithSerial;
 
         private Checkbox _gameWindowLock, _gameWindowFullsize;
         // GameWindowPosition
@@ -2436,6 +2439,61 @@ namespace ClassicUO.Game.UI.Gumps
                 World.Journal.CloseWriter();
             }
 
+            startX += 40;
+
+            _maxJournalFilesEnabled = AddCheckBox
+            (
+                rightArea,
+                ResGumps.MaxJournalFiles,
+                _currentProfile.MaxJournalFiles >= 0,
+                startX,
+                startY
+            );
+
+            startX += _maxJournalFilesEnabled.Width + 5;
+
+            _maxJournalFiles = AddInputField
+            (
+                rightArea,
+                startX,
+                startY,
+                50,
+                TEXTBOX_HEIGHT,
+                null,
+                50,
+                false,
+                true,
+                999
+            );
+
+            if (_currentProfile.MaxJournalFiles < 0)
+            {
+                // if the checkbox is unchecked, we set the value of the input field to 100
+                // so when the user checks it, there's a sensible default value.
+                _maxJournalFiles.SetText("100");
+            }
+            else
+            {
+                _maxJournalFiles.SetText(_currentProfile.MaxJournalFiles.ToString());
+            }
+
+            startX = 5;
+
+            startX += 40;
+            startY += _maxJournalFiles.Height + 2 + 5;
+
+            _journalFileWithSerial = AddCheckBox
+            (
+                rightArea,
+                ResGumps.JournalFileWithSerial,
+                _currentProfile.JournalFileWithSerial,
+                startX,
+                startY
+            );
+
+            startX = 5;
+            startY += _journalFileWithSerial.Height + 2 + 5;
+
             _chatAfterEnter = AddCheckBox
             (
                 rightArea,
@@ -3862,6 +3920,25 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.ActivateChatShiftEnterSupport = _chatShiftEnterCheckbox.IsChecked;
             _currentProfile.SaveJournalToFile = _saveJournalCheckBox.IsChecked;
             _currentProfile.OverheadPartyMessages = _partyMessagesOverhead.IsChecked;
+
+            if (!_maxJournalFilesEnabled.IsChecked)
+            {
+                // if the checkbox is unchecked, ignore the input field and set to -1 (unlimited)
+                _currentProfile.MaxJournalFiles = -1;
+            }
+            else
+            {
+                if (int.TryParse(_maxJournalFiles.Text, out int maxJournalFiles))
+                {
+                    _currentProfile.MaxJournalFiles = maxJournalFiles;
+                }
+                else
+                {
+                    _currentProfile.MaxJournalFiles = -1;
+                }
+            }
+
+            _currentProfile.JournalFileWithSerial = _journalFileWithSerial.IsChecked;
 
             // video
             _currentProfile.EnableDeathScreen = _enableDeathScreen.IsChecked;

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -150,7 +150,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _showStatsMessage, _showSkillsMessage;
         private HSliderBar _showSkillsMessageDelta;
 
-
+        private GlobalProfile _globalProfile = ProfileManager.GlobalProfile;
         private Profile _currentProfile = ProfileManager.CurrentProfile;
 
         public OptionsGump(World world) : base(world, 0, 0)
@@ -2445,7 +2445,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 rightArea,
                 ResGumps.MaxJournalFiles,
-                _currentProfile.MaxJournalFiles >= 0,
+                _globalProfile.MaxJournalFiles >= 0,
                 startX,
                 startY
             );
@@ -2466,7 +2466,7 @@ namespace ClassicUO.Game.UI.Gumps
                 999
             );
 
-            if (_currentProfile.MaxJournalFiles < 0)
+            if (_globalProfile.MaxJournalFiles < 0)
             {
                 // if the checkbox is unchecked, we set the value of the input field to 100
                 // so when the user checks it, there's a sensible default value.
@@ -2474,7 +2474,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
             else
             {
-                _maxJournalFiles.SetText(_currentProfile.MaxJournalFiles.ToString());
+                _maxJournalFiles.SetText(_globalProfile.MaxJournalFiles.ToString());
             }
 
             startX = 5;
@@ -2486,7 +2486,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 rightArea,
                 ResGumps.JournalFileWithSerial,
-                _currentProfile.JournalFileWithSerial,
+                _globalProfile.JournalFileWithSerial,
                 startX,
                 startY
             );
@@ -3924,21 +3924,21 @@ namespace ClassicUO.Game.UI.Gumps
             if (!_maxJournalFilesEnabled.IsChecked)
             {
                 // if the checkbox is unchecked, ignore the input field and set to -1 (unlimited)
-                _currentProfile.MaxJournalFiles = -1;
+                _globalProfile.MaxJournalFiles = -1;
             }
             else
             {
                 if (int.TryParse(_maxJournalFiles.Text, out int maxJournalFiles))
                 {
-                    _currentProfile.MaxJournalFiles = maxJournalFiles;
+                    _globalProfile.MaxJournalFiles = maxJournalFiles;
                 }
                 else
                 {
-                    _currentProfile.MaxJournalFiles = -1;
+                    _globalProfile.MaxJournalFiles = -1;
                 }
             }
 
-            _currentProfile.JournalFileWithSerial = _journalFileWithSerial.IsChecked;
+            _globalProfile.JournalFileWithSerial = _journalFileWithSerial.IsChecked;
 
             // video
             _currentProfile.EnableDeathScreen = _enableDeathScreen.IsChecked;

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -2314,7 +2314,7 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add the speaker&apos;s serial to the journal file.
+        ///   Looks up a localized string similar to Add speaker serial to journal entries.
         /// </summary>
         public static string JournalFileWithSerial {
             get {
@@ -2748,7 +2748,7 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete old files after this amount:.
+        ///   Looks up a localized string similar to Keep at most this many journal files:.
         /// </summary>
         public static string MaxJournalFiles {
             get {

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -2314,6 +2314,15 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add the speaker&apos;s serial to the journal file.
+        /// </summary>
+        public static string JournalFileWithSerial {
+            get {
+                return ResourceManager.GetString("JournalFileWithSerial", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Key combination already exists..
         /// </summary>
         public static string KeyCombinationAlreadyExists {
@@ -2735,6 +2744,15 @@ namespace ClassicUO.Resources {
         public static string MaximumStats {
             get {
                 return ResourceManager.GetString("MaximumStats", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete old files after this amount:.
+        /// </summary>
+        public static string MaxJournalFiles {
+            get {
+                return ResourceManager.GetString("MaxJournalFiles", resourceCulture);
             }
         }
         

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1659,9 +1659,9 @@ start your first counter</value>
     <value>[Prompt]:</value>
   </data>
   <data name="MaxJournalFiles" xml:space="preserve">
-    <value>Delete old files after this amount:</value>
+    <value>Keep at most this many journal files:</value>
   </data>
   <data name="JournalFileWithSerial" xml:space="preserve">
-    <value>Add the speaker's serial to the journal file</value>
+    <value>Add speaker serial to journal entries</value>
   </data>
 </root>

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1658,4 +1658,10 @@ start your first counter</value>
   <data name="Prompt" xml:space="preserve">
     <value>[Prompt]:</value>
   </data>
+  <data name="MaxJournalFiles" xml:space="preserve">
+    <value>Delete old files after this amount:</value>
+  </data>
+  <data name="JournalFileWithSerial" xml:space="preserve">
+    <value>Add the speaker's serial to the journal file</value>
+  </data>
 </root>


### PR DESCRIPTION
Adds two new options

1. Set the amount of logs to be saved
2. Add the speaker's serial to the log files

<img width="424" height="236" alt="image" src="https://github.com/user-attachments/assets/dbed42fb-5629-4505-93b9-30512ea4e0e0" />

Produces the following log output:

```
[09/19/2025 07:36:24]  <0x000FD38E> Cassius Dessin: This is a test of the new journal options
```

The previous behavior is also set as the new default and needs to be manually changed in order for the new features to become active:
1. delete after 100 files
2. do not save the serial