### PR TITLE
Implementation for the new render stack

### DIFF
--- a/src/ClassicUO.Client/Client.cs
+++ b/src/ClassicUO.Client/Client.cs
@@ -5,12 +5,9 @@ using ClassicUO.Configuration;
 using ClassicUO.Game;
 using ClassicUO.Game.Data;
 using ClassicUO.IO;
-using ClassicUO.Network;
-using ClassicUO.Network.Encryption;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
-using ClassicUO.Utility.Platforms;
 using Microsoft.Xna.Framework.Graphics;
 using SDL3;
 using System;
@@ -94,7 +91,7 @@ namespace ClassicUO
             LightColors.LoadLights();
 
             World = new World();
-            GameCursor = new GameCursor(World);
+            GameCursor = new GameCursor(World, game.DpiScale);
         }
 
         public void Unload()

--- a/src/ClassicUO.Client/Game/GameCursor.cs
+++ b/src/ClassicUO.Client/Game/GameCursor.cs
@@ -1,7 +1,5 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
@@ -9,12 +7,11 @@ using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
-using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using SDL3;
+using System;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game
 {
@@ -88,7 +85,7 @@ namespace ClassicUO.Game
         private readonly Tooltip _tooltip;
         private readonly World _world;
 
-        public GameCursor(World world)
+        public GameCursor(World world, float dpiScale)
         {
             _world = world;
             _tooltip = new Tooltip(world);
@@ -104,7 +101,8 @@ namespace ClassicUO.Game
                         id,
                         (ushort)(i == 2 ? 0x0033 : 0),
                         out int hotX,
-                        out int hotY
+                        out int hotY,
+                        dpiScale
                     );
 
                     if (surface != IntPtr.Zero)
@@ -392,7 +390,8 @@ namespace ClassicUO.Game
                                 dist,
                                 Mouse.Position.X - 26,
                                 Mouse.Position.Y - 21,
-                                hue
+                                hue,
+                                0f
                             );
 
                             hue.Y = 0;
@@ -401,7 +400,8 @@ namespace ClassicUO.Game
                                 dist,
                                 Mouse.Position.X - 25,
                                 Mouse.Position.Y - 20,
-                                hue
+                                hue,
+                                0f
                             );
                         }
                     }
@@ -451,7 +451,7 @@ namespace ClassicUO.Game
                         (int)(artInfo.UV.Height * scale)
                     );
 
-                    sb.Draw(artInfo.Texture, rect, artInfo.UV, hue);
+                    sb.Draw(artInfo.Texture, rect, artInfo.UV, hue, 0f);
 
                     if (
                         ItemHold.Amount > 1
@@ -462,7 +462,7 @@ namespace ClassicUO.Game
                         rect.X += 5;
                         rect.Y += 5;
 
-                        sb.Draw(artInfo.Texture, rect, artInfo.UV, hue);
+                        sb.Draw(artInfo.Texture, rect, artInfo.UV, hue, 0f);
                     }
                 }
             }
@@ -512,7 +512,8 @@ namespace ClassicUO.Game
                     artInfo.Texture,
                     new Vector2(Mouse.Position.X - offX, Mouse.Position.Y - offY),
                     rect,
-                    hueVec
+                    hueVec,
+                    0f
                 );
             }
         }

--- a/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
@@ -1,6 +1,5 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Renderer;
 using ClassicUO.Utility.Collections;
@@ -137,7 +136,7 @@ namespace ClassicUO.Game.GameObjects
             }
         }
 
-        public void Draw(UltimaBatcher2D batcher)
+        public void Draw(UltimaBatcher2D batcher, float layerDepth)
         {
             if (IsDestroyed || _messages.Count == 0)
             {
@@ -224,7 +223,7 @@ namespace ClassicUO.Game.GameObjects
                 item.X = p.X - (item.RenderedText.Width >> 1);
                 item.Y = p.Y - offY - item.RenderedText.Height - item.OffsetY;
 
-                item.RenderedText.Draw(batcher, item.X, item.Y, item.Alpha / 255f);
+                item.RenderedText.Draw(batcher, item.X, item.Y, layerDepth, item.Alpha / 255f);
                 offY += item.RenderedText.Height;
             }
         }

--- a/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using ClassicUO.IO;
 using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
@@ -27,7 +26,6 @@ namespace ClassicUO.Game
         ExtraHeight = 0x0100,
         CropTexture = 0x0200
     }
-
     internal sealed class RenderedText
     {
         private static readonly QueuedPool<RenderedText> _pool = new QueuedPool<RenderedText>(
@@ -377,7 +375,8 @@ namespace ClassicUO.Game
             int dheight,
             int offsetX,
             int offsetY,
-            ushort hue = 0
+            float layerDepth,
+            ushort hue = 0            
         )
         {
             if (string.IsNullOrEmpty(Text) || Texture == null || IsDestroyed || Texture.IsDisposed)
@@ -455,7 +454,8 @@ namespace ClassicUO.Game
                 Texture,
                 new Rectangle(dx, dy, dwidth, dheight),
                 new Rectangle(srcX, srcY, srcWidth, srcHeight),
-                hueVector
+                hueVector,
+                layerDepth
             );
 
             return true;
@@ -469,6 +469,7 @@ namespace ClassicUO.Game
             int sy,
             int swidth,
             int sheight,
+            float layerDepth,
             int hue = -1
         )
         {
@@ -523,13 +524,14 @@ namespace ClassicUO.Game
                 Texture,
                 new Vector2(dx, dy),
                 new Rectangle(sx, sy, swidth, sheight),
-                hueVector
+                hueVector,
+                layerDepth
             );
 
             return true;
         }
 
-        public bool Draw(UltimaBatcher2D batcher, int x, int y, float alpha = 1, ushort hue = 0)
+        public bool Draw(UltimaBatcher2D batcher, int x, int y, float depth, float alpha = 1, ushort hue = 0)
         {
             if (string.IsNullOrEmpty(Text) || Texture == null || IsDestroyed || Texture.IsDisposed)
             {
@@ -568,7 +570,7 @@ namespace ClassicUO.Game
                 hueVector.Y = 0;
             }
 
-            batcher.Draw(Texture, new Rectangle(x, y, Width, Height), hueVector);
+            batcher.Draw(Texture, new Rectangle(x, y, Width, Height), hueVector, depth);
 
             return true;
         }

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
-using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
-using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -60,7 +58,7 @@ namespace ClassicUO.Game.GameObjects
                     ProfileManager.CurrentProfile.PartyAura && World.Party.Contains(this)
                         ? ProfileManager.CurrentProfile.PartyAuraHue
                         : Notoriety.GetHue(NotorietyFlag),
-                    depth + 1f
+                    depth
                 );
             }
 

--- a/src/ClassicUO.Client/Game/Managers/AuraManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AuraManager.cs
@@ -1,11 +1,11 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
 using ClassicUO.Configuration;
 using ClassicUO.Input;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
 
 namespace ClassicUO.Game.Managers
 {
@@ -30,6 +30,8 @@ namespace ClassicUO.Game.Managers
 
         public void Draw(UltimaBatcher2D batcher, int x, int y, ushort hue, float depth)
         {
+            int yBump = -5;
+
             if (_texture == null || _texture.IsDisposed)
             {
                 var w = _radius * 2;
@@ -47,7 +49,8 @@ namespace ClassicUO.Game.Managers
             Vector3 hueVec = ShaderHueTranslator.GetHueVector(hue, false, 1);
 
             batcher.SetBlendState(_blend.Value);
-            batcher.Draw(_texture, new Vector2(x, y), null, hueVec, 0f, Vector2.Zero, 1f, SpriteEffects.None, depth);
+            batcher.Draw(_texture, new Rectangle(x, y + yBump, _radius * 2, _radius - yBump), new Rectangle(0, 0, _radius * 2, _radius - yBump), hueVec, depth + 1f);
+            batcher.Draw(_texture, new Rectangle(x, y + _radius, _radius * 2, _radius + yBump), new Rectangle(0, _radius - yBump, _radius * 2, _radius + yBump), hueVec, depth + 1.49f);
             batcher.SetBlendState(null);
         }
 
@@ -72,7 +75,7 @@ namespace ClassicUO.Game.Managers
 
                     var opacityFactor = 1f - distance / (float)radius;
 
-                    blendedColors[x + y * width] = new Color(opacityFactor, opacityFactor, opacityFactor, opacityFactor);
+                    blendedColors[x + y * width] = Color.White * opacityFactor;
                 }
             }
 
@@ -97,7 +100,7 @@ namespace ClassicUO.Game.Managers
         public AuraManager(World world)
         {
             _world = world;
-            _aura = new Aura(30);
+            _aura = new Aura(40);
         }
 
         public bool IsEnabled

--- a/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
@@ -3,11 +3,8 @@
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
-using ClassicUO.Game.Scenes;
-using ClassicUO.Renderer.Animations;
 
 namespace ClassicUO.Game.Managers
 {
@@ -28,7 +25,7 @@ namespace ClassicUO.Game.Managers
         public bool IsEnabled =>
             ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.ShowMobilesHP;
 
-        public void Draw(UltimaBatcher2D batcher)
+        public void Draw(UltimaBatcher2D batcher, float layerDepth)
         {
             var camera = Client.Game.Scene.Camera;
             int mode = ProfileManager.CurrentProfile.MobileHPType;
@@ -140,7 +137,7 @@ namespace ClassicUO.Game.Managers
                                     )
                                 )
                                 {
-                                    mobile.HitsTexture.Draw(batcher, p1.X, p1.Y);
+                                    mobile.HitsTexture.Draw(batcher, p1.X, p1.Y, layerDepth);
                                 }
 
                                 if (newTargSystem)
@@ -169,7 +166,7 @@ namespace ClassicUO.Game.Managers
 
                 if ((isEnabled && mode >= 1) || newTargSystem || forceDraw)
                 {
-                    DrawHealthLine(batcher, mobile, p.X, p.Y, offsetY, passive, newTargSystem);
+                    DrawHealthLine(batcher, mobile, p.X, p.Y, offsetY, passive, newTargSystem, layerDepth);
                 }
             }
         }
@@ -181,7 +178,8 @@ namespace ClassicUO.Game.Managers
             int y,
             int offsetY,
             bool passive,
-            bool newTargetSystem
+            bool newTargetSystem,
+            float layerDepth
         )
         {
             if (entity == null)
@@ -252,7 +250,8 @@ namespace ClassicUO.Game.Managers
                         newTargGumpInfo.Texture,
                         new Vector2(targetX, y - topTargetY),
                         newTargGumpInfo.UV,
-                        hueVec
+                        hueVec,
+                        layerDepth
                     );
 
                 if (hueGumpInfo.Texture != null)
@@ -260,7 +259,8 @@ namespace ClassicUO.Game.Managers
                         hueGumpInfo.Texture,
                         new Vector2(targetX, y - topTargetY),
                         hueGumpInfo.UV,
-                        hueVec
+                        hueVec,
+                        layerDepth
                     );
 
                 y += 7 + newTargGumpInfo.UV.Height / 2 - centerY;
@@ -271,7 +271,8 @@ namespace ClassicUO.Game.Managers
                         newTargGumpInfo.Texture,
                         new Vector2(targetX, y - 1 - newTargGumpInfo.UV.Height / 2f),
                         newTargGumpInfo.UV,
-                        hueVec
+                        hueVec,
+                        layerDepth
                     );
             }
 
@@ -282,7 +283,8 @@ namespace ClassicUO.Game.Managers
                 gumpInfo.Texture,
                 new Rectangle(x, y, gumpInfo.UV.Width * MULTIPLER, gumpInfo.UV.Height * MULTIPLER),
                 gumpInfo.UV,
-                hueVec
+                hueVec,
+                layerDepth
             );
 
             hueVec.X = 0x21;
@@ -307,7 +309,8 @@ namespace ClassicUO.Game.Managers
                         gumpInfo.UV.Height * MULTIPLER
                     ),
                     gumpInfo.UV,
-                    hueVec
+                    hueVec,
+                    layerDepth
                 );
             }
 
@@ -334,7 +337,8 @@ namespace ClassicUO.Game.Managers
                     gumpInfo.Texture,
                     new Rectangle(x, y, per * MULTIPLER, gumpInfo.UV.Height * MULTIPLER),
                     gumpInfo.UV,
-                    hueVec
+                    hueVec,
+                    layerDepth
                 );
             }
         }

--- a/src/ClassicUO.Client/Game/Managers/TextRenderer.cs
+++ b/src/ClassicUO.Client/Game/Managers/TextRenderer.cs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
 using ClassicUO.Configuration;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Input;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.Managers
 {
@@ -31,7 +31,7 @@ namespace ClassicUO.Game.Managers
             ProcessWorldText(false);
         }
 
-        public virtual void Draw(UltimaBatcher2D batcher, int startX, int startY, bool isGump = false)
+        public virtual void Draw(UltimaBatcher2D batcher, int startX, int startY, float layerDepth, bool isGump = false)
         {
             ProcessWorldText(false);
 
@@ -83,6 +83,7 @@ namespace ClassicUO.Game.Managers
                     batcher,
                     x,
                     y,
+                    layerDepth,
                     alpha,
                     hue
                 );

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -367,12 +367,12 @@ namespace ClassicUO.Game.Managers
             batcher.Begin();
             batcher.SetStencil(DepthStencilState.Default);
 
-            float layerDepth = 0;
+            float layerDepth = -10000;
 
             for (LinkedListNode<Gump> last = Gumps.Last; last != null; last = last.Previous)
             {
                 Control g = last.Value;
-                layerDepth++;
+                layerDepth+=10;
                 g.AddToRenderLists(_renderLists, g.X, g.Y, ref layerDepth);
             }
 

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -1,18 +1,15 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.Linq;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Input;
 using ClassicUO.Renderer;
+using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.Managers
 {
@@ -27,7 +24,7 @@ namespace ClassicUO.Game.Managers
         private static bool _isDraggingControl;
         private static Control _keyboardFocusControl, _lastFocus;
         private static bool _needSort;
-
+        private static readonly RenderLists _renderLists = new();
 
         public static float ContainerScale { get; set; } = 1f;
 
@@ -363,16 +360,27 @@ namespace ClassicUO.Game.Managers
 
         public static void Draw(UltimaBatcher2D batcher)
         {
+            _renderLists.Clear();
+
             SortControlsByInfo();
 
             batcher.Begin();
+            batcher.SetStencil(DepthStencilState.Default);
+
+            float layerDepth = 0;
 
             for (LinkedListNode<Gump> last = Gumps.Last; last != null; last = last.Previous)
             {
                 Control g = last.Value;
-                g.Draw(batcher, g.X, g.Y);
+                layerDepth++;
+                g.AddToRenderLists(_renderLists, g.X, g.Y, ref layerDepth);
             }
 
+            Profiler.EnterContext(Profiler.ProfilerContext.RENDER_FRAME_UI);
+            _renderLists.DrawRenderLists(batcher, sbyte.MaxValue);
+            Profiler.ExitContext(Profiler.ProfilerContext.RENDER_FRAME_UI);
+
+            batcher.SetStencil(null);
             batcher.End();
         }
 

--- a/src/ClassicUO.Client/Game/Managers/WorldTextManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/WorldTextManager.cs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Renderer;
+using System;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.Managers
 {
@@ -34,13 +34,14 @@ namespace ClassicUO.Game.Managers
         }
 
 
-        public override void Draw(UltimaBatcher2D batcher, int startX, int startY, bool isGump = false)
+        public override void Draw(UltimaBatcher2D batcher, int startX, int startY, float layerDepth, bool isGump = false)
         {
             base.Draw
             (
                 batcher,
                 startX,
                 startY,
+                layerDepth,
                 isGump
             );
 
@@ -68,7 +69,7 @@ namespace ClassicUO.Game.Managers
                     }
                 }
 
-                overheadDamage.Value.Draw(batcher);
+                overheadDamage.Value.Draw(batcher, layerDepth);
             }
         }
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -976,7 +976,7 @@ namespace ClassicUO.Game.Scenes
             )
             {
                 batcher.GraphicsDevice.SetRenderTarget(renderTargets.LightRenderTarget);
-                batcher.GraphicsDevice.Clear(ClearOptions.Target, Color.White, 0f, 0); // white = maximum light level
+                batcher.GraphicsDevice.Clear(ClearOptions.Target, Color.Transparent, 0f, 0);
                 batcher.GraphicsDevice.SetRenderTarget(null);
 
                 return false;

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -125,7 +125,7 @@ namespace ClassicUO.Game.Scenes
             _world.MessageManager.MessageReceived += ChatOnMessageReceived;
             UIManager.ContainerScale = ProfileManager.CurrentProfile.ContainersScale / 100f;
 
-            SDL.SDL_SetWindowMinimumSize(Client.Game.Window.Handle, 640, 480);
+            SDL.SDL_SetWindowMinimumSize(Client.Game.Window.Handle, Client.Game.ScaleWithDpi(640), Client.Game.ScaleWithDpi(480));
 
             if (ProfileManager.CurrentProfile.WindowBorderless)
             {
@@ -140,8 +140,8 @@ namespace ClassicUO.Game.Scenes
                 int w = Settings.GlobalSettings.WindowSize.Value.X;
                 int h = Settings.GlobalSettings.WindowSize.Value.Y;
 
-                w = Math.Max(640, w);
-                h = Math.Max(480, h);
+                w = Math.Max(Client.Game.ScaleWithDpi(640), w);
+                h = Math.Max(Client.Game.ScaleWithDpi(480), h);
 
                 Client.Game.SetWindowSize(w, h);
             }

--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -1,12 +1,5 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.IO;
-using System.Net;
-using System.Net.NetworkInformation;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
@@ -15,13 +8,17 @@ using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Game.UI.Gumps.CharCreation;
 using ClassicUO.Game.UI.Gumps.Login;
 using ClassicUO.IO;
-using ClassicUO.Assets;
 using ClassicUO.Network;
-using ClassicUO.Network.Encryption;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
 
 namespace ClassicUO.Game.Scenes
 {
@@ -93,7 +90,7 @@ namespace ClassicUO.Game.Scenes
                 Client.Game.RestoreWindow();
             }
 
-            Client.Game.SetWindowSize(640, 480);
+            Client.Game.SetWindowSize(Client.Game.ScaleWithDpi(640), Client.Game.ScaleWithDpi(480));
         }
 
 

--- a/src/ClassicUO.Client/Game/Scenes/MainScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/MainScene.cs
@@ -1,12 +1,12 @@
-using System;
 using ClassicUO.Configuration;
-using ClassicUO.Network.Encryption;
 using ClassicUO.Network;
+using ClassicUO.Network.Encryption;
 using ClassicUO.Renderer;
+using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using ClassicUO.Utility.Logging;
+using System;
 
 namespace ClassicUO.Game.Scenes
 {
@@ -46,12 +46,12 @@ namespace ClassicUO.Game.Scenes
             base.Update();
         }
 
-        public override bool Draw(UltimaBatcher2D batcher)
+        public override bool Draw(UltimaBatcher2D batcher, RenderTargets renderTargets)
         {
             _spritebatch.Begin();
             _spritebatch.DrawRectangle(new Rectangle(0, 0, 100, 100), Color.Red);
             _spritebatch.End();
-            return base.Draw(batcher);
+            return base.Draw(batcher, renderTargets);
         }
 
         public override void Load()

--- a/src/ClassicUO.Client/Game/Scenes/RenderLists.cs
+++ b/src/ClassicUO.Client/Game/Scenes/RenderLists.cs
@@ -1,0 +1,177 @@
+﻿// SPDX-License-Identifier: BSD-2-Clause
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Renderer;
+using System;
+using System.Collections.Generic;
+
+namespace ClassicUO.Game.Scenes
+{
+    /// <summary>
+    /// Represents an ordered queue of GameObjects to be rendered.
+    /// The order is determined by the draw order, not by the insertion order.
+    /// Implementation for sorting and processing is passed as delegates.
+    /// </summary>
+    internal class RenderLists
+    {
+        private readonly List<GameObject> _tiles = [];
+        private readonly List<GameObject> _stretchedTiles = [];
+        private readonly List<GameObject> _statics = [];
+        private readonly List<GameObject> _animations = [];
+        private readonly List<GameObject> _effects = [];
+        private readonly List<GameObject> _transparentObjects = [];
+        private readonly List<Func<UltimaBatcher2D, bool>> _gumpSprites = [];
+        private readonly List<Func<UltimaBatcher2D, bool>> _gumpTexts = [];
+
+        public void Clear()
+        {
+            _tiles.Clear();
+            _stretchedTiles.Clear();
+            _statics.Clear();
+            _animations.Clear();
+            _effects.Clear();
+            _transparentObjects.Clear();
+            _gumpSprites.Clear();
+            _gumpTexts.Clear();
+        }
+
+        public void Add(GameObject toRender, bool isTransparent = false)
+        {
+            if (isTransparent)
+            {
+                _transparentObjects.Add(toRender);
+                return;
+            }
+
+            switch (toRender)
+            {
+                case Land land:
+                    if (land.IsStretched)
+                    {
+                        _stretchedTiles.Add(toRender);
+                    }
+                    else
+                    {
+                        _tiles.Add(toRender);
+                    }
+                    break;
+
+                case Static:
+                case Multi:
+                    _statics.Add(toRender);
+                    break;
+
+                case Mobile:
+                    _animations.Add(toRender);
+                    break;
+
+                case Item item:
+                    if (item.IsCorpse)
+                    {
+                        _animations.Add(toRender);
+                    }
+                    else
+                    {
+                        _statics.Add(toRender);
+                    }
+                    break;
+                
+                case GameEffect:
+                    _effects.Add(toRender);
+                    break;
+         
+                default:
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// This is an itermediate, crappy solution. Rewriting gump rendering would be way too much at this point.
+        /// Adding gump elements that use atlas textures for efficient rendering.
+        /// </summary>
+        /// <param name="toRender"></param>
+        public void AddGumpWithAtlas(Func<UltimaBatcher2D, bool> toRender)
+        {
+            _gumpSprites.Add(toRender);
+        }
+
+        /// <summary>
+        /// This is an itermediate, crappy solution. Rewriting gump rendering would be way too much at this point.
+        /// Adding gump elements that do not use atlas textures and will be rendered separately.
+        /// </summary>
+        /// <param name="toRender"></param>
+        public void AddGumpNoAtlas(Func<UltimaBatcher2D, bool> toRender)
+        {
+            _gumpTexts.Add(toRender);
+        }
+
+        public int DrawRenderLists(UltimaBatcher2D batcher, sbyte maxGroundZ)
+        {
+            int result = DrawRenderList(batcher, _tiles, maxGroundZ) +
+                   DrawRenderList(batcher, _stretchedTiles, maxGroundZ) +
+                   DrawRenderList(batcher, _statics, maxGroundZ) +
+                   DrawRenderList(batcher, _animations, maxGroundZ) +
+                   DrawRenderList(batcher, _effects, maxGroundZ);
+
+            if (_transparentObjects.Count > 0 || _gumpSprites.Count > 0 || _gumpTexts.Count > 0)
+            {
+                //batcher.SetStencil(DepthStencilState.DepthRead);
+                result += DrawRenderList(batcher, _transparentObjects, maxGroundZ);
+                result += DrawRenderListWithAtlas(batcher, _gumpSprites);
+                result += DrawRenderListNoAtlas(batcher, _gumpTexts);
+                //batcher.SetStencil(null);
+            }
+
+            return result;
+        }
+
+        private static int DrawRenderList(UltimaBatcher2D batcher, List<GameObject> renderList, sbyte maxGroundZ)
+        {
+            int done = 0;
+
+            foreach (var obj in renderList)
+            {
+                if (obj.Z <= maxGroundZ)
+                {
+                    float depth = obj.CalculateDepthZ();
+
+                    if (obj.Draw(batcher, obj.RealScreenPosition.X, obj.RealScreenPosition.Y, depth))
+                    {
+                        done++;
+                    }
+                }
+            }
+
+            return done;
+        }
+
+        private static int DrawRenderListWithAtlas(UltimaBatcher2D batcher, List<Func<UltimaBatcher2D, bool>> renderList)
+        {
+            int done = 0;
+
+            foreach (var obj in renderList)
+            {
+                if (obj.Invoke(batcher))
+                {
+                    done++;
+                }
+            }
+
+            return done;
+        }
+
+        private static int DrawRenderListNoAtlas(UltimaBatcher2D batcher, List<Func<UltimaBatcher2D, bool>> renderList)
+        {
+            int done = 0;
+
+            foreach (var obj in renderList)
+            {
+                if (obj.Invoke(batcher))
+                {
+                    done++;
+                }
+            }
+
+            return done;
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Scenes/RenderLists.cs
+++ b/src/ClassicUO.Client/Game/Scenes/RenderLists.cs
@@ -85,7 +85,7 @@ namespace ClassicUO.Game.Scenes
         }
 
         /// <summary>
-        /// This is an itermediate, crappy solution. Rewriting gump rendering would be way too much at this point.
+        /// This is an intermediate, crappy solution. Rewriting gump rendering would be way too much at this point.
         /// Adding gump elements that use atlas textures for efficient rendering.
         /// </summary>
         /// <param name="toRender"></param>
@@ -95,7 +95,7 @@ namespace ClassicUO.Game.Scenes
         }
 
         /// <summary>
-        /// This is an itermediate, crappy solution. Rewriting gump rendering would be way too much at this point.
+        /// This is an intermediate, crappy solution. Rewriting gump rendering would be way too much at this point.
         /// Adding gump elements that do not use atlas textures and will be rendered separately.
         /// </summary>
         /// <param name="toRender"></param>

--- a/src/ClassicUO.Client/Game/Scenes/Scene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/Scene.cs
@@ -1,11 +1,9 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using ClassicUO.Game.Managers;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using SDL3;
+using System;
 
 namespace ClassicUO.Game.Scenes
 {
@@ -34,7 +32,7 @@ namespace ClassicUO.Game.Scenes
             Camera.Update(true, Time.Delta, Mouse.Position);
         }
 
-        public virtual bool Draw(UltimaBatcher2D batcher)
+        public virtual bool Draw(UltimaBatcher2D batcher, RenderTargets renderTargets)
         {
             return true;
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/AlphaBlendControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/AlphaBlendControl.cs
@@ -1,5 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 
@@ -15,21 +16,31 @@ namespace ClassicUO.Game.UI.Controls
 
         public ushort Hue { get; set; }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(Hue, false, Alpha);
 
-            batcher.Draw
+            renderLists.AddGumpNoAtlas
             (
-                SolidColorTextureCache.GetTexture(Color.Black),
-                new Rectangle
-                (
-                    x,
-                    y,
-                    Width,
-                    Height
-                ),
-                hueVector
+                batcher =>
+                {
+                    batcher.Draw
+                    (
+                        SolidColorTextureCache.GetTexture(Color.Black),
+                        new Rectangle
+                        (
+                            x,
+                            y,
+                            Width,
+                            Height
+                        ),
+                        hueVector,
+                        layerDepth
+                    );
+
+                    return true;
+                }
             );
 
             return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/Button.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Button.cs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -171,8 +170,9 @@ namespace ClassicUO.Game.UI.Controls
             _entered = false;
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Texture2D texture = null;
             Rectangle bounds = Rectangle.Empty;
 
@@ -207,7 +207,13 @@ namespace ClassicUO.Game.UI.Controls
 
             var hue = ShaderHueTranslator.GetHueVector(Hue, false, Alpha, true);
 
-            batcher.Draw(texture, new Rectangle(x, y, Width, Height), bounds, hue);
+            renderLists.AddGumpWithAtlas(
+                batcher =>
+                {
+                    batcher.Draw(texture, new Rectangle(x, y, Width, Height), bounds, hue, layerDepth);
+                    return true;
+                });
+            
 
             if (!string.IsNullOrEmpty(_caption))
             {
@@ -217,19 +223,23 @@ namespace ClassicUO.Game.UI.Controls
                 {
                     int yoffset = IsClicked ? 1 : 0;
 
-                    textTexture.Draw(
+                    renderLists.AddGumpNoAtlas(
+                        batcher => textTexture.Draw(
                         batcher,
                         x + ((Width - textTexture.Width) >> 1),
-                        y + yoffset + ((Height - textTexture.Height) >> 1)
-                    );
+                        y + yoffset + ((Height - textTexture.Height) >> 1),
+                        depth: layerDepth
+                    ));
                 }
                 else
                 {
-                    textTexture.Draw(batcher, x, y);
+                    renderLists.AddGumpNoAtlas(
+                        batcher => textTexture.Draw(batcher, x, y, depth: layerDepth)
+                    );
                 }
             }
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         protected override void OnMouseDown(int x, int y, MouseButtonType button)

--- a/src/ClassicUO.Client/Game/UI/Controls/ButtonTileArt.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ButtonTileArt.cs
@@ -1,10 +1,10 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
-using ClassicUO.Assets;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -39,9 +39,10 @@ namespace ClassicUO.Game.UI.Controls
             _isPartial = Client.Game.UO.FileManager.TileData.StaticData[_graphic].IsPartialHue;
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            base.Draw(batcher, x, y);
+            base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
+            float layerDepth = layerDepthRef;
 
             var hueVector = ShaderHueTranslator.GetHueVector(_hue, _isPartial, 1f);
 
@@ -49,11 +50,21 @@ namespace ClassicUO.Game.UI.Controls
 
             if (artInfo.Texture != null)
             {
-                batcher.Draw(
-                    artInfo.Texture,
-                    new Vector2(x + _tileX, y + _tileY),
-                    artInfo.UV,
-                    hueVector
+                var texture = artInfo.Texture;
+                var sourceRectangle = artInfo.UV;
+                renderLists.AddGumpWithAtlas
+                (
+                    (batcher) =>
+                    {
+                        batcher.Draw(
+                            texture,
+                            new Vector2(x + _tileX, y + _tileY),
+                            sourceRectangle,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
 
                 return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/Checkbox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Checkbox.cs
@@ -1,12 +1,12 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -80,27 +80,46 @@ namespace ClassicUO.Game.UI.Controls
 
         public event EventHandler ValueChanged;
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
             if (IsDisposed)
             {
                 return false;
             }
 
-            var ok = base.Draw(batcher, x, y);
+            var ok = base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
+            float layerDepth = layerDepthRef;
 
             ref readonly var gumpInfo = ref Client.Game.UO.Gumps.GetGump(
                 IsChecked ? _active : _inactive
             );
+            var texture = gumpInfo.Texture;
+            var sourceRectangle = gumpInfo.UV;
+            renderLists.AddGumpWithAtlas
+            (
+                (batcher) =>
+                {
+                    batcher.Draw(
+                        texture,
+                        new Vector2(x, y),
+                        sourceRectangle,
+                        ShaderHueTranslator.GetHueVector(0),
+                        layerDepth
+                     );
 
-            batcher.Draw(
-                gumpInfo.Texture,
-                new Vector2(x, y),
-                gumpInfo.UV,
-                ShaderHueTranslator.GetHueVector(0)
+                    return true;
+                }
             );
 
-            _text.Draw(batcher, x + gumpInfo.UV.Width + 2, y);
+            renderLists.AddGumpNoAtlas
+            (
+                (batcher) =>
+                {
+                    _text.Draw(batcher, x + sourceRectangle.Width + 2, y, layerDepth);
+
+                    return true;
+                }
+            );
 
             return ok;
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/CheckerTrans.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/CheckerTrans.cs
@@ -1,10 +1,11 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -64,8 +65,9 @@ namespace ClassicUO.Game.UI.Controls
         }
 
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             //batcher.SetBlendState(_checkerBlend.Value);
             //batcher.SetStencil(_checkerStencil.Value);
 
@@ -79,18 +81,30 @@ namespace ClassicUO.Game.UI.Controls
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, 0.5f);
 
             //batcher.SetStencil(_checkerStencil.Value);
-            batcher.Draw
+
+            renderLists.AddGumpNoAtlas
             (
-                SolidColorTextureCache.GetTexture(Color.Black),
-                new Rectangle
-                (
-                    x,
-                    y,
-                    Width,
-                    Height
-                ),
-                hueVector
+                (batcher) =>
+                {
+                    batcher.Draw
+                    (
+                        SolidColorTextureCache.GetTexture(Color.Black),
+                        new Rectangle
+                        (
+                            x,
+                            y,
+                            Width,
+                            Height
+                        ),
+                        hueVector,
+                        layerDepth
+                    );
+
+                    return true;
+                }
             );
+
+            
 
             //batcher.SetStencil(null);
             return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/ClickableColorBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ClickableColorBox.cs
@@ -1,9 +1,9 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 
@@ -35,26 +35,35 @@ namespace ClassicUO.Game.UI.Controls
             Height = background.Height;
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
             if (Children.Count != 0)
             {
-                Children[0].Draw(batcher, x, y);
+                layerDepthRef += 0.1f;
+                Children[0].AddToRenderLists(renderLists, x, y, ref layerDepthRef);
             }
+            float layerDepth = layerDepthRef;
 
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(Hue);
 
-            batcher.Draw
-            (
-               SolidColorTextureCache.GetTexture(Color.White),
-               new Rectangle
-               (
-                   x + 3,
-                   y + 3,
-                   Width - 6,
-                   Height - 6
-                ),
-                hueVector
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    batcher.Draw
+                    (
+                        SolidColorTextureCache.GetTexture(Color.White),
+                        new Rectangle
+                        (
+                            x + 3,
+                            y + 3,
+                            Width - 6,
+                            Height - 6
+                        ),
+                        hueVector,
+                        layerDepth
+                    );
+                    return true;
+                }
             );
 
             return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/ColorBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ColorBox.cs
@@ -1,10 +1,8 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using ClassicUO.Assets;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
-using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -23,21 +21,31 @@ namespace ClassicUO.Game.UI.Controls
 
         public ushort Hue { get;  set; }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(Hue);
 
-            batcher.Draw
+            renderLists.AddGumpNoAtlas
             (
-                SolidColorTextureCache.GetTexture(Color.White),
-                new Rectangle
-                (
-                    x,
-                    y,
-                    Width,
-                    Height
-                ),
-                hueVector
+                (batcher) =>
+                {
+                    batcher.Draw
+                    (
+                        SolidColorTextureCache.GetTexture(Color.White),
+                        new Rectangle
+                        (
+                            x,
+                            y,
+                            Width,
+                            Height
+                        ),
+                        hueVector,
+                        layerDepth
+                    );
+
+                    return true;
+                }
             );
 
             return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/ColorPickerBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ColorPickerBox.cs
@@ -1,14 +1,13 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Runtime.InteropServices;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -135,8 +134,9 @@ namespace ClassicUO.Game.UI.Controls
             base.Update();
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Texture2D texture = SolidColorTextureCache.GetTexture(Color.White);
 
             Rectangle rect = new Rectangle(0, 0, _cellWidth, _cellHeight);
@@ -152,11 +152,18 @@ namespace ClassicUO.Game.UI.Controls
                     rect.X = x + j * _cellWidth;
                     rect.Y = y + i * _cellHeight;
 
-                    batcher.Draw
-                    (
-                        texture,
-                        rect,
-                        hueVector
+                    renderLists.AddGumpNoAtlas(
+                        batcher =>
+                        {
+                            batcher.Draw
+                            (
+                                texture,
+                                rect,
+                                hueVector,
+                                layerDepth
+                            );
+                            return true;
+                        }
                     );
                 }
             }
@@ -170,15 +177,22 @@ namespace ClassicUO.Game.UI.Controls
                 rect.Width = 2;
                 rect.Height = 2;
 
-                batcher.Draw
-                (
-                    SolidColorTextureCache.GetTexture(Color.White),
-                    rect,
-                    hueVector
+                renderLists.AddGumpNoAtlas(
+                    batcher =>
+                    {
+                        batcher.Draw
+                        (
+                            SolidColorTextureCache.GetTexture(Color.White),
+                            rect,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
             }
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
 

--- a/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
@@ -1,13 +1,12 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Linq;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Input;
-using ClassicUO.Renderer;
-using Microsoft.Xna.Framework;
+using System;
+using System.Linq;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -93,13 +92,27 @@ namespace ClassicUO.Game.UI.Controls
         public event EventHandler<int> OnOptionSelected;
 
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            if (batcher.ClipBegin(x, y, Width, Height))
-            {
-                base.Draw(batcher, x, y);
-                batcher.ClipEnd();
-            }
+            float layerDepth = layerDepthRef;
+            renderLists.AddGumpNoAtlas
+            (
+                (batcher) =>
+                {
+                    // work-around to allow clipping children
+                    RenderLists comboBoxRenderLists = new();
+                    base.AddToRenderLists(comboBoxRenderLists, x, y, ref layerDepth);
+
+                    if (batcher.ClipBegin(x, y, Width, Height))
+                    {
+                        comboBoxRenderLists.DrawRenderLists(batcher, sbyte.MaxValue);
+                        batcher.ClipEnd();
+                    }
+                    return true;
+                }
+            );
+
+
 
             return true;
         }
@@ -241,14 +254,25 @@ namespace ClassicUO.Game.UI.Controls
             }
 
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
-                if (batcher.ClipBegin(x, y, Width, Height))
-                {
-                    base.Draw(batcher, x, y);
+                float layerDepth = layerDepthRef + 100f; // Combo list should be over other gumps
+                renderLists.AddGumpNoAtlas
+                (
+                    (batcher) =>
+                    {
+                        // work-around to allow clipping children
+                        RenderLists comboBoxRenderLists = new();
+                        base.AddToRenderLists(comboBoxRenderLists, x, y, ref layerDepth);
 
-                    batcher.ClipEnd();
-                }
+                        if (batcher.ClipBegin(x, y, Width, Height))
+                        {
+                            comboBoxRenderLists.DrawRenderLists(batcher, sbyte.MaxValue);
+                            batcher.ClipEnd();
+                        }
+                        return true;
+                    }
+                );
 
                 return true;
             }

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -1,12 +1,13 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Input;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -159,21 +160,29 @@ namespace ClassicUO.Game.UI.Controls
             WantUpdateSize = true;
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
-            batcher.DrawRectangle
+            renderLists.AddGumpNoAtlas
             (
-                SolidColorTextureCache.GetTexture(Color.Gray),
-                x - 1,
-                y - 1,
-                _background.Width + 1,
-                _background.Height + 1,
-                hueVector
+                (batcher) =>
+                {
+                    batcher.DrawRectangle
+                    (
+                        SolidColorTextureCache.GetTexture(Color.Gray),
+                        x - 1,
+                        y - 1,
+                        _background.Width + 1,
+                        _background.Height + 1,
+                        hueVector,
+                        layerDepth
+                    );
+                    return true;
+                }
             );
-
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         public override bool Contains(int x, int y)
@@ -332,31 +341,48 @@ namespace ClassicUO.Game.UI.Controls
                 }
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
                 if (!string.IsNullOrWhiteSpace(_label.Text) && MouseIsOver)
                 {
                     Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
-                    batcher.Draw
+                    float layerDepth = layerDepthRef;
+                    renderLists.AddGumpNoAtlas
                     (
-                        SolidColorTextureCache.GetTexture(Color.Gray),
-                        new Rectangle
-                        (
-                            x + 2,
-                            y + 5,
-                            Width - 4,
-                            Height - 10
-                        ),
-                        hueVector
+                        (batcher) =>
+                        {
+                            batcher.Draw
+                            (
+                                SolidColorTextureCache.GetTexture(Color.Gray),
+                                new Rectangle
+                                (
+                                    x + 2,
+                                    y + 5,
+                                    Width - 4,
+                                    Height - 10
+                                ),
+                                hueVector,
+                                layerDepth
+                            );
+                            return true;
+                        }
                     );
                 }
 
-                base.Draw(batcher, x, y);
+                base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
 
                 if (_entry.Items != null && _entry.Items.Count != 0)
                 {
-                    _moreMenuLabel.Draw(batcher, x + Width - _moreMenuLabel.Width, y + (Height >> 1) - (_moreMenuLabel.Height >> 1) - 1);
+                    float layerDepth = layerDepthRef;
+                    renderLists.AddGumpNoAtlas
+                   (
+                       (batcher) =>
+                       {
+                           _moreMenuLabel.Draw(batcher, x + Width - _moreMenuLabel.Width, y + (Height >> 1) - (_moreMenuLabel.Height >> 1) - 1, layerDepth);
+                           return true;
+                       }
+                   );
                 }
 
                 return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/Control.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Control.cs
@@ -244,7 +244,7 @@ namespace ClassicUO.Game.UI.Controls
                 {
                     if (c.IsVisible)
                     {
-                        layerDepth += 0.0001f;
+                        layerDepth += 0.01f;
                         c.AddToRenderLists(renderLists, c.X + x, c.Y + y, ref layerDepth);
                     }
                 }

--- a/src/ClassicUO.Client/Game/UI/Controls/Control.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Control.cs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Input;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using SDL3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Keyboard = ClassicUO.Input.Keyboard;
-using Mouse = ClassicUO.Input.Mouse;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -231,9 +231,7 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
-
-
-        public virtual bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public virtual bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepth)
         {
             if (IsDisposed)
             {
@@ -246,12 +244,13 @@ namespace ClassicUO.Game.UI.Controls
                 {
                     if (c.IsVisible)
                     {
-                        c.Draw(batcher, c.X + x, c.Y + y);
+                        layerDepth += 0.0001f;
+                        c.AddToRenderLists(renderLists, c.X + x, c.Y + y, ref layerDepth);
                     }
                 }
             }
 
-            DrawDebug(batcher, x, y);
+            DrawDebug(renderLists, x, y, layerDepth);
 
             return true;
         }
@@ -325,20 +324,28 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
-        private void DrawDebug(UltimaBatcher2D batcher, int x, int y)
+        private void DrawDebug(RenderLists renderLists, int x, int y, float layerDepth)
         {
             if (IsVisible && CUOEnviroment.Debug)
             {
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
-                batcher.DrawRectangle
+                renderLists.AddGumpNoAtlas
                 (
-                    SolidColorTextureCache.GetTexture(Color.Green),
-                    x,
-                    y,
-                    Width,
-                    Height,
-                    hueVector
+                    (batcher) =>
+                    {
+                        batcher.DrawRectangle
+                        (
+                            SolidColorTextureCache.GetTexture(Color.Green),
+                            x,
+                            y,
+                            Width,
+                            Height,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
             }
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/Control.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Control.cs
@@ -17,6 +17,7 @@ namespace ClassicUO.Game.UI.Controls
 {
     internal abstract class Control
     {
+        protected const float CHILD_LAYER_INCREMENT = 0.01f;
         internal static int _StepsDone = 1;
         internal static int _StepChanger = 1;
 
@@ -244,7 +245,7 @@ namespace ClassicUO.Game.UI.Controls
                 {
                     if (c.IsVisible)
                     {
-                        layerDepth += 0.01f;
+                        layerDepth += CHILD_LAYER_INCREMENT;
                         c.AddToRenderLists(renderLists, c.X + x, c.Y + y, ref layerDepth);
                     }
                 }

--- a/src/ClassicUO.Client/Game/UI/Controls/CroppedText.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/CroppedText.cs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
-using ClassicUO.Renderer;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Utility;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -34,11 +34,19 @@ namespace ClassicUO.Game.UI.Controls
             IsFromServer = true;
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            _gameText.Draw(batcher, x, y);
+            float layerDepth = layerDepthRef;
+            renderLists.AddGumpNoAtlas
+            (
+                (batcher) =>
+                {
+                    _gameText.Draw(batcher, x, y, layerDepth);
+                    return true;
+                }
+            );
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         public override void Dispose()

--- a/src/ClassicUO.Client/Game/UI/Controls/GumpPic.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/GumpPic.cs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Input;
 using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -121,8 +122,9 @@ namespace ClassicUO.Game.UI.Controls
             return hue;
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             if (IsDisposed)
             {
                 return false;
@@ -134,15 +136,23 @@ namespace ClassicUO.Game.UI.Controls
 
             if (gumpInfo.Texture != null)
             {
-                batcher.Draw(
-                    gumpInfo.Texture,
-                    new Rectangle(x, y, Width, Height),
-                    gumpInfo.UV,
-                    hueVector
-                );
+                var texture = gumpInfo.Texture;
+                var sourceRectangle = gumpInfo.UV;
+                renderLists.AddGumpWithAtlas(
+                    batcher =>
+                    {
+                        batcher.Draw(
+                            texture,
+                            new Rectangle(x, y, Width, Height),
+                            sourceRectangle,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    });
             }
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
     }
 
@@ -208,8 +218,9 @@ namespace ClassicUO.Game.UI.Controls
             return true;
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             if (IsDisposed)
             {
                 return false;
@@ -221,17 +232,25 @@ namespace ClassicUO.Game.UI.Controls
 
             var sourceBounds = new Rectangle(gumpInfo.UV.X + _picInPicBounds.X, gumpInfo.UV.Y + _picInPicBounds.Y, _picInPicBounds.Width, _picInPicBounds.Height);
 
-            if (gumpInfo.Texture != null)
+            var texture = gumpInfo.Texture;
+            if (texture != null)
             {
-                batcher.Draw(
-                    gumpInfo.Texture,
-                    new Rectangle(x, y, Width, Height),
-                    sourceBounds,
-                    hueVector
+                renderLists.AddGumpWithAtlas(
+                    batcher =>
+                    {
+                        batcher.Draw(
+                            texture,
+                            new Rectangle(x, y, Width, Height),
+                            sourceBounds,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
             }
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Controls/GumpPicTiled.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/GumpPicTiled.cs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
-using ClassicUO.Assets;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -70,23 +70,34 @@ namespace ClassicUO.Game.UI.Controls
 
         public ushort Hue { get; set; }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(Hue, false, Alpha, true);
 
             ref readonly var gumpInfo = ref Client.Game.UO.Gumps.GetGump(Graphic);
 
-            if (gumpInfo.Texture != null)
-            {
-                batcher.DrawTiled(
-                    gumpInfo.Texture,
-                    new Rectangle(x, y, Width, Height),
-                    gumpInfo.UV,
-                    hueVector
+            var texture = gumpInfo.Texture;
+            if (texture != null)
+            {                
+                var sourceRectangle = gumpInfo.UV;
+                renderLists.AddGumpWithAtlas
+                (
+                    (batcher) =>
+                    {
+                        batcher.DrawTiled(
+                            texture,
+                            new Rectangle(x, y, Width, Height),
+                            sourceRectangle,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
             }
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         public override bool Contains(int x, int y)

--- a/src/ClassicUO.Client/Game/UI/Controls/GumpPicWithWidth.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/GumpPicWithWidth.cs
@@ -1,6 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using ClassicUO.Assets;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 
@@ -18,19 +18,30 @@ namespace ClassicUO.Game.UI.Controls
 
         public int Percent { get; set; }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(Hue);
 
             ref readonly var gumpInfo = ref Client.Game.UO.Gumps.GetGump(Graphic);
 
+            var texture = gumpInfo.Texture;
             if (gumpInfo.Texture != null)
             {
-                batcher.DrawTiled(
-                    gumpInfo.Texture,
-                    new Rectangle(x, y, Percent, Height),
-                    gumpInfo.UV,
-                    hueVector
+                var sourceRectangle = gumpInfo.UV;
+                renderLists.AddGumpWithAtlas
+                (
+                    (batcher) =>
+                    {
+                        batcher.DrawTiled(
+                            texture,
+                            new Rectangle(x, y, Percent, Height),
+                            sourceRectangle,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
 
                 return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/HSliderBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/HSliderBar.cs
@@ -1,12 +1,12 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -134,70 +134,88 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
-            if (_style == HSliderBarStyle.MetalWidgetRecessedBar)
-            {
-                ref readonly var gumpInfo0 = ref Client.Game.UO.Gumps.GetGump(213);
-                ref readonly var gumpInfo1 = ref Client.Game.UO.Gumps.GetGump(214);
-                ref readonly var gumpInfo2 = ref Client.Game.UO.Gumps.GetGump(215);
-                ref readonly var gumpInfo3 = ref Client.Game.UO.Gumps.GetGump(216);
+            renderLists.AddGumpWithAtlas
+            (
+                batcher =>
+                {
 
-                batcher.Draw(gumpInfo0.Texture, new Vector2(x, y), gumpInfo0.UV, hueVector);
+                    if (_style == HSliderBarStyle.MetalWidgetRecessedBar)
+                    {
+                        ref readonly var gumpInfo0 = ref Client.Game.UO.Gumps.GetGump(213);
+                        ref readonly var gumpInfo1 = ref Client.Game.UO.Gumps.GetGump(214);
+                        ref readonly var gumpInfo2 = ref Client.Game.UO.Gumps.GetGump(215);
+                        ref readonly var gumpInfo3 = ref Client.Game.UO.Gumps.GetGump(216);
 
-                batcher.DrawTiled(
-                    gumpInfo1.Texture,
-                    new Rectangle(
-                        x + gumpInfo0.UV.Width,
-                        y,
-                        BarWidth - gumpInfo2.UV.Width - gumpInfo0.UV.Width,
-                        gumpInfo1.UV.Height
-                    ),
-                    gumpInfo1.UV,
-                    hueVector
-                );
+                        batcher.Draw(gumpInfo0.Texture, new Vector2(x, y), gumpInfo0.UV, hueVector, layerDepth);
 
-                batcher.Draw(
-                    gumpInfo2.Texture,
-                    new Vector2(x + BarWidth - gumpInfo2.UV.Width, y),
-                    gumpInfo2.UV,
-                    hueVector
-                );
+                        batcher.DrawTiled(
+                            gumpInfo1.Texture,
+                            new Rectangle(
+                                x + gumpInfo0.UV.Width,
+                                y,
+                                BarWidth - gumpInfo2.UV.Width - gumpInfo0.UV.Width,
+                                gumpInfo1.UV.Height
+                            ),
+                            gumpInfo1.UV,
+                            hueVector,
+                            layerDepth
+                        );
 
-                batcher.Draw(
-                    gumpInfo3.Texture,
-                    new Vector2(x + _sliderX, y),
-                    gumpInfo3.UV,
-                    hueVector
-                );
-            }
-            else
-            {
-                ref readonly var gumpInfo = ref Client.Game.UO.Gumps.GetGump(idx: 0x845);
+                        batcher.Draw(
+                            gumpInfo2.Texture,
+                            new Vector2(x + BarWidth - gumpInfo2.UV.Width, y),
+                            gumpInfo2.UV,
+                            hueVector,
+                            layerDepth
+                        );
 
-                batcher.Draw(
-                    gumpInfo.Texture,
-                    new Vector2(x + _sliderX, y),
-                    gumpInfo.UV,
-                    hueVector
-                );
-            }
+                        batcher.Draw(
+                            gumpInfo3.Texture,
+                            new Vector2(x + _sliderX, y),
+                            gumpInfo3.UV,
+                            hueVector,
+                            layerDepth
+                        );
+                    }
+                    else
+                    {
+                        ref readonly var gumpInfo = ref Client.Game.UO.Gumps.GetGump(idx: 0x845);
 
+                        batcher.Draw(
+                            gumpInfo.Texture,
+                            new Vector2(x + _sliderX, y),
+                            gumpInfo.UV,
+                            hueVector,
+                            layerDepth
+                        );
+                    }
+                    return true;
+                }
+            );
             if (_text != null)
             {
-                if (_drawUp)
-                {
-                    _text.Draw(batcher, x, y - _text.Height);
-                }
-                else
-                {
-                    _text.Draw(batcher, x + BarWidth + 2, y + (Height >> 1) - (_text.Height >> 1));
-                }
+                renderLists.AddGumpNoAtlas
+                (
+                    batcher =>
+                    {
+                        if (_drawUp)
+                        {
+                            _text.Draw(batcher, x, y - _text.Height, layerDepth);
+                        }
+                        else
+                        {
+                            _text.Draw(batcher, x + BarWidth + 2, y + (Height >> 1) - (_text.Height >> 1), layerDepth);
+                        }
+                        return true;
+                    }
+                    );
             }
-
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         private void InternalSetValue(int value)

--- a/src/ClassicUO.Client/Game/UI/Controls/HitBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/HitBox.cs
@@ -1,5 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -37,8 +38,9 @@ namespace ClassicUO.Game.UI.Controls
         protected readonly Texture2D _texture;
 
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             if (IsDisposed)
             {
                 return false;
@@ -54,16 +56,23 @@ namespace ClassicUO.Game.UI.Controls
                                         true
                                     );
 
-                batcher.Draw
-                (
-                    _texture,
-                    new Vector2(x, y),
-                    new Rectangle(0, 0, Width, Height),
-                    hueVector
+                renderLists.AddGumpNoAtlas(
+                    batcher => 
+                    {
+                        batcher.Draw
+                        (
+                            _texture,
+                            new Vector2(x, y),
+                            new Rectangle(0, 0, Width, Height),
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
             }
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Controls/HoveredLabel.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/HoveredLabel.cs
@@ -1,6 +1,7 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using ClassicUO.Assets;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 
@@ -66,27 +67,35 @@ namespace ClassicUO.Game.UI.Controls
             base.Update();
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             if (DrawBackgroundCurrentIndex && MouseIsOver && !string.IsNullOrWhiteSpace(Text))
             {
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
-                batcher.Draw
-                (
-                    SolidColorTextureCache.GetTexture(Color.Gray),
-                    new Rectangle
-                    (
-                        x,
-                        y + 2,
-                        Width - 4,
-                        Height - 4
-                    ),
-                    hueVector
-                );
+                renderLists.AddGumpNoAtlas(
+                   batcher =>
+                   {
+                       batcher.Draw
+                        (
+                            SolidColorTextureCache.GetTexture(Color.Gray),
+                            new Rectangle
+                            (
+                                x,
+                                y + 2,
+                                Width - 4,
+                                Height - 4
+                            ),
+                            hueVector,
+                            layerDepth
+                        );
+                       return true;
+                   }
+               );
             }
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Controls/HtmlControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/HtmlControl.cs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using ClassicUO.Input;
 using ClassicUO.Assets;
-using ClassicUO.Renderer;
+using ClassicUO.Game.Scenes;
+using ClassicUO.Input;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
 using ClassicUO.Utility.Platforms;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -220,32 +218,43 @@ namespace ClassicUO.Game.UI.Controls
             base.Update();
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             if (IsDisposed)
             {
                 return false;
             }
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    if (batcher.ClipBegin(x, y, Width, Height))
+                    {
+                        RenderLists childRenderLists = new();
 
-            if (batcher.ClipBegin(x, y, Width, Height))
-            {
-                base.Draw(batcher, x, y);
+                        base.AddToRenderLists(childRenderLists, x, y, ref layerDepth);
 
-                int offset = HasBackground ? 4 : 0;
+                        childRenderLists.DrawRenderLists(batcher, sbyte.MaxValue);
 
-                _gameText.Draw
-                (
-                    batcher,
-                    x + offset,
-                    y + offset,
-                    ScrollX,
-                    ScrollY,
-                    Width + ScrollX,
-                    Height + ScrollY
-                );
+                        int offset = HasBackground ? 4 : 0;
 
-                batcher.ClipEnd();
-            }
+                        _gameText.Draw
+                        (
+                            batcher,
+                            x + offset,
+                            y + offset,
+                            ScrollX,
+                            ScrollY,
+                            Width + ScrollX,
+                            Height + ScrollY,
+                            layerDepth
+                        );
+
+                        batcher.ClipEnd();
+                    }
+                    return true;
+                }
+            );
 
 
             return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/Label.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Label.cs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
 using ClassicUO.Assets;
-using ClassicUO.Renderer;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Utility;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -84,16 +84,23 @@ namespace ClassicUO.Game.UI.Controls
 
         public bool Unicode => _gText.IsUnicode;
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
             if (IsDisposed)
             {
                 return false;
             }
+            float layerDepth = layerDepthRef;
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    _gText.Draw(batcher, x, y, layerDepth, Alpha);
 
-            _gText.Draw(batcher, x, y, Alpha);
+                    return true;
+                }
+            );
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         public override void Dispose()

--- a/src/ClassicUO.Client/Game/UI/Controls/Line.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Line.cs
@@ -1,5 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -20,22 +21,29 @@ namespace ClassicUO.Game.UI.Controls
             _texture = SolidColorTextureCache.GetTexture(new Color { PackedValue = color });
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, Alpha);
 
-            batcher.Draw
-            (
-                _texture,
-                new Rectangle
+            renderLists.AddGumpNoAtlas(batcher =>
+            {
+                batcher.Draw
                 (
-                    x,
-                    y,
-                    Width,
-                    Height
-                ),
-                hueVector
-            );
+                    _texture,
+                    new Rectangle
+                    (
+                        x,
+                        y,
+                        Width,
+                        Height
+                    ),
+                    hueVector,
+                    layerDepth
+                );
+
+                return true;
+            });
 
             return true;
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/NiceButton.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/NiceButton.cs
@@ -1,10 +1,11 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
-using ClassicUO.Input;
 using ClassicUO.Assets;
+using ClassicUO.Game.Scenes;
+using ClassicUO.Input;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -121,22 +122,30 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
             if (IsSelected)
             {
+                float layerDepth = layerDepthRef;
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, Alpha);
 
-                batcher.Draw
-                (
-                    _texture,
-                    new Vector2(x, y),
-                    new Rectangle(0, 0, Width, Height),
-                    hueVector
+                renderLists.AddGumpNoAtlas(
+                    batcher =>
+                    {
+                        batcher.Draw
+                        (
+                            _texture,
+                            new Vector2(x, y),
+                            new Rectangle(0, 0, Width, Height),
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
             }
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Controls/ResizePic.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ResizePic.cs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
-using ClassicUO.Assets;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -235,22 +235,32 @@ namespace ClassicUO.Game.UI.Controls
             return Client.Game.UO.Gumps.PixelCheck(graphic, x, y);
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            if (batcher.ClipBegin(x, y, Width, Height))
-            {
-                Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, Alpha, true);
+            float layerDepth = layerDepthRef;
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    if (batcher.ClipBegin(x, y, Width, Height))
+                    {
+                        Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, Alpha, true);
 
-                DrawInternal(batcher, x, y, hueVector);
-                base.Draw(batcher, x, y);
+                        DrawInternal(batcher, x, y, hueVector, layerDepth);
+                        RenderLists childRenderLists = new();
+                        base.AddToRenderLists(childRenderLists, x, y, ref layerDepth);
+                        childRenderLists.DrawRenderLists(batcher, sbyte.MaxValue);
 
-                batcher.ClipEnd();
-            }
+                        batcher.ClipEnd();
+                    }
+
+                    return true;
+                }
+            );
 
             return true;
         }
 
-        private void DrawInternal(UltimaBatcher2D batcher, int x, int y, Vector3 color)
+        private void DrawInternal(UltimaBatcher2D batcher, int x, int y, Vector3 color, float layerDepth)
         {
             var texture0 = GetTexture(0, out var bounds0);
             var texture1 = GetTexture(1, out var bounds1);
@@ -269,7 +279,7 @@ namespace ClassicUO.Game.UI.Controls
 
             if (texture0 != null)
             {
-                batcher.Draw(texture0, new Vector2(x, y), bounds0, color);
+                batcher.Draw(texture0, new Vector2(x, y), bounds0, color, layerDepth);
             }
 
             if (texture1 != null)
@@ -283,7 +293,8 @@ namespace ClassicUO.Game.UI.Controls
                         bounds1.Height
                     ),
                     bounds1,
-                    color
+                    color,
+                    layerDepth
                 );
             }
 
@@ -293,7 +304,8 @@ namespace ClassicUO.Game.UI.Controls
                     texture2,
                     new Vector2(x + (Width - bounds2.Width), y + offsetTop),
                     bounds2,
-                    color
+                    color,
+                    layerDepth
                 );
             }
 
@@ -308,7 +320,8 @@ namespace ClassicUO.Game.UI.Controls
                         Height - bounds0.Height - bounds5.Height
                     ),
                     bounds3,
-                    color
+                    color,
+                    layerDepth
                 );
             }
 
@@ -323,7 +336,8 @@ namespace ClassicUO.Game.UI.Controls
                         Height - bounds2.Height - bounds7.Height
                     ),
                     bounds4,
-                    color
+                    color,
+                    layerDepth
                 );
             }
 
@@ -333,7 +347,8 @@ namespace ClassicUO.Game.UI.Controls
                     texture5,
                     new Vector2(x, y + (Height - bounds5.Height)),
                     bounds5,
-                    color
+                    color,
+                    layerDepth
                 );
             }
 
@@ -348,7 +363,8 @@ namespace ClassicUO.Game.UI.Controls
                         bounds6.Height
                     ),
                     bounds6,
-                    color
+                    color,
+                    layerDepth
                 );
             }
 
@@ -358,7 +374,8 @@ namespace ClassicUO.Game.UI.Controls
                     texture7,
                     new Vector2(x + (Width - bounds7.Width), y + (Height - bounds7.Height)),
                     bounds7,
-                    color
+                    color,
+                    layerDepth
                 );
             }
 
@@ -373,7 +390,8 @@ namespace ClassicUO.Game.UI.Controls
                         Height - bounds2.Height - bounds7.Height
                     ),
                     bounds8,
-                    color
+                    color,
+                    layerDepth
                 );
             }
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/ScissorControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ScissorControl.cs
@@ -1,7 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using ClassicUO.Renderer;
-using Microsoft.Xna.Framework;
+using ClassicUO.Game.Scenes;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -27,16 +26,22 @@ namespace ClassicUO.Game.UI.Controls
 
         public bool DoScissor;
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            if (DoScissor)
-            {
-                batcher.ClipBegin(x, y, Width, Height);
-            }
-            else
-            {
-                batcher.ClipEnd();
-            }
+            renderLists.AddGumpWithAtlas(
+                batcher =>
+                {
+                    if (DoScissor)
+                    {
+                        batcher.ClipBegin(x, y, Width, Height);
+                    }
+                    else
+                    {
+                        batcher.ClipEnd();
+                    }
+                    return true;
+                }
+            );
 
             return true;
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/ScrollBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ScrollBar.cs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
+using System;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -54,125 +54,138 @@ namespace ClassicUO.Game.UI.Controls
             _emptySpace.Height = Height - (gumpInfoDown.UV.Height + gumpInfoUp.UV.Height);
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
             if (Height <= 0 || !IsVisible)
             {
                 return false;
             }
+            float layerDepth = layerDepthRef;
 
-            var hueVector = ShaderHueTranslator.GetHueVector(0);
-
-            ref readonly var gumpInfoUp0 = ref Client.Game.UO.Gumps.GetGump(BUTTON_UP_0);
-            ref readonly var gumpInfoUp1 = ref Client.Game.UO.Gumps.GetGump(BUTTON_UP_1);
-            ref readonly var gumpInfoDown0 = ref Client.Game.UO.Gumps.GetGump(BUTTON_DOWN_0);
-            ref readonly var gumpInfoDown1 = ref Client.Game.UO.Gumps.GetGump(BUTTON_DOWN_1);
-            ref readonly var gumpInfoBackground0 = ref Client.Game.UO.Gumps.GetGump(BACKGROUND_0);
-            ref readonly var gumpInfoBackground1 = ref Client.Game.UO.Gumps.GetGump(BACKGROUND_1);
-            ref readonly var gumpInfoBackground2 = ref Client.Game.UO.Gumps.GetGump(BACKGROUND_2);
-            ref readonly var gumpInfoSlider = ref Client.Game.UO.Gumps.GetGump(SLIDER);
-
-            // draw scrollbar background
-            int middleHeight =
-                Height
-                - gumpInfoUp0.UV.Height
-                - gumpInfoDown0.UV.Height
-                - gumpInfoBackground0.UV.Height
-                - gumpInfoBackground2.UV.Height;
-
-            if (middleHeight > 0)
+            renderLists.AddGumpWithAtlas(batcher =>
             {
-                batcher.Draw(
-                    gumpInfoBackground0.Texture,
-                    new Vector2(x, y + gumpInfoUp0.UV.Height),
-                    gumpInfoBackground0.UV,
-                    hueVector
-                );
 
-                batcher.DrawTiled(
-                    gumpInfoBackground1.Texture,
-                    new Rectangle(
-                        x,
-                        y + gumpInfoUp1.UV.Height + gumpInfoBackground0.UV.Height,
-                        gumpInfoBackground0.UV.Width,
-                        middleHeight
-                    ),
-                    gumpInfoBackground1.UV,
-                    hueVector
-                );
+                var hueVector = ShaderHueTranslator.GetHueVector(0);
 
-                batcher.Draw(
-                    gumpInfoBackground2.Texture,
-                    new Vector2(
-                        x,
-                        y + Height - gumpInfoDown0.UV.Height - gumpInfoBackground2.UV.Height
-                    ),
-                    gumpInfoBackground2.UV,
-                    hueVector
-                );
-            }
-            else
-            {
-                middleHeight = Height - gumpInfoUp0.UV.Height - gumpInfoDown0.UV.Height;
+                ref readonly var gumpInfoUp0 = ref Client.Game.UO.Gumps.GetGump(BUTTON_UP_0);
+                ref readonly var gumpInfoUp1 = ref Client.Game.UO.Gumps.GetGump(BUTTON_UP_1);
+                ref readonly var gumpInfoDown0 = ref Client.Game.UO.Gumps.GetGump(BUTTON_DOWN_0);
+                ref readonly var gumpInfoDown1 = ref Client.Game.UO.Gumps.GetGump(BUTTON_DOWN_1);
+                ref readonly var gumpInfoBackground0 = ref Client.Game.UO.Gumps.GetGump(BACKGROUND_0);
+                ref readonly var gumpInfoBackground1 = ref Client.Game.UO.Gumps.GetGump(BACKGROUND_1);
+                ref readonly var gumpInfoBackground2 = ref Client.Game.UO.Gumps.GetGump(BACKGROUND_2);
+                ref readonly var gumpInfoSlider = ref Client.Game.UO.Gumps.GetGump(SLIDER);
 
-                batcher.DrawTiled(
-                    gumpInfoBackground1.Texture,
-                    new Rectangle(
-                        x,
-                        y + gumpInfoUp0.UV.Height,
-                        gumpInfoBackground0.UV.Width,
-                        middleHeight
-                    ),
-                    gumpInfoBackground1.UV,
-                    hueVector
-                );
-            }
+                // draw scrollbar background
+                int middleHeight =
+                    Height
+                    - gumpInfoUp0.UV.Height
+                    - gumpInfoDown0.UV.Height
+                    - gumpInfoBackground0.UV.Height
+                    - gumpInfoBackground2.UV.Height;
 
-            // draw up button
-            if (_btUpClicked)
-            {
-                batcher.Draw(gumpInfoUp1.Texture, new Vector2(x, y), gumpInfoUp1.UV, hueVector);
-            }
-            else
-            {
-                batcher.Draw(gumpInfoUp0.Texture, new Vector2(x, y), gumpInfoUp0.UV, hueVector);
-            }
+                if (middleHeight > 0)
+                {
+                    batcher.Draw(
+                        gumpInfoBackground0.Texture,
+                        new Vector2(x, y + gumpInfoUp0.UV.Height),
+                        gumpInfoBackground0.UV,
+                        hueVector,
+                        layerDepth
+                    );
 
-            // draw down button
-            if (_btDownClicked)
-            {
-                batcher.Draw(
-                    gumpInfoDown1.Texture,
-                    new Vector2(x, y + Height - gumpInfoDown0.UV.Height),
-                    gumpInfoDown1.UV,
-                    hueVector
-                );
-            }
-            else
-            {
-                batcher.Draw(
-                    gumpInfoDown0.Texture,
-                    new Vector2(x, y + Height - gumpInfoDown0.UV.Height),
-                    gumpInfoDown0.UV,
-                    hueVector
-                );
-            }
+                    batcher.DrawTiled(
+                        gumpInfoBackground1.Texture,
+                        new Rectangle(
+                            x,
+                            y + gumpInfoUp1.UV.Height + gumpInfoBackground0.UV.Height,
+                            gumpInfoBackground0.UV.Width,
+                            middleHeight
+                        ),
+                        gumpInfoBackground1.UV,
+                        hueVector,
+                        layerDepth
+                    );
 
-            // draw slider
-            if (MaxValue > MinValue && middleHeight > 0)
-            {
-                batcher.Draw(
-                    gumpInfoSlider.Texture,
-                    new Vector2(
-                        x + ((gumpInfoBackground0.UV.Width - gumpInfoSlider.UV.Width) >> 1),
-                        y + gumpInfoUp0.UV.Height + _sliderPosition
-                    ),
-                    gumpInfoSlider.UV,
-                    hueVector
-                );
-            }
+                    batcher.Draw(
+                        gumpInfoBackground2.Texture,
+                        new Vector2(
+                            x,
+                            y + Height - gumpInfoDown0.UV.Height - gumpInfoBackground2.UV.Height
+                        ),
+                        gumpInfoBackground2.UV,
+                        hueVector,
+                        layerDepth
+                    );
+                }
+                else
+                {
+                    middleHeight = Height - gumpInfoUp0.UV.Height - gumpInfoDown0.UV.Height;
 
-            return base.Draw(batcher, x, y);
+                    batcher.DrawTiled(
+                        gumpInfoBackground1.Texture,
+                        new Rectangle(
+                            x,
+                            y + gumpInfoUp0.UV.Height,
+                            gumpInfoBackground0.UV.Width,
+                            middleHeight
+                        ),
+                        gumpInfoBackground1.UV,
+                        hueVector,
+                        layerDepth
+                    );
+                }
+
+                // draw up button
+                if (_btUpClicked)
+                {
+                    batcher.Draw(gumpInfoUp1.Texture, new Vector2(x, y), gumpInfoUp1.UV, hueVector, layerDepth);
+                }
+                else
+                {
+                    batcher.Draw(gumpInfoUp0.Texture, new Vector2(x, y), gumpInfoUp0.UV, hueVector, layerDepth);
+                }
+
+                // draw down button
+                if (_btDownClicked)
+                {
+                    batcher.Draw(
+                        gumpInfoDown1.Texture,
+                        new Vector2(x, y + Height - gumpInfoDown0.UV.Height),
+                        gumpInfoDown1.UV,
+                        hueVector,
+                        layerDepth
+                    );
+                }
+                else
+                {
+                    batcher.Draw(
+                        gumpInfoDown0.Texture,
+                        new Vector2(x, y + Height - gumpInfoDown0.UV.Height),
+                        gumpInfoDown0.UV,
+                        hueVector,
+                        layerDepth
+                    );
+                }
+
+                // draw slider
+                if (MaxValue > MinValue && middleHeight > 0)
+                {
+                    batcher.Draw(
+                        gumpInfoSlider.Texture,
+                        new Vector2(
+                            x + ((gumpInfoBackground0.UV.Width - gumpInfoSlider.UV.Width) >> 1),
+                            y + gumpInfoUp0.UV.Height + _sliderPosition
+                        ),
+                        gumpInfoSlider.UV,
+                        hueVector,
+                        layerDepth
+                    );
+                }
+                return true;
+            });
+
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         protected override int GetScrollableArea()

--- a/src/ClassicUO.Client/Game/UI/Controls/ScrollFlag.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ScrollFlag.cs
@@ -1,10 +1,9 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using ClassicUO.Input;
-using ClassicUO.Assets;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
+using System;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -58,43 +57,52 @@ namespace ClassicUO.Game.UI.Controls
 
         public override ClickPriority Priority { get; set; } = ClickPriority.High;
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            var hueVector = ShaderHueTranslator.GetHueVector(0);
-
-            ref readonly var gumpInfoFlag = ref Client.Game.UO.Gumps.GetGump(BUTTON_FLAG);
-            ref readonly var gumpInfoUp = ref Client.Game.UO.Gumps.GetGump(BUTTON_UP);
-            ref readonly var gumpInfoDown = ref Client.Game.UO.Gumps.GetGump(BUTTON_DOWN);
-
-            if (MaxValue != MinValue && gumpInfoFlag.Texture != null)
-            {
-                batcher.Draw(
-                    gumpInfoFlag.Texture,
-                    new Vector2(x, y + _sliderPosition),
-                    gumpInfoFlag.UV,
-                    hueVector
-                );
-            }
-
-            if (_showButtons)
-            {
-                if (gumpInfoUp.Texture != null)
+            float layerDepth = layerDepthRef;
+            renderLists.AddGumpWithAtlas
+            (
+                (batcher) =>
                 {
-                    batcher.Draw(gumpInfoUp.Texture, new Vector2(x, y), gumpInfoUp.UV, hueVector);
-                }
+                    var hueVector = ShaderHueTranslator.GetHueVector(0);
 
-                if (gumpInfoDown.Texture != null)
-                {
-                    batcher.Draw(
-                        gumpInfoDown.Texture,
-                        new Vector2(x, y + Height),
-                        gumpInfoDown.UV,
-                        hueVector
-                    );
-                }
-            }
+                    ref readonly var gumpInfoFlag = ref Client.Game.UO.Gumps.GetGump(BUTTON_FLAG);
+                    ref readonly var gumpInfoUp = ref Client.Game.UO.Gumps.GetGump(BUTTON_UP);
+                    ref readonly var gumpInfoDown = ref Client.Game.UO.Gumps.GetGump(BUTTON_DOWN);
 
-            return base.Draw(batcher, x, y);
+                    if (MaxValue != MinValue && gumpInfoFlag.Texture != null)
+                    {
+                        batcher.Draw(
+                            gumpInfoFlag.Texture,
+                            new Vector2(x, y + _sliderPosition),
+                            gumpInfoFlag.UV,
+                            hueVector,
+                            layerDepth
+                        );
+                    }
+
+                    if (_showButtons)
+                    {
+                        if (gumpInfoUp.Texture != null)
+                        {
+                            batcher.Draw(gumpInfoUp.Texture, new Vector2(x, y), gumpInfoUp.UV, hueVector, layerDepth);
+                        }
+
+                        if (gumpInfoDown.Texture != null)
+                        {
+                            batcher.Draw(
+                                gumpInfoDown.Texture,
+                                new Vector2(x, y + Height),
+                                gumpInfoDown.UV,
+                                hueVector,
+                                layerDepth
+                            );
+                        }
+                    }
+                    return true;
+                }
+            );
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         protected override int GetScrollableArea()

--- a/src/ClassicUO.Client/Game/UI/Controls/StaticPic.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/StaticPic.cs
@@ -1,10 +1,10 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
-using ClassicUO.Assets;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Controls
 {
@@ -57,23 +57,34 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(Hue, IsPartialHue, 1);
 
             ref readonly var artInfo = ref Client.Game.UO.Arts.GetArt(Graphic);
 
-            if (artInfo.Texture != null)
+            var texture = artInfo.Texture;
+            if (texture != null)
             {
-                batcher.Draw(
-                    artInfo.Texture,
-                    new Rectangle(x, y, Width, Height),
-                    artInfo.UV,
-                    hueVector
+                var sourceRectangle = artInfo.UV;
+                renderLists.AddGumpWithAtlas
+                (
+                    (batcher) =>
+                    {
+                        batcher.Draw(
+                            texture,
+                            new Rectangle(x, y, Width, Height),
+                            sourceRectangle,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
             }
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         public override bool Contains(int x, int y)

--- a/src/ClassicUO.Client/Game/UI/Gumps/BuffGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/BuffGump.cs
@@ -1,17 +1,16 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Xml;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -323,22 +322,38 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
+                float layerDepth = layerDepthRef;
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, _alpha / 255f, true);
 
                 ref readonly var gumpInfo = ref Client.Game.UO.Gumps.GetGump(Graphic);
-
-                if (gumpInfo.Texture != null)
+                var texture = gumpInfo.Texture;
+                if (texture != null)
                 {
-                    batcher.Draw(gumpInfo.Texture, new Vector2(x, y), gumpInfo.UV, hueVector);
 
+                    var sourceRectangle = gumpInfo.UV;
+                    renderLists.AddGumpWithAtlas
+                    (
+                        (batcher) =>
+                        {
+                            batcher.Draw(texture, new Vector2(x, y), sourceRectangle, hueVector, layerDepth);
+                            return true;
+                        }
+                    );
                     if (
                         ProfileManager.CurrentProfile != null
                         && ProfileManager.CurrentProfile.BuffBarTime
                     )
                     {
-                        _gText.Draw(batcher, x - 3, y + gumpInfo.UV.Height / 2 - 3, hueVector.Z);
+                        renderLists.AddGumpNoAtlas
+                    (
+                        (batcher) =>
+                        {
+                            _gText.Draw(batcher, x - 3, y + sourceRectangle.Height / 2 - 3, hueVector.Z);
+                            return true;
+                        }
+                    );
                     }
                 }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ChatGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ChatGump.cs
@@ -1,14 +1,15 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
+using ClassicUO.Assets;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -480,27 +481,36 @@ namespace ClassicUO.Game.UI.Gumps
                 return true;
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
+                float layerDepth = layerDepthRef;
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
                 if (MouseIsOver)
                 {
-                    batcher.Draw
+                    renderLists.AddGumpNoAtlas
                     (
-                        SolidColorTextureCache.GetTexture(Color.Cyan),
-                        new Rectangle
-                        (
-                            x,
-                            y,
-                            Width,
-                            Height
-                        ),
-                        hueVector
+                        batcher =>
+                        {
+                            batcher.Draw
+                            (
+                                SolidColorTextureCache.GetTexture(Color.Cyan),
+                                new Rectangle
+                                (
+                                    x,
+                                    y,
+                                    Width,
+                                    Height
+                                ),
+                                hueVector,
+                                layerDepth
+                            );
+                            return true;
+                        }
                     );
                 }
 
-                return base.Draw(batcher, x, y);
+                return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
             }
         }
     }

--- a/src/ClassicUO.Client/Game/UI/Gumps/ContainerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ContainerGump.cs
@@ -1,8 +1,5 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.IO;
-using System.Xml;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
@@ -10,9 +7,10 @@ using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
+using System;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -659,9 +657,10 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            base.Draw(batcher, x, y);
+            base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
+            float layerDepth = layerDepthRef;
 
             if (CUOEnviroment.Debug && !IsMinimized)
             {
@@ -674,13 +673,20 @@ namespace ClassicUO.Game.UI.Gumps
 
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
-                batcher.DrawRectangle(
-                    SolidColorTextureCache.GetTexture(Color.Red),
-                    x + boundX,
-                    y + boundY,
-                    boundWidth - boundX,
-                    boundHeight - boundY,
-                    hueVector
+                renderLists.AddGumpNoAtlas(
+                    batcher =>
+                    {
+                        batcher.DrawRectangle(
+                            SolidColorTextureCache.GetTexture(Color.Red),
+                            x + boundX,
+                            y + boundY,
+                            boundWidth - boundX,
+                            boundHeight - boundY,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/CreditsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CreditsGump.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ClassicUO.Game.Scenes;
+﻿using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
@@ -70,14 +65,20 @@ Ultima Online(R) 2021 Electronic Arts Inc. All Rights Reserved.
             }
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            base.Draw(batcher, x, y);
+            base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
+            float layerDepth = layerDepthRef;
 
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
-            batcher.DrawString(Fonts.Bold, CREDITS, x + _offset.X, y + _offset.Y, hueVector);
-
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    batcher.DrawString(Fonts.Bold, CREDITS, x + _offset.X, y + _offset.Y, hueVector, layerDepth);
+                    return true;
+                }
+            );
             return true;
         }
     }

--- a/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Xml;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
-using ClassicUO.Renderer;
-using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -130,9 +128,9 @@ namespace ClassicUO.Game.UI.Gumps
             Location = position;
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            return IsVisible && base.Draw(batcher, x, y);
+            return IsVisible && base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         public override void OnButtonClick(int buttonID)

--- a/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
@@ -1,22 +1,20 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.IO;
-using System.Xml;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
-using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using SDL3;
-using ClassicUO.Game.Scenes;
+using System;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -1221,21 +1219,28 @@ namespace ClassicUO.Game.UI.Gumps
             public int LineWidth { get; set; }
             public Texture2D LineColor { get; set; }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
+                float layerDepth = layerDepthRef;
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, Alpha);
-
-                batcher.Draw
-                (
-                    LineColor,
-                    new Rectangle
-                    (
-                        x,
-                        y,
-                        LineWidth,
-                        Height
-                    ),
-                    hueVector
+                renderLists.AddGumpNoAtlas(
+                    batcher =>
+                    {
+                        batcher.Draw
+                        (
+                            LineColor,
+                            new Rectangle
+                            (
+                                x,
+                                y,
+                                LineWidth,
+                                Height
+                            ),
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
 
                 return true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/InfoBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/InfoBarGump.cs
@@ -1,8 +1,5 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Xml;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
@@ -10,6 +7,9 @@ using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -185,38 +185,47 @@ namespace ClassicUO.Game.UI.Gumps
             base.Update();
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            base.Draw(batcher, x, y);
+            base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
+            float layerDepth = layerDepthRef;
 
             if (Var != InfoBarVars.NameNotoriety && ProfileManager.CurrentProfile.InfoBarHighlightType == 1 && _warningLinesHue != 0x0481)
             {
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(_warningLinesHue);
 
-                batcher.Draw
-                (
-                    SolidColorTextureCache.GetTexture(Color.White),
-                    new Rectangle
-                    (
-                        _data.ScreenCoordinateX,
-                        _data.ScreenCoordinateY,
-                        _data.Width,
-                        2
-                    ),
-                    hueVector
-                );
+                renderLists.AddGumpNoAtlas(
+                    batcher =>
+                    {
+                        batcher.Draw
+                        (
+                            SolidColorTextureCache.GetTexture(Color.White),
+                            new Rectangle
+                            (
+                                _data.ScreenCoordinateX,
+                                _data.ScreenCoordinateY,
+                                _data.Width,
+                                2
+                            ),
+                            hueVector,
+                            layerDepth
+                        );
 
-                batcher.Draw
-                (
-                    SolidColorTextureCache.GetTexture(Color.White),
-                    new Rectangle
-                    (
-                        _data.ScreenCoordinateX,
-                        _data.ScreenCoordinateY + Parent.Height - 2,
-                        _data.Width,
-                        2
-                    ),
-                    hueVector
+                        batcher.Draw
+                        (
+                            SolidColorTextureCache.GetTexture(Color.White),
+                            new Rectangle
+                            (
+                                _data.ScreenCoordinateX,
+                                _data.ScreenCoordinateY + Parent.Height - 2,
+                                _data.Width,
+                                2
+                            ),
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
@@ -1,11 +1,11 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
@@ -642,11 +642,11 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 }
             }
 
-            protected override void DrawCaret(UltimaBatcher2D batcher, int x, int y)
+            protected override void DrawCaret(UltimaBatcher2D batcher, int x, int y, float layerDepth)
             {
                 if (HasKeyboardFocus)
                 {
-                    _rendererCaret.Draw(batcher, x + _caretScreenPosition.X, y + _caretScreenPosition.Y);
+                    _rendererCaret.Draw(batcher, x + _caretScreenPosition.X, y + _caretScreenPosition.Y, layerDepth);
                 }
             }
 
@@ -706,17 +706,24 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 _caretScreenPosition = _rendererText.GetCaretPosition(Stb.CursorIndex);
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
-                if (batcher.ClipBegin(x, y, Width, Height))
-                {
-                    DrawSelection(batcher, x, y);
+                float layerDepth = layerDepthRef;
+                renderLists.AddGumpNoAtlas(
+                    batcher =>
+                    {
+                        if (batcher.ClipBegin(x, y, Width, Height))
+                        {
+                            DrawSelection(batcher, x, y, layerDepth);
 
-                    _rendererText.Draw(batcher, x, y);
+                            _rendererText.Draw(batcher, x, y, layerDepth);
 
-                    DrawCaret(batcher, x, y);
-                    batcher.ClipEnd();
-                }
+                            DrawCaret(batcher, x, y, layerDepth);
+                            batcher.ClipEnd();
+                        }
+                        return true;
+                    }
+                );
 
                 return true;
             }

--- a/src/ClassicUO.Client/Game/UI/Gumps/MacroButtonGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MacroButtonGump.cs
@@ -1,16 +1,16 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Xml;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -118,34 +118,41 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    batcher.Draw
+                    (
+                        backgroundTexture,
+                        new Rectangle
+                        (
+                            x,
+                            y,
+                            Width,
+                            Height
+                        ),
+                        hueVector,
+                        layerDepth
+                    );
 
-            batcher.Draw
-            (
-                backgroundTexture,
-                new Rectangle
-                (
-                    x,
-                    y,
-                    Width,
-                    Height
-                ),
-                hueVector
+                    batcher.DrawRectangle
+                    (
+                        SolidColorTextureCache.GetTexture(Color.Gray),
+                        x,
+                        y,
+                        Width,
+                        Height,
+                        hueVector,
+                        layerDepth
+                    );
+                    return true;
+                }
             );
-
-            batcher.DrawRectangle
-            (
-                SolidColorTextureCache.GetTexture(Color.Gray),
-                x,
-                y,
-                Width,
-                Height,
-                hueVector
-            );
-
-            base.Draw(batcher, x, y);
+            base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
 
             return true;
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/MarkersManagerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MarkersManagerGump.cs
@@ -1,15 +1,16 @@
 ﻿using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
+using ClassicUO.Renderer;
+using ClassicUO.Resources;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using ClassicUO.Resources;
-using Microsoft.Xna.Framework.Graphics;
 using static ClassicUO.Game.UI.Gumps.WorldMapGump;
-using ClassicUO.Renderer;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -321,10 +322,15 @@ namespace ClassicUO.Game.UI.Gumps
                 Width = Height = 15;
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
+                float layerDepth = layerDepthRef;
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
-                batcher.Draw(Texture, new Rectangle(x, y + 7, Width, Height), hueVector);
+                renderLists.AddGumpNoAtlas(batcher =>
+                {
+                    batcher.Draw(Texture, new Rectangle(x, y + 7, Width, Height), hueVector, layerDepth);
+                    return true;
+                });
                 return true;
             }
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
@@ -1,17 +1,18 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
-using System.Text;
+using ClassicUO.Assets;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -349,139 +350,153 @@ namespace ClassicUO.Game.UI.Gumps
             base.CloseWithRightClick();
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            base.Draw(batcher, x, y);
+            base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
+            float layerDepth = layerDepthRef;
 
-            if (batcher.ClipBegin(x, y, Width, Height))
-            {
-                RenderedText t = _bookPage.renderedText;
-                int startpage = (ActivePage - 1) * 2;
-
-                if (startpage < BookPageCount)
+            renderLists.AddGumpNoAtlas
+            (
+                batcher =>
                 {
-                    int poy = _bookPage._pageCoords[startpage, 0], phy = _bookPage._pageCoords[startpage, 1];
-
-                    _bookPage.DrawSelection
-                    (
-                        batcher,
-                        x + RIGHT_X,
-                        y + UPPER_MARGIN,
-                        poy,
-                        poy + phy
-                    );
-
-                    t.Draw
-                    (
-                        batcher,
-                        x + RIGHT_X,
-                        y + UPPER_MARGIN,
-                        0,
-                        poy,
-                        t.Width,
-                        phy
-                    );
-
-                    if (startpage == _bookPage._caretPage)
+                    if (batcher.ClipBegin(x, y, Width, Height))
                     {
-                        if (_bookPage._caretPos.Y < poy + phy)
+                        RenderedText t = _bookPage.renderedText;
+                        int startpage = (ActivePage - 1) * 2;
+
+                        if (startpage < BookPageCount)
                         {
-                            if (_bookPage._caretPos.Y >= poy)
+                            int poy = _bookPage._pageCoords[startpage, 0], phy = _bookPage._pageCoords[startpage, 1];
+
+                            _bookPage.DrawSelection
+                            (
+                                batcher,
+                                x + RIGHT_X,
+                                y + UPPER_MARGIN,
+                                poy,
+                                poy + phy,
+                                layerDepth
+                            );
+
+                            t.Draw
+                            (
+                                batcher,
+                                x + RIGHT_X,
+                                y + UPPER_MARGIN,
+                                0,
+                                poy,
+                                t.Width,
+                                phy,
+                                layerDepth
+                            );
+
+                            if (startpage == _bookPage._caretPage)
                             {
-                                if (_bookPage.HasKeyboardFocus)
+                                if (_bookPage._caretPos.Y < poy + phy)
                                 {
-                                    _bookPage.renderedCaret.Draw
-                                    (
-                                        batcher,
-                                        _bookPage._caretPos.X + x + RIGHT_X,
-                                        _bookPage._caretPos.Y + y + UPPER_MARGIN - poy,
-                                        0,
-                                        0,
-                                        _bookPage.renderedCaret.Width,
-                                        _bookPage.renderedCaret.Height
-                                    );
+                                    if (_bookPage._caretPos.Y >= poy)
+                                    {
+                                        if (_bookPage.HasKeyboardFocus)
+                                        {
+                                            _bookPage.renderedCaret.Draw
+                                            (
+                                                batcher,
+                                                _bookPage._caretPos.X + x + RIGHT_X,
+                                                _bookPage._caretPos.Y + y + UPPER_MARGIN - poy,
+                                                0,
+                                                0,
+                                                _bookPage.renderedCaret.Width,
+                                                _bookPage.renderedCaret.Height,
+                                                layerDepth
+                                            );
+                                        }
+                                    }
+                                    else
+                                    {
+                                        _bookPage._caretPage = _bookPage.GetCaretPage();
+                                    }
+                                }
+                                else if (_bookPage._caretPos.Y <= _bookPage.Height)
+                                {
+                                    if (_bookPage._caretPage + 2 < _bookPage._pagesChanged.Length)
+                                    {
+                                        _bookPage._focusPage = _bookPage._caretPage++;
+                                        SetActivePage(_bookPage._caretPage / 2 + 2);
+                                    }
                                 }
                             }
-                            else
-                            {
-                                _bookPage._caretPage = _bookPage.GetCaretPage();
-                            }
                         }
-                        else if (_bookPage._caretPos.Y <= _bookPage.Height)
+
+                        startpage--;
+
+                        if (startpage > 0)
                         {
-                            if (_bookPage._caretPage + 2 < _bookPage._pagesChanged.Length)
+                            int poy = _bookPage._pageCoords[startpage, 0], phy = _bookPage._pageCoords[startpage, 1];
+
+                            _bookPage.DrawSelection
+                            (
+                                batcher,
+                                x + LEFT_X,
+                                y + UPPER_MARGIN,
+                                poy,
+                                poy + phy,
+                                layerDepth
+                            );
+
+                            t.Draw
+                            (
+                                batcher,
+                                x + LEFT_X,
+                                y + UPPER_MARGIN,
+                                0,
+                                poy,
+                                t.Width,
+                                phy,
+                                layerDepth
+                            );
+
+                            if (startpage == _bookPage._caretPage)
                             {
-                                _bookPage._focusPage = _bookPage._caretPage++;
-                                SetActivePage(_bookPage._caretPage / 2 + 2);
-                            }
-                        }
-                    }
-                }
-
-                startpage--;
-
-                if (startpage > 0)
-                {
-                    int poy = _bookPage._pageCoords[startpage, 0], phy = _bookPage._pageCoords[startpage, 1];
-
-                    _bookPage.DrawSelection
-                    (
-                        batcher,
-                        x + LEFT_X,
-                        y + UPPER_MARGIN,
-                        poy,
-                        poy + phy
-                    );
-
-                    t.Draw
-                    (
-                        batcher,
-                        x + LEFT_X,
-                        y + UPPER_MARGIN,
-                        0,
-                        poy,
-                        t.Width,
-                        phy
-                    );
-
-                    if (startpage == _bookPage._caretPage)
-                    {
-                        if (_bookPage._caretPos.Y < poy + phy)
-                        {
-                            if (_bookPage._caretPos.Y >= poy)
-                            {
-                                if (_bookPage.HasKeyboardFocus)
+                                if (_bookPage._caretPos.Y < poy + phy)
                                 {
-                                    _bookPage.renderedCaret.Draw
-                                    (
-                                        batcher,
-                                        _bookPage._caretPos.X + x + LEFT_X,
-                                        _bookPage._caretPos.Y + y + UPPER_MARGIN - poy,
-                                        0,
-                                        0,
-                                        _bookPage.renderedCaret.Width,
-                                        _bookPage.renderedCaret.Height
-                                    );
+                                    if (_bookPage._caretPos.Y >= poy)
+                                    {
+                                        if (_bookPage.HasKeyboardFocus)
+                                        {
+                                            _bookPage.renderedCaret.Draw
+                                            (
+                                                batcher,
+                                                _bookPage._caretPos.X + x + LEFT_X,
+                                                _bookPage._caretPos.Y + y + UPPER_MARGIN - poy,
+                                                0,
+                                                0,
+                                                _bookPage.renderedCaret.Width,
+                                                _bookPage.renderedCaret.Height,
+                                                layerDepth
+                                            );
+                                        }
+                                    }
+                                    else if (_bookPage._caretPage > 0)
+                                    {
+                                        _bookPage._focusPage = _bookPage._caretPage--;
+                                        SetActivePage(_bookPage._caretPage / 2 + 1);
+                                    }
+                                }
+                                else if (_bookPage._caretPos.Y <= _bookPage.Height)
+                                {
+                                    if (_bookPage._caretPage + 2 < _bookPage._pagesChanged.Length)
+                                    {
+                                        _bookPage._caretPage++;
+                                    }
                                 }
                             }
-                            else if (_bookPage._caretPage > 0)
-                            {
-                                _bookPage._focusPage = _bookPage._caretPage--;
-                                SetActivePage(_bookPage._caretPage / 2 + 1);
-                            }
                         }
-                        else if (_bookPage._caretPos.Y <= _bookPage.Height)
-                        {
-                            if (_bookPage._caretPage + 2 < _bookPage._pagesChanged.Length)
-                            {
-                                _bookPage._caretPage++;
-                            }
-                        }
-                    }
-                }
 
-                batcher.ClipEnd();
-            }
+                        batcher.ClipEnd();
+                    }
+                    return true;
+                }
+            );
 
             return true;
         }
@@ -673,7 +688,7 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
-            internal void DrawSelection(UltimaBatcher2D batcher, int x, int y, int starty, int endy)
+            internal void DrawSelection(UltimaBatcher2D batcher, int x, int y, int starty, int endy, float layerDepth)
             {
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, 0.5f);
 
@@ -727,7 +742,8 @@ namespace ClassicUO.Game.UI.Gumps
                                             endX,
                                             info.MaxHeight + 1
                                         ),
-                                        hueVector
+                                        hueVector,
+                                        layerDepth
                                     );
                                 }
 
@@ -748,7 +764,8 @@ namespace ClassicUO.Game.UI.Gumps
                                         info.Width - drawX,
                                         info.MaxHeight + 1
                                     ),
-                                    hueVector
+                                    hueVector,
+                                    layerDepth
                                 );
                             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -668,7 +668,8 @@ namespace ClassicUO.Game.UI.Gumps
                         Width,
                         Height,
                         0,
-                        0
+                        0,
+                        layerDepth + CHILD_LAYER_INCREMENT * 2
                     );
                 }
             );

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using ClassicUO.Game.Scenes;
+using System;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -547,7 +547,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
             if (IsDisposed || !SetName())
             {
@@ -642,27 +642,37 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 return false;
             }
+            float layerDepth = layerDepthRef;
 
             X = x;
             Y = y;
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    batcher.DrawRectangle(_borderColor, x - 1, y - 1, Width + 1, Height + 1, hueVector, layerDepth);
+                    return true;
+                }
+            );
 
-            batcher.DrawRectangle(_borderColor, x - 1, y - 1, Width + 1, Height + 1, hueVector);
-
-            base.Draw(batcher, x, y);
+            base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
 
             int renderedTextOffset = Math.Max(0, Width - _renderedText.Width - 4) >> 1;
-
-            return _renderedText.Draw(
-                batcher,
-                Width,
-                Height,
-                x + 2 + renderedTextOffset,
-                y + 2,
-                Width,
-                Height,
-                0,
-                0
+            renderLists.AddGumpNoAtlas(batcher =>
+                {
+                    return _renderedText.Draw(
+                        batcher,
+                        Width,
+                        Height,
+                        x + 2 + renderedTextOffset,
+                        y + 2,
+                        Width,
+                        Height,
+                        0,
+                        0
+                    );
+                }
             );
+            return true;
         }
 
         public override void Dispose()

--- a/src/ClassicUO.Client/Game/UI/Gumps/NetworkStatsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NetworkStatsGump.cs
@@ -1,14 +1,14 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Text;
-using System.Xml;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
 using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -107,12 +107,13 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            if (!base.Draw(batcher, x, y))
+            if (!base.AddToRenderLists(renderLists, x, y, ref layerDepthRef))
             {
                 return false;
             }
+            float layerDepth = layerDepthRef;
 
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
@@ -135,13 +136,20 @@ namespace ClassicUO.Game.UI.Gumps
 
             hueVector.Y = 1;
 
-            batcher.DrawString
-            (
-                Fonts.Bold,
-                _cacheText,
-                x + 10,
-                y + 10,
-                hueVector
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    batcher.DrawString
+                    (
+                        Fonts.Bold,
+                        _cacheText,
+                        x + 10,
+                        y + 10,
+                        hueVector,
+                        layerDepth
+                    );
+                    return true;
+                }
             );
 
             return true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Xml;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
@@ -9,11 +7,11 @@ using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
-using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -805,7 +803,7 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                 }
 
-                public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+                public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
                 {
                     Item item = _gump.World.Items.Get(LocalSerial);
 
@@ -828,23 +826,34 @@ namespace ClassicUO.Game.UI.Gumps
 
                     ref readonly var artInfo = ref Client.Game.UO.Arts.GetArt(item.DisplayedGraphic);
 
-                    if (artInfo.Texture != null)
+                    var texture = artInfo.Texture;
+                    if (texture != null)
                     {
-                        batcher.Draw(
-                            artInfo.Texture,
-                            new Rectangle(
-                                x + _point.X,
-                                y + _point.Y,
-                                _originalSize.X,
-                                _originalSize.Y
-                            ),
-                            new Rectangle(
-                                artInfo.UV.X + _rect.X,
-                                artInfo.UV.Y + _rect.Y,
-                                _rect.Width,
-                                _rect.Height
-                            ),
-                            hueVector
+                        float layerDepth = layerDepthRef;
+                        var sourceRectangle = artInfo.UV;
+                        renderLists.AddGumpWithAtlas
+                        (
+                            (batcher) =>
+                            {
+                                batcher.Draw(
+                                    texture,
+                                    new Rectangle(
+                                        x + _point.X,
+                                        y + _point.Y,
+                                        _originalSize.X,
+                                        _originalSize.Y
+                                    ),
+                                    new Rectangle(
+                                        sourceRectangle.X + _rect.X,
+                                        sourceRectangle.Y + _rect.Y,
+                                        _rect.Width,
+                                        _rect.Height
+                                    ),
+                                    hueVector,
+                                    layerDepth
+                                );
+                                return true;
+                            }
                         );
 
                         return true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ShopGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ShopGump.cs
@@ -1,20 +1,20 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Network;
 using ClassicUO.Renderer;
+using ClassicUO.Renderer.Animations;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using ClassicUO.Renderer.Animations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -456,9 +456,9 @@ namespace ClassicUO.Game.UI.Gumps
             base.Update();
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         private void ProcessListScroll()
@@ -775,8 +775,9 @@ namespace ClassicUO.Game.UI.Gumps
                 return true;
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
+                float layerDepth = layerDepthRef;
                 Vector3 hueVector;
 
                 if (InBuyGump && SerialHelper.IsMobile(LocalSerial))
@@ -810,18 +811,28 @@ namespace ClassicUO.Game.UI.Gumps
 
                         ref var spriteInfo = ref frames[0];
 
-                        if (spriteInfo.Texture != null)
+                        var texture = spriteInfo.Texture;
+                        if (texture != null)
                         {
-                            batcher.Draw(
-                                spriteInfo.Texture,
-                                new Rectangle(
-                                    x - 3,
-                                    y + 5 + 15,
-                                    Math.Min(spriteInfo.UV.Width, 45),
-                                    Math.Min(spriteInfo.UV.Height, 45)
-                                ),
-                                spriteInfo.UV,
-                                hueVector
+                            var sourceRectangle = spriteInfo.UV;
+                            renderLists.AddGumpWithAtlas
+                            (
+                                (batcher) =>
+                                {
+                                    batcher.Draw(
+                                        texture,
+                                        new Rectangle(
+                                            x - 3,
+                                            y + 5 + 15,
+                                            Math.Min(sourceRectangle.Width, 45),
+                                            Math.Min(sourceRectangle.Height, 45)
+                                        ),
+                                        sourceRectangle,
+                                        hueVector,
+                                        layerDepth
+                                    );
+                                    return true;
+                                }
                             );
                         }
                     }
@@ -854,25 +865,35 @@ namespace ClassicUO.Game.UI.Gumps
                         point.Y = (Height >> 1) - (originalSize.Y >> 1);
                     }
 
-                    batcher.Draw(
-                        artInfo.Texture,
-                        new Rectangle(
-                            x + point.X - 5,
-                            y + point.Y + 10,
-                            originalSize.X,
-                            originalSize.Y
-                        ),
-                        new Rectangle(
-                            artInfo.UV.X + rect.X,
-                            artInfo.UV.Y + rect.Y,
-                            rect.Width,
-                            rect.Height
-                        ),
-                        hueVector
+                    var texture = artInfo.Texture;
+                    var sourceRectangle = artInfo.UV;
+                    renderLists.AddGumpWithAtlas
+                    (
+                        (batcher) =>
+                        {
+                            batcher.Draw(
+                                texture,
+                                new Rectangle(
+                                    x + point.X - 5,
+                                    y + point.Y + 10,
+                                    originalSize.X,
+                                    originalSize.Y
+                                ),
+                                new Rectangle(
+                                    sourceRectangle.X + rect.X,
+                                    sourceRectangle.Y + rect.Y,
+                                    rect.Width,
+                                    rect.Height
+                                ),
+                                hueVector,
+                                layerDepth
+                            );
+                            return true;
+                        }
                     );
                 }
 
-                return base.Draw(batcher, x, y);
+                return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
             }
         }
 
@@ -1096,33 +1117,42 @@ namespace ClassicUO.Game.UI.Gumps
                 );
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
-                ref readonly var gumpInfo0 = ref Client.Game.UO.Gumps.GetGump(_graphic);
-                ref readonly var gumpInfo1 = ref Client.Game.UO.Gumps.GetGump((uint)(_graphic + 1));
-                ref readonly var gumpInfo2 = ref Client.Game.UO.Gumps.GetGump((uint)(_graphic + 2));
+                float layerDepth = layerDepthRef;
+                renderLists.AddGumpWithAtlas
+                (
+                    batcher =>
+                    {
+                        ref readonly var gumpInfo0 = ref Client.Game.UO.Gumps.GetGump(_graphic);
+                        ref readonly var gumpInfo1 = ref Client.Game.UO.Gumps.GetGump((uint)(_graphic + 1));
+                        ref readonly var gumpInfo2 = ref Client.Game.UO.Gumps.GetGump((uint)(_graphic + 2));
 
-                var hueVector = ShaderHueTranslator.GetHueVector(0, false, Alpha, true);
+                        var hueVector = ShaderHueTranslator.GetHueVector(0, false, Alpha, true);
 
-                int middleWidth = Width - gumpInfo0.UV.Width - gumpInfo2.UV.Width;
+                        int middleWidth = Width - gumpInfo0.UV.Width - gumpInfo2.UV.Width;
 
-                batcher.Draw(gumpInfo0.Texture, new Vector2(x, y), gumpInfo0.UV, hueVector);
+                        batcher.Draw(gumpInfo0.Texture, new Vector2(x, y), gumpInfo0.UV, hueVector, layerDepth);
 
-                batcher.DrawTiled(
-                    gumpInfo1.Texture,
-                    new Rectangle(x + gumpInfo0.UV.Width, y, middleWidth, gumpInfo1.UV.Height),
-                    gumpInfo1.UV,
-                    hueVector
+                        batcher.DrawTiled(
+                            gumpInfo1.Texture,
+                            new Rectangle(x + gumpInfo0.UV.Width, y, middleWidth, gumpInfo1.UV.Height),
+                            gumpInfo1.UV,
+                            hueVector,
+                            layerDepth
+                        );
+
+                        batcher.Draw(
+                            gumpInfo2.Texture,
+                            new Vector2(x + Width - gumpInfo2.UV.Width, y),
+                            gumpInfo2.UV,
+                            hueVector,
+                            layerDepth
+                        );
+                        return true;
+                    }
                 );
-
-                batcher.Draw(
-                    gumpInfo2.Texture,
-                    new Vector2(x + Width - gumpInfo2.UV.Width, y),
-                    gumpInfo2.UV,
-                    hueVector
-                );
-
-                return base.Draw(batcher, x, y);
+                return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
             }
         }
 
@@ -1147,41 +1177,48 @@ namespace ClassicUO.Game.UI.Gumps
                 _tiled = tiled;
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
+                float layerDepth = layerDepthRef;
                 var gumpInfo = Client.Game.UO.Gumps.GetGump(_graphic);
                 var hueVector = ShaderHueTranslator.GetHueVector(0);
 
-                if (_tiled)
+                renderLists.AddGumpWithAtlas(batcher =>
                 {
-                    batcher.DrawTiled(
-                        gumpInfo.Texture,
-                        new Rectangle(x, y, Width, Height),
-                        new Rectangle(
-                            gumpInfo.UV.X + _rect.X,
-                            gumpInfo.UV.Y + _rect.Y,
-                            _rect.Width,
-                            _rect.Height
-                        ),
-                        hueVector
-                    );
-                }
-                else
-                {
-                    batcher.Draw(
-                        gumpInfo.Texture,
-                        new Rectangle(x, y, Width, Height),
-                        new Rectangle(
-                            gumpInfo.UV.X + _rect.X,
-                            gumpInfo.UV.Y + _rect.Y,
-                            _rect.Width,
-                            _rect.Height
-                        ),
-                        hueVector
-                    );
-                }
+                    if (_tiled)
+                    {
+                        batcher.DrawTiled(
+                            gumpInfo.Texture,
+                            new Rectangle(x, y, Width, Height),
+                            new Rectangle(
+                                gumpInfo.UV.X + _rect.X,
+                                gumpInfo.UV.Y + _rect.Y,
+                                _rect.Width,
+                                _rect.Height
+                            ),
+                            hueVector,
+                            layerDepth
+                        );
+                    }
+                    else
+                    {
+                        batcher.Draw(
+                            gumpInfo.Texture,
+                            new Rectangle(x, y, Width, Height),
+                            new Rectangle(
+                                gumpInfo.UV.X + _rect.X,
+                                gumpInfo.UV.Y + _rect.Y,
+                                _rect.Width,
+                                _rect.Height
+                            ),
+                            hueVector,
+                            layerDepth
+                        );
+                    }
+                    return true;
+                });
 
-                return base.Draw(batcher, x, y);
+                return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
             }
         }
     }

--- a/src/ClassicUO.Client/Game/UI/Gumps/SkillGumpAdvanced.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SkillGumpAdvanced.cs
@@ -1,16 +1,16 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -216,20 +216,27 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
+            float layerDepth = layerDepthRef;
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
-            batcher.DrawRectangle(
-                SolidColorTextureCache.GetTexture(Color.Gray),
-                x,
-                y,
-                Width,
-                Height,
-                hueVector
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    batcher.DrawRectangle(
+                        SolidColorTextureCache.GetTexture(Color.Gray),
+                        x,
+                        y,
+                        Width,
+                        Height,
+                        hueVector,
+                        layerDepth
+                    );
+                    return true;
+                }
             );
-
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         public void ForceUpdate()

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellbookGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellbookGump.cs
@@ -1,9 +1,5 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Xml;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
@@ -11,10 +7,12 @@ using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -1479,9 +1477,10 @@ namespace ClassicUO.Game.UI.Gumps
             /// <param name="x"></param>
             /// <param name="y"></param>
             /// <returns></returns>
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
-                base.Draw(batcher, x, y);
+                base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
+                float layerDepth = layerDepthRef;
 
                 if (ShowEdit)
                 {
@@ -1508,11 +1507,21 @@ namespace ClassicUO.Game.UI.Gumps
                             hueVector.Y = 1;
                         }
 
-                        batcher.Draw(
-                            gumpInfo.Texture,
-                            new Vector2(x + (Width - gumpInfo.UV.Width), y),
-                            gumpInfo.UV,
-                            hueVector
+                        var texture = gumpInfo.Texture;
+                        var sourceRectangle = gumpInfo.UV;
+                        renderLists.AddGumpWithAtlas
+                        (
+                            (batcher) =>
+                            {
+                                batcher.Draw(
+                                    texture,
+                                    new Vector2(x + (Width - sourceRectangle.Width), y),
+                                    sourceRectangle,
+                                    hueVector,
+                                    layerDepth
+                                );
+                                return true;
+                            }
                         );
                     }
                 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/StandardSkillsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/StandardSkillsGump.cs
@@ -1,19 +1,19 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Xml;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using Microsoft.Xna.Framework;
 using SDL3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -709,42 +709,59 @@ namespace ClassicUO.Game.UI.Gumps
                 WantUpdateSize = true;
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
+                float layerDepth = layerDepthRef;
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
                 if (_status == 2)
                 {
-                    batcher.Draw
+                    renderLists.AddGumpNoAtlas
                     (
-                        SolidColorTextureCache.GetTexture(Color.Beige),
-                        new Rectangle
-                        (
-                            x,
-                            y,
-                            Width,
-                            17
-                        ),
-                        hueVector
+                        batcher =>
+                        {
+                            batcher.Draw
+                            (
+                                SolidColorTextureCache.GetTexture(Color.Beige),
+                                new Rectangle
+                                (
+                                    x,
+                                    y,
+                                    Width,
+                                    17
+                                ),
+                                hueVector,
+                                layerDepth
+                            );
+                            return true;
+                        }
                     );
                 }
                 else if (_status == 1)
                 {
-                    batcher.Draw
+                    renderLists.AddGumpNoAtlas
                     (
-                        SolidColorTextureCache.GetTexture(Color.Bisque),
-                        new Rectangle
-                        (
-                            x + 16,
-                            y,
-                            200,
-                            17
-                        ),
-                        hueVector
+                        batcher =>
+                        {
+                            batcher.Draw
+                            (
+                                SolidColorTextureCache.GetTexture(Color.Bisque),
+                                new Rectangle
+                                (
+                                    x + 16,
+                                    y,
+                                    200,
+                                    17
+                                ),
+                                hueVector,
+                                layerDepth
+                            );
+                            return true;
+                        }
                     );
                 }
 
-                return base.Draw(batcher, x, y);
+                return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
             }
         }
 
@@ -950,27 +967,37 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+            public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
             {
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
                 if (UIManager.LastControlMouseDown(MouseButtonType.Left) == this)
                 {
-                    batcher.Draw
+                    float layerDepth = layerDepthRef;
+                    renderLists.AddGumpNoAtlas
                     (
-                        SolidColorTextureCache.GetTexture(Color.Wheat),
-                        new Rectangle
-                        (
-                            x,
-                            y,
-                            Width,
-                            Height
-                        ),
-                        hueVector
+                        batcher =>
+                        {
+                            batcher.Draw
+                            (
+                                SolidColorTextureCache.GetTexture(Color.Wheat),
+                                new Rectangle
+                                (
+                                    x,
+                                    y,
+                                    Width,
+                                    Height
+                                ),
+                                hueVector,
+                                layerDepth
+                            );
+
+                            return true;
+                        }
                     );
                 }
 
-                return base.Draw(batcher, x, y);
+                return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
             }
         }
     }

--- a/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
@@ -561,34 +561,38 @@ namespace ClassicUO.Game.UI.Gumps
             base.Update();
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
             int yy = TextBoxControl.Y + y - 20;
 
             LinkedListNode<ChatLineTime> last = _textEntries.Last;
 
-            while (last != null)
+            renderLists.AddGumpNoAtlas(batcher =>
             {
-                LinkedListNode<ChatLineTime> prev = last.Previous;
-
-                if (last.Value.IsDisposed)
+                while (last != null)
                 {
-                    _textEntries.Remove(last);
-                }
-                else
-                {
-                    yy -= last.Value.TextHeight;
+                    LinkedListNode<ChatLineTime> prev = last.Previous;
 
-                    if (yy >= y)
+                    if (last.Value.IsDisposed)
                     {
-                        last.Value.Draw(batcher, x + 2, yy);
+                        _textEntries.Remove(last);
                     }
+                    else
+                    {
+                        yy -= last.Value.TextHeight;
+
+                        if (yy >= y)
+                        {
+                            last.Value.Draw(batcher, x + 2, yy);
+                        }
+                    }
+
+                    last = prev;
                 }
+                return true;
+            });
 
-                last = prev;
-            }
-
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         protected override void OnKeyDown(SDL.SDL_Keycode key, SDL.SDL_Keymod mod)
@@ -1099,7 +1103,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             public bool Draw(UltimaBatcher2D batcher, int x, int y)
             {
-                return !IsDisposed && _renderedText.Draw(batcher, x, y /*, ShaderHueTranslator.GetHueVector(0, false, _alpha, true)*/);
+                return !IsDisposed && _renderedText.Draw(batcher, x, y, 0f /*, ShaderHueTranslator.GetHueVector(0, false, _alpha, true)*/);
             }
 
             public override string ToString()

--- a/src/ClassicUO.Client/Game/UI/Gumps/TextContainerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TextContainerGump.cs
@@ -2,7 +2,7 @@
 
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
-using ClassicUO.Renderer;
+using ClassicUO.Game.Scenes;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -42,19 +42,27 @@ namespace ClassicUO.Game.UI.Gumps
         }
 
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            base.Draw(batcher, x, y);
+            base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
+            float layerDepth = layerDepthRef;
 
             //TextRenderer.MoveToTopIfSelected();
             TextRenderer.ProcessWorldText(true);
 
-            TextRenderer.Draw
-            (
-                batcher,
-                x,
-                y,
-                true
+            renderLists.AddGumpNoAtlas(
+                batcher =>
+                {
+                    TextRenderer.Draw
+                    (
+                        batcher,
+                        x,
+                        y,
+                        layerDepth,
+                        true
+                    );
+                    return true;
+                }
             );
 
             return true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/UseAbilityButtonGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/UseAbilityButtonGump.cs
@@ -1,11 +1,10 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System.Xml;
 using ClassicUO.Game.Data;
+using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
-using ClassicUO.Renderer;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -80,7 +79,7 @@ namespace ClassicUO.Game.UI.Gumps
         }
 
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
             if (IsDisposed)
             {
@@ -99,7 +98,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
 
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
 
         public override void Save(XmlTextWriter writer)

--- a/src/ClassicUO.Client/Game/UI/Gumps/UseSpellButtonGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/UseSpellButtonGump.cs
@@ -1,16 +1,15 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Xml;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
+using System;
+using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -73,9 +72,10 @@ namespace ClassicUO.Game.UI.Gumps
             AnchorType = ANCHOR_TYPE.SPELL;
         }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            base.Draw(batcher, x, y);
+            base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
+            float layerDepth = layerDepthRef;
 
             if (ShowEdit)
             {
@@ -97,11 +97,21 @@ namespace ClassicUO.Game.UI.Gumps
                         hueVector.Y = 1;
                     }
 
-                    batcher.Draw(
-                        gumpInfo.Texture,
-                        new Vector2(x + (Width - gumpInfo.UV.Width), y),
-                        gumpInfo.UV,
-                        hueVector
+                    var texture = gumpInfo.Texture;
+                    var sourceRectangle = gumpInfo.UV;
+                    renderLists.AddGumpWithAtlas
+                    (
+                        (batcher) =>
+                        {
+                           batcher.Draw(
+                                texture,
+                                new Vector2(x + (Width - sourceRectangle.Width), y),
+                                sourceRectangle,
+                                hueVector,
+                                layerDepth
+                            );
+                            return true;
+                        }
                     );
                 }
             }

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
@@ -5,7 +5,6 @@ using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
-using ClassicUO.Assets;
 using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
@@ -302,7 +301,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public ushort Hue { get; set; }
 
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+        public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
             Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
 
@@ -311,48 +310,59 @@ namespace ClassicUO.Game.UI.Gumps
                 hueVector.X = Hue;
                 hueVector.Y = 1;
             }
+            float layerDepth = layerDepthRef;
 
-            ref readonly var gumpInfo = ref Client.Game.UO.Gumps.GetGump(H_BORDER);
+            renderLists.AddGumpWithAtlas(
+                (batcher) =>
+                {
+                    ref readonly var gumpInfo = ref Client.Game.UO.Gumps.GetGump(H_BORDER);
 
-            // sopra
-            batcher.DrawTiled(
-                gumpInfo.Texture,
-                new Rectangle(x, y, Width, BorderSize),
-                gumpInfo.UV,
-                hueVector
+                    // sopra
+                    batcher.DrawTiled(
+                        gumpInfo.Texture,
+                        new Rectangle(x, y, Width, BorderSize),
+                        gumpInfo.UV,
+                        hueVector,
+                        layerDepth
+                    );
+
+                    // sotto
+                    batcher.DrawTiled(
+                        gumpInfo.Texture,
+                        new Rectangle(x, y + Height - BorderSize, Width, BorderSize),
+                        gumpInfo.UV,
+                        hueVector,
+                        layerDepth
+                    );
+
+                    gumpInfo = ref Client.Game.UO.Gumps.GetGump(V_BORDER);
+                    //sx
+                    batcher.DrawTiled(
+                        gumpInfo.Texture,
+                        new Rectangle(x, y, BorderSize, Height),
+                        gumpInfo.UV,
+                        hueVector,
+                        layerDepth
+                    );
+
+                    //dx
+                    batcher.DrawTiled(
+                        gumpInfo.Texture,
+                        new Rectangle(
+                            x + Width - BorderSize,
+                            y + (gumpInfo.UV.Width >> 1),
+                            BorderSize,
+                            Height - BorderSize
+                        ),
+                        gumpInfo.UV,
+                        hueVector,
+                        layerDepth
+                    );
+                    return true;
+                }
             );
 
-            // sotto
-            batcher.DrawTiled(
-                gumpInfo.Texture,
-                new Rectangle(x, y + Height - BorderSize, Width, BorderSize),
-                gumpInfo.UV,
-                hueVector
-            );
-
-            gumpInfo = ref Client.Game.UO.Gumps.GetGump(V_BORDER);
-            //sx
-            batcher.DrawTiled(
-                gumpInfo.Texture,
-                new Rectangle(x, y, BorderSize, Height),
-                gumpInfo.UV,
-                hueVector
-            );
-
-            //dx
-            batcher.DrawTiled(
-                gumpInfo.Texture,
-                new Rectangle(
-                    x + Width - BorderSize,
-                    y + (gumpInfo.UV.Width >> 1),
-                    BorderSize,
-                    Height - BorderSize
-                ),
-                gumpInfo.UV,
-                hueVector
-            );
-
-            return base.Draw(batcher, x, y);
+            return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
@@ -111,14 +111,17 @@ namespace ClassicUO.Game.UI.Gumps
                     int w = _lastSize.X + offset.X;
                     int h = _lastSize.Y + offset.Y;
 
-                    if (w < 640)
+                    int targetWidth = Client.Game.ScaleWithDpi(640);
+                    int targetHeight = Client.Game.ScaleWithDpi(480);
+
+                    if (w < targetWidth)
                     {
-                        w = 640;
+                        w = targetWidth;
                     }
 
-                    if (h < 480)
+                    if (h < targetHeight)
                     {
-                        h = 480;
+                        h = targetHeight;
                     }
 
                     if (w > Client.Game.Window.ClientBounds.Width - BORDER_WIDTH)
@@ -228,14 +231,16 @@ namespace ClassicUO.Game.UI.Gumps
 
         public Point ResizeGameWindow(Point newSize)
         {
-            if (newSize.X < 640)
+            int targetWidth = Client.Game.ScaleWithDpi(640);
+            int targetHeight = Client.Game.ScaleWithDpi(480);
+            if (newSize.X < targetWidth)
             {
-                newSize.X = 640;
+                newSize.X = targetWidth;
             }
 
-            if (newSize.Y < 480)
+            if (newSize.Y < targetHeight)
             {
-                newSize.Y = 480;
+                newSize.Y = targetHeight;
             }
 
             //Resize();

--- a/src/ClassicUO.Client/Game/UI/Tooltip.cs
+++ b/src/ClassicUO.Client/Game/UI/Tooltip.cs
@@ -1,11 +1,9 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Text;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
-using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
@@ -165,7 +163,8 @@ namespace ClassicUO.Game.UI
                     (int)(z_width * zoom),
                     (int)(z_height * zoom)
                 ),
-                hue_vec
+                hue_vec,
+                0f
             );
 
 
@@ -176,7 +175,8 @@ namespace ClassicUO.Game.UI
                 y - 2,
                 (int) (z_width * zoom),
                 (int) (z_height * zoom),
-                hue_vec
+                hue_vec,
+                0f
             );
 
             batcher.Draw
@@ -190,7 +190,8 @@ namespace ClassicUO.Game.UI
                     (int)(_renderedText.Texture.Height * zoom)
                 ),
                 null,
-                Vector3.UnitZ
+                Vector3.UnitZ,
+                0f
             );
 
             return true;

--- a/src/ClassicUO.Client/Game/Weather.cs
+++ b/src/ClassicUO.Client/Game/Weather.cs
@@ -174,10 +174,11 @@ namespace ClassicUO.Game
             _windTimer = 0;
 
             ScaledCount = CalculateScaledCount(Count);
+            CurrentCount = ScaledCount;
 
-            while (CurrentCount < _effects.Length)
+            for (int i = 0; i < _effects.Length; i++)
             {
-                ref WeatherEffect effect = ref _effects[CurrentCount++];
+                ref WeatherEffect effect = ref _effects[i];
                 effect.X = RandomHelper.GetValue(0, Client.Game.Scene.Camera.Bounds.Width);
                 effect.Y = RandomHelper.GetValue(0, Client.Game.Scene.Camera.Bounds.Height);
             }

--- a/src/ClassicUO.Client/Game/Weather.cs
+++ b/src/ClassicUO.Client/Game/Weather.cs
@@ -1,12 +1,11 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System;
 using MathHelper = Microsoft.Xna.Framework.MathHelper;
 
 namespace ClassicUO.Game
@@ -209,7 +208,7 @@ namespace ClassicUO.Game
             Client.Game.Audio.PlaySoundWithDistance(_world, sound, _world.Player.X + randX, _world.Player.Y + randY);
         }
 
-        public void Draw(UltimaBatcher2D batcher, int x, int y)
+        public void Draw(UltimaBatcher2D batcher, int x, int y, float layerDepth)
         {
             bool removeEffects = false;
 
@@ -423,7 +422,8 @@ namespace ClassicUO.Game
                            start,
                            end,
                            Vector3.UnitZ,
-                           2
+                           2,
+                           layerDepth
                         );
 
                         break;
@@ -440,7 +440,8 @@ namespace ClassicUO.Game
                         (
                             SolidColorTextureCache.GetTexture(Color.White),
                             snowRect,
-                            Vector3.UnitZ
+                            Vector3.UnitZ,
+                            layerDepth
                         );
 
                         break;

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -481,6 +481,11 @@ namespace ClassicUO
             get => SDL_GetWindowDisplayScale(Window.Handle);
         }
 
+        public int ScaleWithDpi(int value)
+        {
+            return (int)(value * DpiScale);
+        }
+
         protected override bool BeginDraw()
         {
             return !_suppressedDraw && base.BeginDraw();

--- a/src/ClassicUO.Client/Input/Mouse.cs
+++ b/src/ClassicUO.Client/Input/Mouse.cs
@@ -127,10 +127,10 @@ namespace ClassicUO.Input
                 Position.Y = (int)y;
             }
 
-            // Scale the mouse coordinates for the faux-backbuffer
-            Position.X = (int) ((double) Position.X * Client.Game.GraphicManager.PreferredBackBufferWidth / Client.Game.Window.ClientBounds.Width);
+            // Scale the mouse coordinates for the faux-backbuffer and DPI settings
+            Position.X = (int) ((double) Position.X * (Client.Game.GraphicManager.PreferredBackBufferWidth / Client.Game.Window.ClientBounds.Width) / Client.Game.DpiScale);
 
-            Position.Y = (int) ((double) Position.Y * Client.Game.GraphicManager.PreferredBackBufferHeight / Client.Game.Window.ClientBounds.Height);
+            Position.Y = (int) ((double) Position.Y * (Client.Game.GraphicManager.PreferredBackBufferHeight / Client.Game.Window.ClientBounds.Height) / Client.Game.DpiScale);
 
             IsDragging = LButtonPressed || RButtonPressed || MButtonPressed;
         }

--- a/src/ClassicUO.Renderer/Batcher2D.cs
+++ b/src/ClassicUO.Renderer/Batcher2D.cs
@@ -6,7 +6,6 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -120,10 +119,10 @@ namespace ClassicUO.Renderer
             _basicUOEffect.Brighlight.SetValue(f);
         }
 
-        public void DrawString(SpriteFont spriteFont, ReadOnlySpan<char> text, int x, int y, Vector3 color)
-            => DrawString(spriteFont, text, new Vector2(x, y), color);
+        public void DrawString(SpriteFont spriteFont, ReadOnlySpan<char> text, int x, int y, Vector3 color, float layerDepth)
+            => DrawString(spriteFont, text, new Vector2(x, y), color, layerDepth);
 
-        public void DrawString(SpriteFont spriteFont, ReadOnlySpan<char> text, Vector2 position, Vector3 color)
+        public void DrawString(SpriteFont spriteFont, ReadOnlySpan<char> text, Vector2 position, Vector3 color, float layerDepth)
         {
             if (text.IsEmpty)
             {
@@ -213,7 +212,8 @@ namespace ClassicUO.Renderer
                     textureValue,
                     position + pos,
                     cGlyph,
-                    color
+                    color,
+                    layerDepth
                 );
 
                 curOffset.X += cKern.Y + cKern.Z;
@@ -591,7 +591,8 @@ namespace ClassicUO.Renderer
             Texture2D texture,
             Rectangle destinationRectangle,
             Rectangle sourceRectangle,
-            Vector3 hue
+            Vector3 hue,
+            float layerDepth
         )
         {
             int h = destinationRectangle.Height;
@@ -615,7 +616,8 @@ namespace ClassicUO.Renderer
                         texture,
                         pos,
                         rect,
-                        hue
+                        hue,
+                        layerDepth
                     );
 
                     w -= sourceRectangle.Width;
@@ -635,7 +637,7 @@ namespace ClassicUO.Renderer
             int width,
             int height,
             Vector3 hue,
-            float depth = 0f
+            float depth
         )
         {
             Rectangle rect = new Rectangle(x, y, width, 1);
@@ -667,7 +669,8 @@ namespace ClassicUO.Renderer
             Vector2 start,
             Vector2 end,
             Vector3 color,
-            float stroke
+            float stroke,
+            float depth
         )
         {
             var radians = ClassicUO.Utility.MathHelper.AngleBetweenVectors(start, end);
@@ -683,7 +686,7 @@ namespace ClassicUO.Renderer
                 Vector2.Zero,
                 new Vector2(length, stroke),
                 SpriteEffects.None,
-                0
+                depth
             );
         }
 
@@ -694,10 +697,11 @@ namespace ClassicUO.Renderer
         (
             Texture2D texture,
             Vector2 position,
-            Vector3 color
+            Vector3 color,
+            float depth
         )
         {
-            AddSprite(texture, 0f, 0f, 1f, 1f, position.X, position.Y, texture.Width, texture.Height, color, 0f, 0f, 0f, 1f, 0f, 0);
+            AddSprite(texture, 0f, 0f, 1f, 1f, position.X, position.Y, texture.Width, texture.Height, color, 0f, 0f, 0f, 1f, depth, 0);
         }
 
         public void Draw
@@ -705,7 +709,8 @@ namespace ClassicUO.Renderer
             Texture2D texture,
             Vector2 position,
             Rectangle? sourceRectangle,
-            Vector3 color
+            Vector3 color,
+            float depth
         )
         {
             float sourceX, sourceY, sourceW, sourceH;
@@ -730,7 +735,7 @@ namespace ClassicUO.Renderer
                 destH = texture.Height;
             }
 
-            AddSprite(texture, sourceX, sourceY, sourceW, sourceH, position.X, position.Y, destW, destH, color, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0);
+            AddSprite(texture, sourceX, sourceY, sourceW, sourceH, position.X, position.Y, destW, destH, color, 0.0f, 0.0f, 0.0f, 1.0f, depth, 0);
         }
 
         public void Draw
@@ -848,7 +853,8 @@ namespace ClassicUO.Renderer
         (
             Texture2D texture,
             Rectangle destinationRectangle,
-            Vector3 color
+            Vector3 color,
+            float layerDepth
         )
         {
             AddSprite(
@@ -866,7 +872,7 @@ namespace ClassicUO.Renderer
                 0.0f,
                 0.0f,
                 1.0f,
-                0.0f,
+                layerDepth,
                 0
             );
         }
@@ -876,7 +882,8 @@ namespace ClassicUO.Renderer
             Texture2D texture,
             Rectangle destinationRectangle,
             Rectangle? sourceRectangle,
-            Vector3 color
+            Vector3 color,
+            float layerDepth
         )
         {
             float sourceX, sourceY, sourceW, sourceH;
@@ -911,7 +918,7 @@ namespace ClassicUO.Renderer
                 0.0f,
                 0.0f,
                 1.0f,
-                0.0f,
+                layerDepth,
                 0
             );
         }

--- a/src/ClassicUO.Renderer/RenderTargets.cs
+++ b/src/ClassicUO.Renderer/RenderTargets.cs
@@ -1,0 +1,133 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+
+
+namespace ClassicUO.Renderer
+{
+    public class RenderTargets
+    {
+        private RenderTarget2D _uiRenderTarget;
+        private RenderTarget2D _lightRenderTarget;
+        private RenderTarget2D _worldRenderTarget;
+
+        private Rectangle _gameWindowOnScreen;
+        private Rectangle _gameWindowAfterDPI;
+        private Rectangle _gameWorldSceneOnScreen;
+        private Rectangle _gameWorldSceneAfterDPI;
+
+        private Func<Vector3> _lightsHue;
+        private Func<BlendState> _lightsBlendState;
+
+        private Texture2D _background;
+
+        public RenderTarget2D UiRenderTarget { get => _uiRenderTarget; }
+        public RenderTarget2D LightRenderTarget { get => _lightRenderTarget; }
+        public RenderTarget2D WorldRenderTarget { get => _worldRenderTarget; }
+
+        public void SetLightsConfiguration(Func<BlendState> lightsBlendState, Func<Vector3> lightsHue)
+        {
+            _lightsBlendState = lightsBlendState;
+            _lightsHue = lightsHue;
+        }
+
+        public void EnsureSizes(GraphicsDevice graphicsDevice, Rectangle gameWindowOnScreen, Rectangle gameWorldSceneAfterDPI, float dpiScale)
+        {
+            _gameWindowOnScreen = gameWindowOnScreen;
+            _gameWindowAfterDPI = ScaleRectangle(gameWindowOnScreen, dpiScale);
+            _gameWorldSceneOnScreen = ScaleRectangle(gameWorldSceneAfterDPI, 1/dpiScale);
+            _gameWorldSceneAfterDPI = gameWorldSceneAfterDPI;
+
+            EnsureSize(graphicsDevice, ref _uiRenderTarget, _gameWindowAfterDPI.Width, _gameWindowAfterDPI.Height);
+            EnsureSize(graphicsDevice, ref _lightRenderTarget, _gameWorldSceneAfterDPI.Width, _gameWorldSceneAfterDPI.Height);
+            EnsureSize(graphicsDevice, ref _worldRenderTarget, _gameWorldSceneAfterDPI.Width, _gameWorldSceneAfterDPI.Height);
+        }
+
+        private static Rectangle ScaleRectangle(Rectangle gameWindowOnScreen, float dpiScale) => new(
+                (int)(gameWindowOnScreen.X / dpiScale),
+                (int)(gameWindowOnScreen.Y / dpiScale),
+                (int)(gameWindowOnScreen.Width / dpiScale),
+                (int)(gameWindowOnScreen.Height / dpiScale)
+            );
+
+        private static void EnsureSize(GraphicsDevice graphicsDevice, ref RenderTarget2D renderTarget, int width, int height)
+        {
+            if (width <= 0 || height <= 0)
+                return;
+
+            if (renderTarget == null || renderTarget.IsDisposed || renderTarget.Width != width || renderTarget.Height != height)
+            {
+                renderTarget?.Dispose();
+
+                PresentationParameters pp = graphicsDevice.PresentationParameters;
+
+                renderTarget = new RenderTarget2D(
+                    graphicsDevice,
+                    width,
+                    height,
+                    false,
+                    pp.BackBufferFormat,
+                    pp.DepthStencilFormat,
+                    pp.MultiSampleCount,
+                    pp.RenderTargetUsage
+                    );
+            }
+        }
+
+        public void InitializeBackground(Texture2D background)
+        {
+            _background = background ?? throw new ArgumentNullException(nameof(background));
+        }
+
+        public void Draw(UltimaBatcher2D batcher)
+        {
+            // draw world
+            Vector3 fullAlphaNoColor = Vector3.UnitZ;
+
+            batcher.Begin();
+            batcher.GraphicsDevice.Clear(ClearOptions.Target, Color.Black, 0f, 0);
+
+            var rect = new Rectangle(
+                0,
+                0,
+                _gameWindowOnScreen.Width,
+                _gameWindowOnScreen.Height
+            );
+            batcher.DrawTiled(
+                _background,
+                rect,
+                _background.Bounds,
+                new Vector3(0, 0, 0.1f),
+                0f
+            );
+
+            batcher.Draw(
+                WorldRenderTarget,
+                _gameWorldSceneOnScreen,
+                fullAlphaNoColor,
+                0f
+            );
+
+            // draw lights
+            batcher.SetBlendState(_lightsBlendState?.Invoke());
+
+            batcher.Draw(
+                LightRenderTarget,
+                _gameWorldSceneOnScreen,
+                _lightsHue?.Invoke() ?? Vector3.Up,
+                0f
+            );
+
+            batcher.SetBlendState(null);
+
+            // draw ui
+            batcher.Draw(
+                UiRenderTarget,
+                _gameWindowOnScreen,
+                fullAlphaNoColor,
+                0f
+            );
+            batcher.End();
+        }
+    }
+}


### PR DESCRIPTION
1. Added a new RenderLists class and separated tiles, stretched tiles, and statics to benefit most from the separate texture atlases; this adds a layer of indirection between selecting what to draw and actually drawing it
2. Drawing those lists to separate RenderTargets and then simply composing them
3. Implemented DPI scaling by simply adjusting how to compose the previous render targets
4. Fixed some weather bugs and scaled it up to larger game world sized so the effects won't look so lost