### PR TITLE
The ScissorControl must not only clip elements with atlasses, but also UI elements without an atlas

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/ScissorControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ScissorControl.cs
@@ -28,20 +28,21 @@ namespace ClassicUO.Game.UI.Controls
 
         public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            renderLists.AddGumpWithAtlas(
-                batcher =>
+            bool clipIt(Renderer.UltimaBatcher2D batcher)
+            {
+                if (DoScissor)
                 {
-                    if (DoScissor)
-                    {
-                        batcher.ClipBegin(x, y, Width, Height);
-                    }
-                    else
-                    {
-                        batcher.ClipEnd();
-                    }
-                    return true;
+                    batcher.ClipBegin(x, y, Width, Height);
                 }
-            );
+                else
+                {
+                    batcher.ClipEnd();
+                }
+                return true;
+            }
+
+            renderLists.AddGumpWithAtlas(clipIt);
+            renderLists.AddGumpNoAtlas(clipIt);
 
             return true;
         }

--- a/src/ClassicUO.Renderer/Camera.cs
+++ b/src/ClassicUO.Renderer/Camera.cs
@@ -103,12 +103,15 @@ namespace ClassicUO.Renderer
         }
 
         /// <summary>
-        ///     With the way that render targets are now used,
-        ///     everything that renders in the game world, is already correct.
-        /// 
-        ///     We ONLY need to go back and forth when drawing something in the
-        ///     UI render target that should be at a position of something in the
-        ///     world render target.
+        ///     Returns screen coordinates from world coordinates.
+        ///     There are two variants for screen coordinates:
+        ///     1. Relative to the game window (withOffset = true)
+        ///     2. Relative to the camera viewport (withOffset = false)
+        ///     Because of the fact that the camera viewport content now
+        ///     fully scales with the zoom level, everything that
+        ///     is not supposed to zoom (UI, etc.) is drawn
+        ///     in the UI render target now.
+        ///     Only those aspects need to adjust for case 1 above.
         /// </summary>
         public Point WorldToScreen(Point point, bool withOffset = false)
         {


### PR DESCRIPTION
Reported with the Counter Bar, where the count and border were drawn outside the gump