### PR TITLE
fixed incorrect transformations from screen to world space

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Runtime.CompilerServices;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
-using ClassicUO.Game.Managers;
 using ClassicUO.Game.Map;
-using ClassicUO.Assets;
-using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using System;
+using System.Runtime.CompilerServices;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -208,8 +205,6 @@ namespace ClassicUO.Game.GameObjects
 
             p.X += (int)Offset.X + 22;
             p.Y += (int)(Offset.Y - Offset.Z) + 44;
-
-            p = Client.Game.Scene.Camera.WorldToScreen(p);
 
             for (; last != null; last = (TextObject)last.Previous)
             {

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -1,20 +1,12 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System;
-using System.Collections.Generic;
+using ClassicUO.Assets;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
-using ClassicUO.IO;
-using ClassicUO.Assets;
-using ClassicUO.Renderer;
-using ClassicUO.Utility;
-using ClassicUO.Utility.Logging;
-using ClassicUO.Utility.Platforms;
 using Microsoft.Xna.Framework;
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
+using System;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -446,8 +438,6 @@ namespace ClassicUO.Game.GameObjects
 
                 p.X += (int)Offset.X + 22;
                 p.Y += (int)(Offset.Y - Offset.Z) + 22;
-
-                p = Client.Game.Scene.Camera.WorldToScreen(p);
 
                 for (; last != null; last = (TextObject)last.Previous)
                 {

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps;
-using ClassicUO.Assets;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Collections;
 using Microsoft.Xna.Framework;
-using ClassicUO.Game.Scenes;
+using System;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -958,7 +957,6 @@ namespace ClassicUO.Game.GameObjects
 
             p.X += (int)Offset.X + 22;
             p.Y += (int)(Offset.Y - Offset.Z - (height + centerY + 8));
-            p = Client.Game.Scene.Camera.WorldToScreen(p);
 
             if (ObjectHandlesStatus == ObjectHandlesStatus.DISPLAYING)
             {

--- a/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
@@ -118,7 +118,6 @@ namespace ClassicUO.Game.Managers
                                     p1.Y += 22;
                                 }
 
-                                p1 = Client.Game.Scene.Camera.WorldToScreen(p1);
                                 p1.X -= (mobile.HitsTexture.Width >> 1) + 5;
                                 p1.Y -= mobile.HitsTexture.Height;
 
@@ -150,7 +149,6 @@ namespace ClassicUO.Game.Managers
                 }
 
                 p.X -= 5;
-                p = Client.Game.Scene.Camera.WorldToScreen(p);
                 p.X -= BAR_WIDTH_HALF;
                 p.Y -= BAR_HEIGHT_HALF;
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -1079,19 +1079,26 @@ namespace ClassicUO.Game.Scenes
         {
             if (_isSelectionActive)
             {
-                Vector3 selectionHue = new Vector3();
-                selectionHue.Z = 0.7f;
+                Vector3 selectionHue = new()
+                {
+                    Z = 0.7f
+                };
 
-                int minX = Math.Min(_selectionStart.X, Mouse.Position.X);
-                int maxX = Math.Max(_selectionStart.X, Mouse.Position.X);
-                int minY = Math.Min(_selectionStart.Y, Mouse.Position.Y);
-                int maxY = Math.Max(_selectionStart.Y, Mouse.Position.Y);
+                Point upperLeftInWorld = Camera.ScreenToWorld(new Point(
+                    Math.Min(_selectionStart.X, Mouse.Position.X) - Camera.Bounds.X,
+                    Math.Min(_selectionStart.Y, Mouse.Position.Y) - Camera.Bounds.Y
+                ));
+
+                Point lowerRightInWorld = Camera.ScreenToWorld(new Point(
+                    Math.Max(_selectionStart.X, Mouse.Position.X) - Camera.Bounds.X,
+                    Math.Max(_selectionStart.Y, Mouse.Position.Y) - Camera.Bounds.Y
+                ));
 
                 Rectangle selectionRect = new Rectangle(
-                    minX - Camera.Bounds.X,
-                    minY - Camera.Bounds.Y,
-                    maxX - minX,
-                    maxY - minY
+                    upperLeftInWorld.X,
+                    upperLeftInWorld.Y,
+                    lowerRightInWorld.X - upperLeftInWorld.X,
+                    lowerRightInWorld.Y - upperLeftInWorld.Y
                 );
 
                 batcher.Draw(

--- a/src/ClassicUO.Renderer/Camera.cs
+++ b/src/ClassicUO.Renderer/Camera.cs
@@ -94,6 +94,14 @@ namespace ClassicUO.Renderer
             return point;
         }
 
+        /// <summary>
+        ///     With the way that render targets are now used,
+        ///     everything that renders in the game world, is already correct.
+        /// 
+        ///     We ONLY need to go back and forth when drawing something in the
+        ///     UI render target that should be at a position of something in the
+        ///     world render target.
+        /// </summary>
         public Point WorldToScreen(Point point)
         {
             UpdateMatrices();


### PR DESCRIPTION
Removed incorrect transformations from screen space to world space and added a missing transformation for selection rectangles Text, health bars and selections should now be correctly aligned in all zoom levels tested with different DPI settings as well