### PR TITLE
Hotfix for the broken SpriteFont textures after switching to SDL3

### DIFF
--- a/src/ClassicUO.Renderer/SpriteFont.cs
+++ b/src/ClassicUO.Renderer/SpriteFont.cs
@@ -211,7 +211,7 @@ namespace ClassicUO.Renderer
                 unsafe
                 {
                     fixed (byte* ptr = levelData)
-                        texture.SetDataPointerEXT(0, null, (IntPtr)ptr, width * height * sizeof(byte));
+                        texture.SetDataPointerEXT(0, null, (IntPtr)ptr, levelDataSizeInBytes);
                 }
 
                 reader.Read7BitEncodedInt();


### PR DESCRIPTION
The bug affected the world map and other places where SpriteFonts were rendered instead of pre-rendering text

Hints to find the bug were graciously provided by TazmanianTad

https://discord.com/channels/458277173208547350/1425491919349219450/1425504944110178365
<img width="355" height="362" alt="image" src="https://github.com/user-attachments/assets/b30974cf-c798-4f12-a5d1-b35a7cefd927" />
<img width="421" height="409" alt="image" src="https://github.com/user-attachments/assets/ce2acf81-90a8-40c3-957b-f296c5388d08" />
