### PR TITLE
Sound def issue

### DIFF
--- a/src/ClassicUO.Assets/SoundsLoader.cs
+++ b/src/ClassicUO.Assets/SoundsLoader.cs
@@ -61,7 +61,7 @@ namespace ClassicUO.Assets
                     {
                         int index = reader.ReadInt();
 
-                        if (index < 0 || index >= MAX_SOUND_DATA_INDEX_COUNT || index >= _file.Entries.Length || _file.Entries[index].Length != 0)
+                        if (index < 0 || index >= MAX_SOUND_DATA_INDEX_COUNT || index >= _file.Entries.Length || _file.Entries[index].Length > 0)
                         {
                             continue;
                         }


### PR DESCRIPTION
Sound.def is not respected when Sound.mul returns a length of -1. As a result, some sounds don’t work (for example, the Eagle mob and the Invisible spell, tested in version 4.0.4b).

This simple fix changes the skip condition from “not equal to zero” to “greater than zero.”