### PR TITLE
Proposal: Fix Weather Particle Following Player Bug & Add Immersive Weather Enhancements

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -64,6 +64,7 @@ namespace ClassicUO.Configuration
         public bool EnableMusic { get; set; } = true;
         public int MusicVolume { get; set; } = 100;
         public bool EnableFootstepsSound { get; set; } = true;
+        public bool EnableRainSound { get; set; } = true;
         public bool EnableCombatMusic { get; set; } = true;
         public bool ReproduceSoundsInBackground { get; set; }
 
@@ -238,6 +239,7 @@ namespace ClassicUO.Configuration
         public int AuraUnderFeetType { get; set; } // 0 = NO, 1 = in warmode, 2 = ctrl+shift, 3 = always
         public bool AuraOnMouse { get; set; } = true;
         public bool AnimatedWaterEffect { get; set; } = false;
+        public bool EnableWeatherEffects { get; set; } = true;
 
         public bool PartyAura { get; set; }
 

--- a/src/ClassicUO.Client/Game/Effects/RippleEffect.cs
+++ b/src/ClassicUO.Client/Game/Effects/RippleEffect.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using ClassicUO.Game.GameObjects;
 using ClassicUO.Renderer;
-using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using System;
 
@@ -37,11 +35,6 @@ namespace ClassicUO.Game.Effects
             if (_world.Map == null)
             {
                 return;
-            }
-
-            if (!IsWaterTileAtPosition(worldX, worldY))
-            {
-                return; 
             }
 
             // Find inactive ripple slot
@@ -156,35 +149,6 @@ namespace ClassicUO.Game.Effects
             {
                 _ripples[i].Active = false;
             }
-        }
-
-        /// <summary>
-        /// Checks if the given absolute isometric position is on a water tile.
-        /// Converts directly from absolute isometric coordinates to tile coordinates.
-        /// </summary>
-        /// <param name="worldX">Absolute isometric X coordinate.</param>
-        /// <param name="worldY">Absolute isometric Y coordinate.</param>
-        /// <returns>True if the position is on a water tile, false otherwise.</returns>
-        private bool IsWaterTileAtPosition(float worldX, float worldY)
-        {
-            if (_world.Map == null)
-            {
-                return false;
-            }
-
-            
-            int targetTileX = (int)Math.Round((worldX + worldY) / 44f);
-            int targetTileY = (int)Math.Round((worldY - worldX) / 44f);
-
-            // Check if tile is water
-            GameObject tileObj = _world.Map.GetTile(targetTileX, targetTileY, load: false);
-            if (tileObj is Land land)
-            {
-                return land.TileData.IsWet &&
-                       (land.TileData.Name?.ToLower().Contains("water") == true);
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/src/ClassicUO.Client/Game/Effects/SplashEffect.cs
+++ b/src/ClassicUO.Client/Game/Effects/SplashEffect.cs
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+using ClassicUO.Renderer;
+using ClassicUO.Utility;
+using ClassicUO;
+using Microsoft.Xna.Framework;
+using System;
+
+namespace ClassicUO.Game.Effects
+{
+    /// <summary>
+    /// Configuration structure for splash effect visual parameters.
+    /// All visual aspects of the splash can be customized via this struct.
+    /// </summary>
+    public struct SplashConfig
+    {
+        // Timing
+        public float Duration;              // Animation duration in seconds
+        public float RiseSpeed;            // Vertical velocity (negative = up, 0 = no movement)
+        
+        // Particle Count
+        public int DropletCount;           // Number of droplets per splash
+        
+        // Spread Pattern
+        public float SpreadMultiplier;     // How far droplets spread from impact point
+        public float EllipseX;             // Horizontal ellipse factor (1.0 = circle, >1.0 = wider horizontally)
+        public float EllipseY;             // Vertical ellipse factor (<1.0 = flatter)
+        public float AngleRangeMin;         // Minimum angle in degrees (0-360)
+        public float AngleRangeMax;         // Maximum angle in degrees (0-360)
+        
+        // Droplet Size
+        public float BaseSize;             // Base size multiplier
+        public int MinDropletSize;         // Minimum droplet size in pixels
+        public int MaxDropletSize;         // Maximum droplet size in pixels
+        public float SizeScaleMultiplier;  // Size animation scale (grow/shrink effect)
+        
+        // Color
+        public Color BaseColor;             // Base splash color
+        public float AlphaMultiplier;       // Overall alpha multiplier (0.0-1.0)
+        public float AlphaVariationMin;     // Minimum alpha variation per droplet
+        public float AlphaVariationMax;     // Maximum alpha variation per droplet
+        
+        // Coordinate Mode
+        public bool UseWorldCoordinates;    // true = world coords, false = viewport coords
+        
+        /// <summary>
+        /// Creates a water splash configuration (default rain splash settings).
+        /// Light blue-white color, upward spread (0-180 degrees), moderate animation.
+        /// </summary>
+        public static SplashConfig WaterSplash()
+        {
+            return new SplashConfig
+            {
+                Duration = 3.25f,
+                RiseSpeed = -1.0f,
+                DropletCount = 6, // Default to middle layer count
+                SpreadMultiplier = 1.5f,
+                EllipseX = 1.2f,
+                EllipseY = 0.2f,
+                AngleRangeMin = 0f,
+                AngleRangeMax = 180f, // Upper hemisphere only (water splashes upward)
+                BaseSize = 1.5f,
+                MinDropletSize = 1,
+                MaxDropletSize = 3,
+                SizeScaleMultiplier = 1.5f,
+                BaseColor = Color.Lerp(Color.LightBlue, Color.White, 0.7f),
+                AlphaMultiplier = 0.7f,
+                AlphaVariationMin = 0.6f,
+                AlphaVariationMax = 1.0f,
+                UseWorldCoordinates = true
+            };
+        }
+        
+        /// <summary>
+        /// Creates a fire splash configuration.
+        /// Orange-red color, wider spread, faster animation.
+        /// </summary>
+        public static SplashConfig FireSplash()
+        {
+            return new SplashConfig
+            {
+                Duration = 0.5f,
+                RiseSpeed = -2.0f,
+                DropletCount = 12,
+                SpreadMultiplier = 2.0f,
+                EllipseX = 1.5f,
+                EllipseY = 0.8f,
+                AngleRangeMin = 0f,
+                AngleRangeMax = 360f, // Full circle for fire
+                BaseSize = 2.0f,
+                MinDropletSize = 2,
+                MaxDropletSize = 4,
+                SizeScaleMultiplier = 2.0f,
+                BaseColor = Color.OrangeRed,
+                AlphaMultiplier = 0.9f,
+                AlphaVariationMin = 0.7f,
+                AlphaVariationMax = 1.0f,
+                UseWorldCoordinates = true
+            };
+        }
+        
+        /// <summary>
+        /// Creates an explosion splash configuration.
+        /// Yellow-white color, very wide spread, many particles, fast animation.
+        /// </summary>
+        public static SplashConfig ExplosionSplash()
+        {
+            return new SplashConfig
+            {
+                Duration = 0.4f,
+                RiseSpeed = -3.0f,
+                DropletCount = 30,
+                SpreadMultiplier = 3.0f,
+                EllipseX = 1.0f, // Circular for explosion
+                EllipseY = 1.0f,
+                AngleRangeMin = 0f,
+                AngleRangeMax = 360f, // Full circle
+                BaseSize = 3.0f,
+                MinDropletSize = 2,
+                MaxDropletSize = 5,
+                SizeScaleMultiplier = 2.5f,
+                BaseColor = Color.Lerp(Color.Yellow, Color.White, 0.5f),
+                AlphaMultiplier = 1.0f,
+                AlphaVariationMin = 0.8f,
+                AlphaVariationMax = 1.0f,
+                UseWorldCoordinates = true
+            };
+        }
+        
+        /// <summary>
+        /// Creates a metal conflict/spark configuration.
+        /// Gray-white sparks, tight spread, quick fade.
+        /// </summary>
+        public static SplashConfig MetalConflictSplash()
+        {
+            return new SplashConfig
+            {
+                Duration = 0.3f,
+                RiseSpeed = -1.5f,
+                DropletCount = 8,
+                SpreadMultiplier = 1.0f,
+                EllipseX = 1.2f,
+                EllipseY = 1.2f,
+                AngleRangeMin = 0f,
+                AngleRangeMax = 360f, // Full circle for sparks
+                BaseSize = 1.0f,
+                MinDropletSize = 1,
+                MaxDropletSize = 2,
+                SizeScaleMultiplier = 1.0f,
+                BaseColor = Color.Lerp(Color.Gray, Color.White, 0.8f),
+                AlphaMultiplier = 0.9f,
+                AlphaVariationMin = 0.7f,
+                AlphaVariationMax = 1.0f,
+                UseWorldCoordinates = true
+            };
+        }
+    }
+    
+    /// <summary>
+    /// Independent splash effect system that can be used by any game system.
+    /// Manages a pool of splash particles with configurable visual parameters.
+    /// </summary>
+    internal sealed class SplashEffect
+    {
+        /// <summary>
+        /// Internal particle data structure.
+        /// </summary>
+        private struct SplashParticle
+        {
+            public float WorldX, WorldY;        // World coordinates
+            public float X, Y;                  // Viewport-relative (cached)
+            public float LifeTime;              // 0.0-1.0 (animation progress)
+            public float VelocityY;             // Vertical velocity
+            public float Size;                  // Base size
+            public uint SeedID;                 // Random seed for consistent pattern
+            public bool Active;                 // Is active
+            public SplashConfig Config;         // Configuration snapshot (for this particle)
+        }
+        
+        private readonly SplashParticle[] _particles;
+        private const int MAX_PARTICLES = byte.MaxValue; // 255 particles
+        
+        /// <summary>
+        /// Initializes a new instance of the SplashEffect.
+        /// </summary>
+        public SplashEffect()
+        {
+            _particles = new SplashParticle[MAX_PARTICLES];
+        }
+        
+        /// <summary>
+        /// Creates a new splash effect at the specified position.
+        /// </summary>
+        /// <param name="worldX">World X coordinate (or viewport X if UseWorldCoordinates is false)</param>
+        /// <param name="worldY">World Y coordinate (or viewport Y if UseWorldCoordinates is false)</param>
+        /// <param name="config">Visual configuration for the splash</param>
+        public void CreateSplash(float worldX, float worldY, SplashConfig config)
+        {
+            // Find an inactive particle slot
+            for (int i = 0; i < _particles.Length; i++)
+            {
+                ref SplashParticle particle = ref _particles[i];
+                if (!particle.Active)
+                {
+                    particle.Active = true;
+                    particle.LifeTime = 0f;
+                    particle.SeedID = (uint)Time.Ticks + (uint)i; // Unique seed for random pattern
+                    
+                    // Store position based on coordinate mode
+                    if (config.UseWorldCoordinates)
+                    {
+                        particle.WorldX = worldX;
+                        particle.WorldY = worldY;
+                    }
+                    else
+                    {
+                        // Viewport coordinates - store directly in X/Y
+                        particle.X = worldX;
+                        particle.Y = worldY;
+                        particle.WorldX = 0f; // Not used in viewport mode
+                        particle.WorldY = 0f;
+                    }
+                    
+                    // Initial velocity
+                    particle.VelocityY = config.RiseSpeed;
+                    
+                    // Base size with some variation
+                    float sizeVariation = RandomHelper.GetValue(0, 10) * 0.1f;
+                    particle.Size = config.BaseSize + sizeVariation;
+                    
+                    // Store configuration snapshot
+                    particle.Config = config;
+                    
+                    break; // Found a slot, exit
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Updates all active splash particles.
+        /// </summary>
+        /// <param name="deltaTime">Time since last update in seconds</param>
+        /// <param name="viewportOffsetX">Viewport offset X (only used if UseWorldCoordinates is true)</param>
+        /// <param name="viewportOffsetY">Viewport offset Y (only used if UseWorldCoordinates is true)</param>
+        /// <param name="visibleRangeX">Visible range X for culling</param>
+        /// <param name="visibleRangeY">Visible range Y for culling</param>
+        public void Update(float deltaTime, int viewportOffsetX = 0, int viewportOffsetY = 0,
+                          int visibleRangeX = int.MaxValue, int visibleRangeY = int.MaxValue)
+        {
+            for (int i = 0; i < _particles.Length; i++)
+            {
+                ref SplashParticle particle = ref _particles[i];
+                if (!particle.Active) continue;
+                
+                // Update lifetime
+                particle.LifeTime += deltaTime / particle.Config.Duration;
+                
+                // Deactivate if splash animation complete
+                if (particle.LifeTime >= 1.0f)
+                {
+                    particle.Active = false;
+                    continue;
+                }
+                
+                // Apply upward movement physics
+                if (particle.VelocityY != 0.0f && particle.Config.UseWorldCoordinates)
+                {
+                    // Apply physics in world space
+                    float speedOffset = deltaTime * 37.0f; // Same as SIMULATION_TIME scaling
+                    particle.WorldY += particle.VelocityY * speedOffset;
+                }
+                
+                // Convert to viewport-relative coordinates if using world coordinates
+                if (particle.Config.UseWorldCoordinates)
+                {
+                    particle.X = particle.WorldX - viewportOffsetX;
+                    particle.Y = particle.WorldY - viewportOffsetY;
+                }
+                
+                // Check visibility and cull if outside viewport
+                if (particle.X < -visibleRangeX || particle.X > visibleRangeX * 2 ||
+                    particle.Y < -visibleRangeY || particle.Y > visibleRangeY * 2)
+                {
+                    particle.Active = false;
+                    continue;
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Renders all active splash particles.
+        /// </summary>
+        /// <param name="batcher">Renderer to draw with</param>
+        /// <param name="layerDepth">Layer depth for rendering</param>
+        public void Draw(UltimaBatcher2D batcher, float layerDepth)
+        {
+            for (int i = 0; i < _particles.Length; i++)
+            {
+                ref SplashParticle particle = ref _particles[i];
+                if (!particle.Active) continue;
+                
+                SplashConfig config = particle.Config;
+                float progress = particle.LifeTime;
+                
+                // Size animation: grows then shrinks (parabolic curve using sine)
+                float sizeScale = 1f + (float)Math.Sin(progress * Math.PI) * config.SizeScaleMultiplier;
+                float currentSize = particle.Size * sizeScale;
+                
+                // Ensure minimum size to prevent invisible droplets
+                currentSize = Math.Max(2f, currentSize);
+                
+                // Alpha fades out linearly over animation duration
+                float alpha = (1f - progress) * config.AlphaMultiplier;
+                
+                // Splash center position
+                int splashX = (int)particle.X;
+                int splashY = (int)particle.Y;
+                
+                // Base splash color with alpha
+                Color baseSplashColor = config.BaseColor * alpha;
+                
+                // Draw scattered splash droplets
+                for (int p = 0; p < config.DropletCount; p++)
+                {
+                    // Generate truly random pattern using hash function (prevents sequential angles)
+                    uint particleSeed = (particle.SeedID * 73856093u) ^ ((uint)p * 19349663u);
+                    
+                    // Random angle within configured range
+                    float angleRange = config.AngleRangeMax - config.AngleRangeMin;
+                    float randomAngle = config.AngleRangeMin + (float)(particleSeed % (uint)angleRange);
+                    float angle = randomAngle * 0.017453f; // Convert to radians
+                    
+                    // Random spread distance per droplet (0.5-1.0 variation)
+                    float randomSpread = ((particleSeed % 100) / 100f) * 0.5f + 0.5f;
+                    
+                    // Calculate final position (where droplet will end up)
+                    float finalSpreadRadius = currentSize * randomSpread * config.SpreadMultiplier;
+                    
+                    // Animated spreading: droplet position interpolates from center to final position
+                    // progress = 0.0: droplet at impact point (center)
+                    // progress = 1.0: droplet at final position
+                    float currentSpreadRadius = finalSpreadRadius * progress;
+                    
+                    // Elliptical spread pattern
+                    int offsetX = (int)(Math.Cos(angle) * currentSpreadRadius * config.EllipseX);
+                    // Negate Y to make upward motion (screen Y increases downward)
+                    int offsetY = -(int)(Math.Sin(angle) * currentSpreadRadius * config.EllipseY);
+                    
+                    // Random droplet size using configured min/max range
+                    int dropletSizeRange = config.MaxDropletSize - config.MinDropletSize + 1;
+                    int dropletSize = config.MinDropletSize + (int)(particleSeed % (uint)dropletSizeRange);
+                    
+                    // Position droplet - animates from center outward as progress increases
+                    Rectangle dropletRect = new Rectangle(
+                        splashX + offsetX - dropletSize / 2,
+                        splashY + offsetY - dropletSize / 2,
+                        dropletSize,
+                        dropletSize
+                    );
+                    
+                    // Random alpha variation per droplet using configured range
+                    float alphaRange = config.AlphaVariationMax - config.AlphaVariationMin;
+                    float alphaVariation = config.AlphaVariationMin + ((particleSeed % 100) / 100f) * alphaRange;
+                    Color dropletColor = baseSplashColor * alphaVariation;
+                    
+                    batcher.Draw(
+                        SolidColorTextureCache.GetTexture(dropletColor),
+                        dropletRect,
+                        Vector3.UnitZ,
+                        layerDepth
+                    );
+                }
+            }
+        }
+    }
+}
+

--- a/src/ClassicUO.Client/Game/Effects/SplashEffect.cs
+++ b/src/ClassicUO.Client/Game/Effects/SplashEffect.cs
@@ -51,17 +51,17 @@ namespace ClassicUO.Game.Effects
         {
             return new SplashConfig
             {
-                Duration = 3.25f,
-                RiseSpeed = -1.0f,
+                Duration = 0.15f,
+                RiseSpeed = -3.0f,
                 DropletCount = 6, // Default to middle layer count
-                SpreadMultiplier = 1.5f,
-                EllipseX = 1.2f,
+                SpreadMultiplier = 1.0f,
+                EllipseX = 3.2f,
                 EllipseY = 0.2f,
-                AngleRangeMin = 0f,
-                AngleRangeMax = 180f, // Upper hemisphere only (water splashes upward)
-                BaseSize = 1.5f,
+                AngleRangeMin = 25f,
+                AngleRangeMax = 125f, // Upper hemisphere only (water splashes upward)
+                BaseSize = 1.0f,
                 MinDropletSize = 1,
-                MaxDropletSize = 3,
+                MaxDropletSize = 2,
                 SizeScaleMultiplier = 1.5f,
                 BaseColor = Color.Lerp(Color.LightBlue, Color.White, 0.7f),
                 AlphaMultiplier = 0.7f,
@@ -223,9 +223,9 @@ namespace ClassicUO.Game.Effects
                     
                     // Initial velocity
                     particle.VelocityY = config.RiseSpeed;
-                    
+
                     // Base size with some variation
-                    float sizeVariation = RandomHelper.GetValue(0, 10) * 0.1f;
+                    float sizeVariation = RandomHelper.GetValue(0, 5) * 0.1f;
                     particle.Size = config.BaseSize + sizeVariation;
                     
                     // Store configuration snapshot

--- a/src/ClassicUO.Client/Game/Map/CoordinateHelper.cs
+++ b/src/ClassicUO.Client/Game/Map/CoordinateHelper.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ClassicUO.Game.Map
+{
+    /// <summary>
+    /// Helper class for coordinate conversions between different coordinate systems.
+    /// </summary>
+    public static class CoordinateHelper
+    {
+        /// <summary>
+        /// Converts absolute isometric world coordinates to tile coordinates.
+        /// This is used in Weather, SplashEffect, and RippleEffect for position calculations.
+        /// </summary>
+        /// <param name="worldX">Absolute isometric X coordinate</param>
+        /// <param name="worldY">Absolute isometric Y coordinate</param>
+        /// <returns>A tuple containing (tileX, tileY)</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (int tileX, int tileY) IsometricToTile(float worldX, float worldY)
+        {
+            int targetTileX = (int)Math.Round((worldX + worldY) / 44f);
+            int targetTileY = (int)Math.Round((worldY - worldX) / 44f);
+            return (targetTileX, targetTileY);
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Map/TileDetectionHelper.cs
+++ b/src/ClassicUO.Client/Game/Map/TileDetectionHelper.cs
@@ -41,7 +41,7 @@ namespace ClassicUO.Game.Map
                 ref StaticTiles itemData = ref Client.Game.UO.FileManager.TileData.StaticData[obj.Graphic];
 
                 // Check if tile is above the player and it's not rendering
-                if (obj.Z > pz14 && obj.AlphaHue == 0)
+                if ((sbyte)obj.PriorityZ > pz14 && obj.AlphaHue == 0)
                 {
                     return true;
                 }
@@ -79,9 +79,11 @@ namespace ClassicUO.Game.Map
 
             while (obj != null)
             {
-                if (obj.Z > highestZ)
+                if ((sbyte)obj.PriorityZ > highestZ &&
+                    obj.Graphic < Client.Game.UO.FileManager.TileData.StaticData.Length &&
+                    obj.AlphaHue != 0)
                 {
-                    highestZ = obj.Z;
+                    highestZ = (sbyte)obj.PriorityZ;
                     topMostObject = obj;
                 }
                 obj = obj.TNext;

--- a/src/ClassicUO.Client/Game/Map/TileDetectionHelper.cs
+++ b/src/ClassicUO.Client/Game/Map/TileDetectionHelper.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+using ClassicUO.Assets;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Utility;
+
+namespace ClassicUO.Game.Map
+{
+    internal static class TileDetectionHelper
+    {
+        /// <summary>
+        /// Checks if the given tile position has a covering tile above the specified Z level.
+        /// A covering tile is a roof or other structure that blocks weather effects and it's not currently rendering
+        /// (e.g., hidden roof when player is inside a house or other non-rendering tile above player).
+        /// </summary>
+        /// <param name="map">The map instance</param>
+        /// <param name="targetTileX">Tile X coordinate</param>
+        /// <param name="targetTileY">Tile Y coordinate</param>
+        /// <param name="playerZ">Player Z coordinate</param>
+        /// <returns>True if the position has a non-rendering covering tile above the player, false otherwise.</returns>
+        public static bool HasNonRenderingCoveringTile(Map map, int targetTileX, int targetTileY, int playerZ)
+        {
+            if (map == null) return false;
+
+            Chunk chunk = map.GetChunk(targetTileX, targetTileY, load: false);
+
+            if (chunk == null) return false;
+
+            int pz14 = playerZ + 14; // Threshold for detecting tiles above player
+
+            GameObject obj = chunk.GetHeadObject(targetTileX % 8, targetTileY % 8);
+
+            while (obj != null)
+            {
+                if (obj.Graphic >= Client.Game.UO.FileManager.TileData.StaticData.Length)
+                {
+                    obj = obj.TNext;
+                    continue;
+                }
+
+                ref StaticTiles itemData = ref Client.Game.UO.FileManager.TileData.StaticData[obj.Graphic];
+
+                // Check if tile is above the player and it's not rendering
+                if (obj.Z > pz14 && obj.AlphaHue == 0)
+                {
+                    return true;
+                }
+
+                obj = obj.TNext;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the given tile position is a water tile.
+        /// </summary>
+        /// <param name="map">The map instance</param>
+        /// <param name="targetTileX">Tile X coordinate</param>
+        /// <param name="targetTileY">Tile Y coordinate</param>
+        /// <returns>True if the position is on a water tile, false otherwise.</returns>
+        /// <remarks>
+        /// Thanks to [markdwags](https://github.com/markdwags) for the code 
+        /// in [this comment](https://github.com/ClassicUO/ClassicUO/pull/1852#issuecomment-3656749076).
+        /// </remarks>
+        public static bool IsWaterTile(Map map, int targetTileX, int targetTileY)
+        {
+            if (map == null) return false;
+
+            Chunk chunk = map.GetChunk(targetTileX, targetTileY, load: false);
+
+            if (chunk == null) return false;
+
+            // Get the first object in the tile's linked list
+            GameObject obj = chunk.Tiles[targetTileX % 8, targetTileY % 8];
+            // Find the highest Z-level object (the one that's actually visible)
+            GameObject topMostObject = null;
+            sbyte highestZ = sbyte.MinValue;
+
+            while (obj != null)
+            {
+                if (obj.Z > highestZ)
+                {
+                    highestZ = obj.Z;
+                    topMostObject = obj;
+                }
+                obj = obj.TNext;
+            }
+
+            // Now check only the top-most visible object
+            if (topMostObject != null)
+            {
+                switch (topMostObject)
+                {
+                    case Land land:
+                        return land.TileData.IsWet &&
+                            (land.TileData.Name?.ToLower().Contains("water") == true);
+                    case Static staticTile:
+                        return staticTile.ItemData.IsWet &&
+                            (staticTile.ItemData.Name?.ToLower().Contains("water") == true);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/RippleEffect.cs
+++ b/src/ClassicUO.Client/Game/RippleEffect.cs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Renderer;
+using ClassicUO.Utility;
+using Microsoft.Xna.Framework;
+using System;
+
+namespace ClassicUO.Game
+{
+    /// <summary>
+    /// Ripple effect system for water tiles.
+    /// </summary>
+    internal sealed class RippleEffect
+    {
+        // Configuration constants
+        private const int MAX_RIPPLES = 64;
+        private const float RIPPLE_DURATION = 0.8f;
+        private const int CIRCLE_SEGMENTS = 32;
+        private const float RIPPLE_MAX_RADIUS = 20f;
+        private const float RIPPLE_ALPHA_MULTIPLIER = 0.7f;
+        private const float RIPPLE_RING_SPACING = 0.3f;
+
+        private readonly Ripple[] _ripples = new Ripple[MAX_RIPPLES];
+        private readonly World _world;
+        private uint _lastTick;
+
+        public RippleEffect(World world)
+        {
+            _world = world;
+            _lastTick = Time.Ticks;
+        }
+
+        public void CreateRipple(float worldX, float worldY)
+        {
+            if (_world.Map == null)
+            {
+                return;
+            }
+
+            if (!IsWaterTileAtPosition(worldX, worldY))
+            {
+                return; 
+            }
+
+            // Find inactive ripple slot
+            for (int i = 0; i < _ripples.Length; i++)
+            {
+                ref Ripple ripple = ref _ripples[i];
+                if (!ripple.Active)
+                {
+                    ripple.Active = true;
+                    ripple.WorldX = worldX;
+                    ripple.WorldY = worldY;
+                    ripple.LifeTime = 0.0f;
+                    ripple.MaxRadius = RIPPLE_MAX_RADIUS;
+                    ripple.SeedID = (uint)(Time.Ticks + i);
+
+                    break;
+                }
+            }
+        }
+
+        public void Draw(UltimaBatcher2D batcher, int x, int y, float layerDepth)
+        {
+            if (_world.Player == null) return;
+
+            // Calculate viewport offset (same as weather system)
+            Point winsize = new Point(
+                Client.Game.Scene.Camera.Bounds.Width,
+                Client.Game.Scene.Camera.Bounds.Height
+            );
+
+            int tileOffX = _world.Player.X;
+            int tileOffY = _world.Player.Y;
+            int winGameCenterX = (winsize.X >> 1) + (_world.Player.Z << 2);
+            int winGameCenterY = (winsize.Y >> 1) + (_world.Player.Z << 2);
+            winGameCenterX -= (int)_world.Player.Offset.X;
+            winGameCenterY -= (int)(_world.Player.Offset.Y - _world.Player.Offset.Z);
+
+            int viewportOffsetX = (tileOffX - tileOffY) * 22 - winGameCenterX;
+            int viewportOffsetY = (tileOffX + tileOffY) * 22 - winGameCenterY;
+
+            // Calculate time delta
+            uint currentTick = Time.Ticks;
+            uint deltaTicks = currentTick - _lastTick;
+            _lastTick = currentTick;
+
+            // Cap delta to prevent large jumps (e.g., when game resumes)
+            if (deltaTicks > 7000)
+            {
+                deltaTicks = 25; // Approximate one frame at 60 FPS
+            }
+
+            float deltaTime = deltaTicks / 1000f; // Convert to seconds
+
+            // Update and render each active ripple
+            for (int i = 0; i < _ripples.Length; i++)
+            {
+                ref Ripple ripple = ref _ripples[i];
+                if (!ripple.Active) continue;
+
+                // Update lifetime
+                ripple.LifeTime += deltaTime / RIPPLE_DURATION;
+
+                // Deactivate if animation complete
+                if (ripple.LifeTime >= 1.0f)
+                {
+                    ripple.Active = false;
+                    continue;
+                }
+
+                // Convert to viewport-relative coordinates
+                ripple.X = ripple.WorldX - viewportOffsetX;
+                ripple.Y = ripple.WorldY - viewportOffsetY;
+
+                // Check visibility (off-screen ripples can be skipped for performance)
+                int visibleRangeX = winsize.X * 2;
+                int visibleRangeY = winsize.Y * 2;
+                if (ripple.X < -visibleRangeX || ripple.X > visibleRangeX ||
+                    ripple.Y < -visibleRangeY || ripple.Y > visibleRangeY)
+                {
+                    ripple.Active = false; // Deactivate off-screen ripples
+                    continue;
+                }
+
+                // Calculate ripple properties
+                float progress = ripple.LifeTime;
+                float currentRadius = ripple.MaxRadius * progress; // Expand over time
+                float alpha = (1.0f - progress) * RIPPLE_ALPHA_MULTIPLIER; // Fade out
+
+                // Draw expanding ripple circle
+                Color rippleColor = Color.Lerp(Color.LightBlue, Color.Transparent, progress) * alpha;
+
+                DrawCircle(
+                    batcher,
+                    new Vector2(ripple.X, ripple.Y),
+                    currentRadius,
+                    rippleColor,
+                    layerDepth
+                );
+
+                // Optional: Draw 2nd concentric ring for depth (if progress > 0.3)
+                if (progress > RIPPLE_RING_SPACING)
+                {
+                    float ring2Radius = ripple.MaxRadius * (progress - RIPPLE_RING_SPACING);
+                    float ring2Progress = (progress - RIPPLE_RING_SPACING) / (1.0f - RIPPLE_RING_SPACING);
+                    float ring2Alpha = (1.0f - ring2Progress) * 0.5f;
+                    Color ring2Color = Color.LightBlue * ring2Alpha;
+
+                    DrawCircle(
+                        batcher,
+                        new Vector2(ripple.X, ripple.Y),
+                        ring2Radius,
+                        ring2Color,
+                        layerDepth
+                    );
+                }
+            }
+        }
+
+        public void Reset()
+        {
+            for (int i = 0; i < _ripples.Length; i++)
+            {
+                _ripples[i].Active = false;
+            }
+        }
+
+        /// <summary>
+        /// Checks if the given absolute isometric position is on a water tile.
+        /// Converts directly from absolute isometric coordinates to tile coordinates.
+        /// </summary>
+        /// <param name="worldX">Absolute isometric X coordinate.</param>
+        /// <param name="worldY">Absolute isometric Y coordinate.</param>
+        /// <returns>True if the position is on a water tile, false otherwise.</returns>
+        private bool IsWaterTileAtPosition(float worldX, float worldY)
+        {
+            if (_world.Map == null)
+            {
+                return false;
+            }
+
+            // Convert absolute isometric coordinates directly to tile coordinates
+            // Forward formula: isoX = (tileX - tileY) * 22, isoY = (tileX + tileY) * 22 - (tileZ * 4)
+            // Reverse formula (ignoring Z for ground tile lookup):
+            //   tileX = (isoX + isoY) / 44
+            //   tileY = (isoY - isoX) / 44
+            
+            int targetTileX = (int)Math.Round((worldX + worldY) / 44f);
+            int targetTileY = (int)Math.Round((worldY - worldX) / 44f);
+
+            // Check if tile is water
+            GameObject tileObj = _world.Map.GetTile(targetTileX, targetTileY, load: false);
+            if (tileObj is Land land)
+            {
+                return land.TileData.IsWet &&
+                       (land.TileData.Name?.ToLower().Contains("water") == true);
+            }
+
+            return false;
+        }
+
+        private void DrawCircle(UltimaBatcher2D batcher, Vector2 center, float radius, Color color, float layerDepth)
+        {
+            if (radius <= 0) return;
+
+            const int segments = CIRCLE_SEGMENTS;
+            float angleStep = (float)(Math.PI * 2.0 / segments);
+
+            Vector2 prevPoint = center + new Vector2(radius, 0);
+
+            for (int i = 1; i <= segments; i++)
+            {
+                float angle = i * angleStep;
+                Vector2 currentPoint = center + new Vector2(
+                    (float)(Math.Cos(angle) * radius),
+                    (float)(Math.Sin(angle) * radius)
+                );
+
+                // Draw line segment (creates circle outline)
+                batcher.DrawLine(
+                    SolidColorTextureCache.GetTexture(color),
+                    prevPoint,
+                    currentPoint,
+                    Vector3.UnitZ,
+                    1, // Line thickness: 1 pixel
+                    layerDepth
+                );
+
+                prevPoint = currentPoint;
+            }
+        }
+
+        private struct Ripple
+        {
+            public float WorldX, WorldY;      // Absolute isometric coordinates
+            public float X, Y;                // Viewport-relative coordinates (cached)
+            public float LifeTime;            // 0.0 to 1.0 (animation progress)
+            public float MaxRadius;           // Maximum expansion radius
+            public bool Active;               // Is this ripple currently active
+            public uint SeedID;               // Random seed for consistent pattern
+        }
+    }
+}
+

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -55,7 +55,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _enableDragSelect, _dragSelectHumanoidsOnly, _dragSelectHostileOnly;
 
         // sounds
-        private Checkbox _enableSounds, _enableMusic, _footStepsSound, _combatMusic, _musicInBackground, _loginMusic;
+        private Checkbox _enableSounds, _enableMusic, _footStepsSound, _rainSound, _combatMusic, _musicInBackground, _loginMusic;
 
         // fonts
         private FontSelector _fontSelectorChat;
@@ -140,7 +140,7 @@ namespace ClassicUO.Game.UI.Gumps
         private NiceButton _setAsNewDefault;
 
         // video
-        private Checkbox _use_old_status_gump, _statusGumpBarMutuallyExclusive, _windowBorderless, _enableDeathScreen, _enableBlackWhiteEffect, _altLights, _enableLight, _enableShadows, _enableShadowsStatics, _auraMouse, _runMouseInSeparateThread, _useColoredLights, _darkNights, _partyAura, _hideChatGradient, _animatedWaterEffect;
+        private Checkbox _use_old_status_gump, _statusGumpBarMutuallyExclusive, _windowBorderless, _enableDeathScreen, _enableBlackWhiteEffect, _altLights, _enableLight, _enableShadows, _enableShadowsStatics, _auraMouse, _runMouseInSeparateThread, _useColoredLights, _darkNights, _partyAura, _hideChatGradient, _animatedWaterEffect, _weatherEffects;
         private Combobox _lightLevelType;
         private Checkbox _use_smooth_boat_movement;
         private HSliderBar _terrainShadowLevel;
@@ -1493,6 +1493,17 @@ namespace ClassicUO.Game.UI.Gumps
 
             startY += _footStepsSound.Height + 2;
 
+            _rainSound = AddCheckBox
+            (
+                rightArea,
+                ResGumps.PlayRainSound,
+                _currentProfile.EnableRainSound,
+                startX,
+                startY
+            );
+
+            startY += _rainSound.Height + 2;
+
             _combatMusic = AddCheckBox
             (
                 rightArea,
@@ -1874,6 +1885,20 @@ namespace ClassicUO.Game.UI.Gumps
                     null,
                     ResGumps.AnimatedWaterEffect,
                     _currentProfile.AnimatedWaterEffect,
+                    startX,
+                    startY
+                )
+            );
+
+            startY += 25;
+
+            section4.Add
+            (
+                _weatherEffects = AddCheckBox
+                (
+                    null,
+                    ResGumps.WeatherEffects,
+                    _currentProfile.EnableWeatherEffects,
                     startX,
                     startY
                 )
@@ -3610,6 +3635,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _musicVolume.Value = 100;
                     _musicInBackground.IsChecked = false;
                     _footStepsSound.IsChecked = true;
+                    _rainSound.IsChecked = true;
                     _loginMusicVolume.Value = 100;
                     _loginMusic.IsChecked = true;
                     _soundsVolume.IsVisible = _enableSounds.IsChecked;
@@ -3643,6 +3669,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _auraMouse.IsChecked = true;
                     _partyAura.IsChecked = true;
                     _animatedWaterEffect.IsChecked = false;
+                    _weatherEffects.IsChecked = true;
                     _partyAuraColorPickerBox.Hue = 0x0044;
 
                     break;
@@ -3878,6 +3905,7 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.EnableSound = _enableSounds.IsChecked;
             _currentProfile.EnableMusic = _enableMusic.IsChecked;
             _currentProfile.EnableFootstepsSound = _footStepsSound.IsChecked;
+            _currentProfile.EnableRainSound = _rainSound.IsChecked;
             _currentProfile.EnableCombatMusic = _combatMusic.IsChecked;
             _currentProfile.ReproduceSoundsInBackground = _musicInBackground.IsChecked;
             _currentProfile.SoundVolume = _soundsVolume.Value;
@@ -4076,6 +4104,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             _currentProfile.AuraOnMouse = _auraMouse.IsChecked;
             _currentProfile.AnimatedWaterEffect = _animatedWaterEffect.IsChecked;
+            _currentProfile.EnableWeatherEffects = _weatherEffects.IsChecked;
             _currentProfile.PartyAura = _partyAura.IsChecked;
             _currentProfile.PartyAuraHue = _partyAuraColorPickerBox.Hue;
             _currentProfile.HideChatGradient = _hideChatGradient.IsChecked;

--- a/src/ClassicUO.Client/Game/Weather.cs
+++ b/src/ClassicUO.Client/Game/Weather.cs
@@ -6,6 +6,7 @@ using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using System;
 using MathHelper = Microsoft.Xna.Framework.MathHelper;
 using ClassicUO.Game.Map;
@@ -83,9 +84,34 @@ namespace ClassicUO.Game
         private readonly World _world;
         private UOSound _currentRainSound;
 
+        private static Texture2D _whiteTexture;
+        private static Texture2D WhiteTexture
+        {
+            get
+            {
+                if (_whiteTexture == null)
+                {
+                    Console.WriteLine("Initializing Weather WhiteTexture");
+                    _whiteTexture = SolidColorTextureCache.GetTexture(Color.White);
+                    Console.WriteLine("Initialized Weather WhiteTexture");
+                    if (_whiteTexture == null)
+                    {
+                        throw new Exception("Failed to initialize Weather WhiteTexture");
+                    }
+                }
+
+                return _whiteTexture;
+            }
+        }
+
         public Weather(World world)
         {
             _world = world;
+        }
+
+        private static Vector3 ColorToVector3(Color color)
+        {
+            return new Vector3(color.R / 255f, color.G / 255f, color.B / 255f);
         }
 
 
@@ -1034,9 +1060,9 @@ namespace ClassicUO.Game
 
                                         batcher.Draw
                                         (
-                                            SolidColorTextureCache.GetTexture(outerColor),
+                                            WhiteTexture,
                                             outerRect,
-                                            Vector3.UnitZ,
+                                            ColorToVector3(outerColor),
                                             layerDepth
                                         );
                                     }
@@ -1057,9 +1083,9 @@ namespace ClassicUO.Game
 
                                         batcher.Draw
                                         (
-                                            SolidColorTextureCache.GetTexture(midOuterColor),
+                                            WhiteTexture,
                                             midOuterRect,
-                                            Vector3.UnitZ,
+                                            ColorToVector3(midOuterColor),
                                             layerDepth + 0.0001f
                                         );
                                     }
@@ -1080,9 +1106,9 @@ namespace ClassicUO.Game
 
                                         batcher.Draw
                                         (
-                                            SolidColorTextureCache.GetTexture(middleColor),
+                                            WhiteTexture,
                                             middleRect,
-                                            Vector3.UnitZ,
+                                            ColorToVector3(middleColor),
                                             layerDepth + 0.0002f
                                         );
                                     }
@@ -1100,9 +1126,9 @@ namespace ClassicUO.Game
 
                                     batcher.Draw
                                     (
-                                        SolidColorTextureCache.GetTexture(smallCoreColor),
+                                        WhiteTexture,
                                         smallCoreRect,
-                                        Vector3.UnitZ,
+                                        ColorToVector3(smallCoreColor),
                                         layerDepth + 0.0003f
                                     );
                                     break;
@@ -1133,9 +1159,9 @@ namespace ClassicUO.Game
 
                                         batcher.Draw
                                         (
-                                            SolidColorTextureCache.GetTexture(outerColor),
+                                            WhiteTexture,
                                             outerRect,
-                                            Vector3.UnitZ,
+                                            ColorToVector3(outerColor),
                                             layerDepth
                                         );
                                     }
@@ -1156,9 +1182,9 @@ namespace ClassicUO.Game
 
                                         batcher.Draw
                                         (
-                                            SolidColorTextureCache.GetTexture(midOuterColor),
+                                            WhiteTexture,
                                             midOuterRect,
-                                            Vector3.UnitZ,
+                                            ColorToVector3(midOuterColor),
                                             layerDepth + 0.0001f
                                         );
                                     }
@@ -1179,9 +1205,9 @@ namespace ClassicUO.Game
 
                                         batcher.Draw
                                         (
-                                            SolidColorTextureCache.GetTexture(middleColor),
+                                            WhiteTexture,
                                             middleRect,
-                                            Vector3.UnitZ,
+                                            ColorToVector3(middleColor),
                                             layerDepth + 0.0002f
                                         );
                                     }
@@ -1199,9 +1225,9 @@ namespace ClassicUO.Game
 
                                     batcher.Draw
                                     (
-                                        SolidColorTextureCache.GetTexture(largeCoreColor),
+                                        WhiteTexture,
                                         largeCoreRect,
-                                        Vector3.UnitZ,
+                                        ColorToVector3(largeCoreColor),
                                         layerDepth + 0.0003f
                                     );
                                     break;
@@ -1238,10 +1264,10 @@ namespace ClassicUO.Game
 
                                     batcher.DrawLine
                                     (
-                                        SolidColorTextureCache.GetTexture(shortLineColor),
+                                        WhiteTexture,
                                         shortStart,
                                         shortEnd,
-                                        Vector3.UnitZ,
+                                        ColorToVector3(shortLineColor),
                                         shortLineWidth,
                                         layerDepth
                                     );
@@ -1277,10 +1303,10 @@ namespace ClassicUO.Game
 
                                     batcher.DrawLine
                                     (
-                                        SolidColorTextureCache.GetTexture(boltColor),
+                                        WhiteTexture,
                                         boltStart,
                                         boltEnd,
-                                        Vector3.UnitZ,
+                                        ColorToVector3(boltColor),
                                         boltLineWidth,
                                         layerDepth
                                     );
@@ -1309,10 +1335,10 @@ namespace ClassicUO.Game
 
                             batcher.DrawLine
                             (
-                                SolidColorTextureCache.GetTexture(Color.Blue),
+                                WhiteTexture,
                                 start,
                                 end,
-                                Vector3.UnitZ,
+                                ColorToVector3(Color.Blue),
                                 2,
                                 layerDepth
                             );
@@ -1431,9 +1457,9 @@ namespace ClassicUO.Game
 
                             batcher.Draw
                             (
-                                SolidColorTextureCache.GetTexture(outerColor),
+                                WhiteTexture,
                                 outerRect,
-                                Vector3.UnitZ,
+                                ColorToVector3(outerColor),
                                 layerDepth
                             );
                         }
@@ -1454,9 +1480,9 @@ namespace ClassicUO.Game
 
                             batcher.Draw
                             (
-                                SolidColorTextureCache.GetTexture(midOuterColor),
+                                WhiteTexture,
                                 midOuterRect,
-                                Vector3.UnitZ,
+                                ColorToVector3(midOuterColor),
                                 layerDepth + 0.0001f
                             );
                         }
@@ -1477,9 +1503,9 @@ namespace ClassicUO.Game
 
                             batcher.Draw
                             (
-                                SolidColorTextureCache.GetTexture(middleColor),
+                                WhiteTexture,
                                 middleRect,
-                                Vector3.UnitZ,
+                                ColorToVector3(middleColor),
                                 layerDepth + 0.0002f
                             );
                         }
@@ -1497,9 +1523,9 @@ namespace ClassicUO.Game
 
                         batcher.Draw
                         (
-                            SolidColorTextureCache.GetTexture(coreColor),
+                            WhiteTexture,
                             coreRect,
-                            Vector3.UnitZ,
+                            ColorToVector3(coreColor),
                             layerDepth + 0.0003f
                         );
 

--- a/src/ClassicUO.Client/Game/Weather.cs
+++ b/src/ClassicUO.Client/Game/Weather.cs
@@ -74,7 +74,7 @@ namespace ClassicUO.Game
         // Enable splash effects for long bolts (density 50-70)
         // - Always recommended to be true for storm conditions
 
-        private const float RAIN_VOLUME_MULTIPLIER = 0.65f;
+        private const float RAIN_VOLUME_MULTIPLIER = 0.30f;
         private const int MINOR_RAIN_SOUND_ID = 0x011;
         private const int HEAVY_RAIN_SOUND_ID = 0x010;
 
@@ -94,14 +94,14 @@ namespace ClassicUO.Game
         public byte Count { get; private set; }
         public byte ScaledCount { get; private set; }
         public byte CurrentCount { get; private set; }
-        public byte Temperature{ get; private set; }
+        public byte Temperature { get; private set; }
         public sbyte Wind { get; private set; }
 
 
 
         private static float SinOscillate(float freq, int range, uint current_tick)
         {
-            float anglef = (int) (current_tick / 2.7777f * freq) % 360;
+            float anglef = (int)(current_tick / 2.7777f * freq) % 360;
 
             return Math.Sign(MathHelper.ToRadians(anglef)) * range;
         }
@@ -127,7 +127,7 @@ namespace ClassicUO.Game
             }
 
             Type = type;
-            Count = (byte) Math.Min(MAX_WEATHER_EFFECT, (int) count);
+            Count = (byte)Math.Min(MAX_WEATHER_EFFECT, (int)count);
             Temperature = temp;
             _timer = Time.Ticks + Constants.WEATHER_TIMER;
 
@@ -239,23 +239,23 @@ namespace ClassicUO.Game
             int tileOffY = _world.Player.Y;
             int playerAbsIsoX = (tileOffX - tileOffY) * 22;
             int playerAbsIsoY = (tileOffX + tileOffY) * 22;
-            
+
             int spreadX = Client.Game.Scene.Camera.Bounds.Width;
             int spreadY = Client.Game.Scene.Camera.Bounds.Height;
 
             for (int i = 0; i < _effects.Length; i++)
             {
                 ref WeatherEffect effect = ref _effects[i];
-                
+
                 // Initialize particles randomly around player position (original behavior)
                 // This creates natural scattered appearance at weather start
                 effect.WorldX = playerAbsIsoX + RandomHelper.GetValue(-spreadX, spreadX);
                 effect.WorldY = playerAbsIsoY + RandomHelper.GetValue(-spreadY, spreadY);
-                
+
                 effect.ID = (uint)i;
                 effect.ScaleRatio = RandomHelper.GetValue(0, 10) * 0.1f;
                 effect.RippleCreated = false; // Initialize ripple flag
-                
+
                 // Assign depth layer based on ScaleRatio (distribute evenly across 3 layers)
                 float depthValue = effect.ScaleRatio;  // Reuse existing 0.0-1.0 value
                 if (depthValue < 0.33f)
@@ -264,7 +264,7 @@ namespace ClassicUO.Game
                     effect.Depth = DepthLayer.Middle;
                 else
                     effect.Depth = DepthLayer.Foreground;
-                
+
                 // Assign random fade threshold based on depth layer for natural scattered depth
                 switch (effect.Depth)
                 {
@@ -273,13 +273,13 @@ namespace ClassicUO.Game
                         effect.FadeThreshold = RandomHelper.GetValue(0, 30) * 0.01f;  // 0.0 to 0.3
                         effect.NeverFade = false;
                         break;
-                        
+
                     case DepthLayer.Middle:
                         // Middle particles randomly fade in 31-70% range
                         effect.FadeThreshold = 0.31f + RandomHelper.GetValue(0, 39) * 0.01f;  // 0.31 to 0.70
                         effect.NeverFade = false;
                         break;
-                        
+
                     case DepthLayer.Foreground:
                         // Foreground: 50% never fade, 50% fade randomly in 71-100% range
                         if (RandomHelper.RandomBool())
@@ -366,7 +366,7 @@ namespace ClassicUO.Game
         private DepthProperties GetDepthProperties(DepthLayer layer, WeatherType weatherType)
         {
             DepthProperties props = new DepthProperties();
-            
+
             switch (layer)
             {
                 case DepthLayer.Background:
@@ -374,33 +374,33 @@ namespace ClassicUO.Game
                     props.SpeedMultiplier = 0.5f + (0.2f * RandomHelper.GetValue(0, 10) * 0.1f); // 50-70%
                     props.AlphaMultiplier = 0.4f + (0.2f * RandomHelper.GetValue(0, 10) * 0.1f); // 40-60%
                     props.TrailMultiplier = 0.4f + (0.2f * RandomHelper.GetValue(0, 10) * 0.1f); // 40-60%
-                    
+
                     // Atmospheric color tint (lighter for distance)
                     if (weatherType == WeatherType.WT_RAIN || weatherType == WeatherType.WT_STORM_APPROACH)
                         props.ColorTint = Color.Lerp(Color.LightBlue, Color.White, 0.5f);
                     else // Snow
                         props.ColorTint = Color.White;
                     break;
-                    
+
                 case DepthLayer.Middle:
                     props.SizeMultiplier = 0.85f + (0.15f * RandomHelper.GetValue(0, 10) * 0.1f); // 85-100%
                     props.SpeedMultiplier = 0.8f + (0.2f * RandomHelper.GetValue(0, 10) * 0.1f);  // 80-100%
                     props.AlphaMultiplier = 0.7f + (0.2f * RandomHelper.GetValue(0, 10) * 0.1f);  // 70-90%
                     props.TrailMultiplier = 0.8f + (0.2f * RandomHelper.GetValue(0, 10) * 0.1f);  // 80-100%
-                    
+
                     // Standard colors with subtle tint
                     if (weatherType == WeatherType.WT_RAIN || weatherType == WeatherType.WT_STORM_APPROACH)
                         props.ColorTint = Color.LightGray;
                     else
                         props.ColorTint = Color.White;
                     break;
-                    
+
                 case DepthLayer.Foreground:
                     props.SizeMultiplier = 1.1f + (0.4f * RandomHelper.GetValue(0, 10) * 0.1f); // 110-150%
                     props.SpeedMultiplier = 1.2f + (0.3f * RandomHelper.GetValue(0, 10) * 0.1f); // 120-150%
                     props.AlphaMultiplier = 0.9f + (0.1f * RandomHelper.GetValue(0, 10) * 0.1f); // 90-100%
                     props.TrailMultiplier = 1.2f + (0.3f * RandomHelper.GetValue(0, 10) * 0.1f); // 120-150%
-                    
+
                     // Darker/more saturated for proximity
                     if (weatherType == WeatherType.WT_RAIN || weatherType == WeatherType.WT_STORM_APPROACH)
                         props.ColorTint = Color.Gray;
@@ -408,7 +408,7 @@ namespace ClassicUO.Game
                         props.ColorTint = Color.Lerp(Color.White, Color.LightGray, 0.2f);
                     break;
             }
-            
+
             return props;
         }
 
@@ -447,7 +447,7 @@ namespace ClassicUO.Game
 
         private void PlayThunder()
         {
-           PlaySound(RandomHelper.RandomList(0x028, 0x206));
+            PlaySound(RandomHelper.RandomList(0x028, 0x206));
         }
 
         private void PlayMinorRain()
@@ -564,6 +564,39 @@ namespace ClassicUO.Game
                     PlayMinorRain();
                 }
             }
+            else
+            {
+                // Update volume to follow system sound effect volume changes
+                UpdateRainSoundVolume();
+            }
+        }
+
+        private void UpdateRainSoundVolume()
+        {
+            if (_currentRainSound == null || !_world.InGame || _world.Player == null)
+            {
+                return;
+            }
+
+            Profile currentProfile = ProfileManager.CurrentProfile;
+            if (currentProfile == null || !currentProfile.EnableSound)
+            {
+                _currentRainSound.Volume = 0;
+                return;
+            }
+
+            const float SOUND_DELTA = 250.0f;
+            float volume = currentProfile.SoundVolume / SOUND_DELTA;
+
+            if (!Client.Game.IsActive && !currentProfile.ReproduceSoundsInBackground)
+            {
+                volume = 0;
+            }
+
+            // Rain sound is kept at 50% of system sound effect volume
+            volume *= RAIN_VOLUME_MULTIPLIER;
+
+            _currentRainSound.Volume = Math.Clamp(volume, 0f, 1.0f);
         }
 
         private void PlaySound(int sound)
@@ -636,11 +669,11 @@ namespace ClassicUO.Game
                     windChanged = true;
                 }
 
-                _windTimer = Time.Ticks + (uint) (RandomHelper.GetValue(13, 19) * 1000);
+                _windTimer = Time.Ticks + (uint)(RandomHelper.GetValue(13, 19) * 1000);
 
                 sbyte lastWind = Wind;
 
-                Wind = (sbyte) RandomHelper.GetValue(0, 4);
+                Wind = (sbyte)RandomHelper.GetValue(0, 4);
 
                 if (RandomHelper.GetValue(0, 2) != 0)
                 {
@@ -689,10 +722,10 @@ namespace ClassicUO.Game
             int winGameCenterY = (winsize.Y >> 1) + (_world.Player.Z << 2);
             winGameCenterX -= (int)_world.Player.Offset.X;
             winGameCenterY -= (int)(_world.Player.Offset.Y - _world.Player.Offset.Z);
-            
+
             int viewportOffsetX = (tileOffX - tileOffY) * 22 - winGameCenterX;
             int viewportOffsetY = (tileOffX + tileOffY) * 22 - winGameCenterY;
-            
+
             int visibleRangeX = winsize.X;
             int visibleRangeY = winsize.Y;
 
@@ -706,7 +739,7 @@ namespace ClassicUO.Game
                 effect.Y = effect.WorldY - viewportOffsetY;
 
                 // Check if particle is outside visible viewport bounds
-                if (effect.X < -visibleRangeX || effect.X > visibleRangeX * 2 || 
+                if (effect.X < -visibleRangeX || effect.X > visibleRangeX * 2 ||
                     effect.Y < -visibleRangeY || effect.Y > visibleRangeY * 2)
                 {
                     if (removeEffects)
@@ -722,15 +755,15 @@ namespace ClassicUO.Game
 
                         continue;
                     }
-                    
+
                     // Respawn particle at top of viewport
                     // Calculate viewport top in world coordinates
                     int viewportTopY = viewportOffsetY - visibleRangeY;
                     int playerAbsIsoX = (tileOffX - tileOffY) * 22;
-                    
+
                     effect.WorldX = playerAbsIsoX + RandomHelper.GetValue(-visibleRangeX, visibleRangeX);
                     effect.WorldY = viewportTopY; // Spawn at exact top of viewport
-                    
+
                     // Recalculate viewport-relative position
                     effect.X = effect.WorldX - viewportOffsetX;
                     effect.Y = effect.WorldY - viewportOffsetY;
@@ -741,13 +774,13 @@ namespace ClassicUO.Game
                     case WeatherType.WT_RAIN:
                         float scaleRatio = effect.ScaleRatio;
                         RainRenderStyle rainStyle = GetRainRenderStyle();
-                        
+
                         // Get depth properties for this particle
                         DepthProperties depthProps = GetDepthProperties(effect.Depth, Type);
-                        
+
                         float baseSpeedY = BASE_RAIN_SPEED_Y;
                         float densitySpeedMultiplier = 1.0f;
-                        
+
                         // Higher density = faster speeds
                         switch (rainStyle)
                         {
@@ -764,7 +797,7 @@ namespace ClassicUO.Game
                                 densitySpeedMultiplier = 2.4f;
                                 break;
                         }
-                        
+
                         // Apply depth-based speed multiplier for parallax effect
                         effect.SpeedX = (BASE_RAIN_SPEED_X - scaleRatio) * densitySpeedMultiplier * depthProps.SpeedMultiplier;
                         effect.SpeedY = (baseSpeedY + scaleRatio) * densitySpeedMultiplier * depthProps.SpeedMultiplier;
@@ -830,9 +863,9 @@ namespace ClassicUO.Game
 
                         if (windChanged)
                         {
-                            effect.SpeedAngle = MathHelper.ToDegrees((float) Math.Atan2(effect.SpeedX, effect.SpeedY));
+                            effect.SpeedAngle = MathHelper.ToDegrees((float)Math.Atan2(effect.SpeedX, effect.SpeedY));
 
-                            effect.SpeedMagnitude = (float) Math.Sqrt(Math.Pow(effect.SpeedX, 2) + Math.Pow(effect.SpeedY, 2));
+                            effect.SpeedMagnitude = (float)Math.Sqrt(Math.Pow(effect.SpeedX, 2) + Math.Pow(effect.SpeedY, 2));
 
                             PlayThunder();
                         }
@@ -846,8 +879,8 @@ namespace ClassicUO.Game
 
                         float rad = MathHelper.ToRadians(speedAngle);
                         // Apply depth-based speed multiplier for parallax effect
-                        effect.SpeedX = speedMagnitude * (float) Math.Sin(rad) * snowStormProps.SpeedMultiplier;
-                        effect.SpeedY = speedMagnitude * (float) Math.Cos(rad) * snowStormProps.SpeedMultiplier;
+                        effect.SpeedX = speedMagnitude * (float)Math.Sin(rad) * snowStormProps.SpeedMultiplier;
+                        effect.SpeedY = speedMagnitude * (float)Math.Cos(rad) * snowStormProps.SpeedMultiplier;
 
                         break;
                 }
@@ -910,7 +943,7 @@ namespace ClassicUO.Game
                                             splashEnabled = SPLASH_ENABLED_LONG_BOLTS;
                                             break;
                                     }
-                                    
+
                                     // Create splash at current position (if enabled)
                                     if (splashEnabled)
                                     {
@@ -938,7 +971,7 @@ namespace ClassicUO.Game
                                     effect.WorldX = playerAbsIsoX + RandomHelper.GetValue(-visibleRangeX, visibleRangeX);
                                     effect.WorldY = viewportTopY; // Spawn at exact top of viewport
                                     effect.RippleCreated = false; // Reset ripple flag for respawned particle
-                                    
+
                                     // Re-randomize fade threshold for next cycle
                                     switch (effect.Depth)
                                     {
@@ -963,35 +996,35 @@ namespace ClassicUO.Game
                                             }
                                             break;
                                     }
-                                    
+
                                     continue; // Skip rendering, particle respawning
                                 }
                             }
-                            
+
                             // Calculate speed-based trail length
                             float speedMagnitude = (float)Math.Sqrt(effect.SpeedX * effect.SpeedX + effect.SpeedY * effect.SpeedY);
-                            
+
                             switch (rainStyle)
                             {
                                 case RainRenderStyle.SmallDots:
                                     // Apply depth-based size multiplier
                                     int smallDotSize = (int)(2 * rainDepthProps.SizeMultiplier);
                                     smallDotSize = Math.Max(2, smallDotSize);
-                                    
+
                                     Rectangle smallDotRect = new Rectangle(
-                                        newX - smallDotSize / 2, 
-                                        newY - smallDotSize / 2, 
-                                        smallDotSize, 
+                                        newX - smallDotSize / 2,
+                                        newY - smallDotSize / 2,
+                                        smallDotSize,
                                         smallDotSize
                                     );
-                                    
+
                                     // Apply alpha and color tint with proper visibility
                                     // 10% blend towards tint
                                     Color smallDotColor = Color.Lerp(Color.LightBlue, rainDepthProps.ColorTint, 0.1f);
                                     // Boost alpha for visibility (minimum 80% even for background)
                                     float smallDotAlpha = Math.Max(0.8f, rainDepthProps.AlphaMultiplier);
                                     smallDotColor *= smallDotAlpha;
-                                    
+
                                     batcher.Draw
                                     (
                                         SolidColorTextureCache.GetTexture(smallDotColor),
@@ -1000,26 +1033,26 @@ namespace ClassicUO.Game
                                         layerDepth
                                     );
                                     break;
-                                
+
                                 case RainRenderStyle.LargeDots:
                                     // Apply depth-based size multiplier
                                     int largeDotSize = (int)(2 * rainDepthProps.SizeMultiplier);
-                                    largeDotSize = Math.Max(2, largeDotSize); 
-                                    
+                                    largeDotSize = Math.Max(2, largeDotSize);
+
                                     Rectangle largeDotRect = new Rectangle(
-                                        newX - largeDotSize / 2, 
-                                        newY - largeDotSize / 2, 
-                                        largeDotSize, 
+                                        newX - largeDotSize / 2,
+                                        newY - largeDotSize / 2,
+                                        largeDotSize,
                                         largeDotSize
                                     );
-                                    
+
                                     // Apply alpha and color tint with better visibility
                                     // 20% blend towards tint
                                     Color largeDotColor = Color.Lerp(Color.CornflowerBlue, rainDepthProps.ColorTint, 0.2f);
                                     // Boost alpha for visibility (minimum 70% even for background)
                                     float largeDotAlpha = Math.Max(0.7f, rainDepthProps.AlphaMultiplier);
                                     largeDotColor *= largeDotAlpha;
-                                    
+
                                     batcher.Draw
                                     (
                                         SolidColorTextureCache.GetTexture(largeDotColor),
@@ -1028,37 +1061,37 @@ namespace ClassicUO.Game
                                         layerDepth
                                     );
                                     break;
-                                
+
                                 case RainRenderStyle.ShortLines:
                                     // Calculate depth-adjusted trail length
                                     float shortBaseTrail = 0.9f;
                                     float shortLineLength = speedMagnitude * shortBaseTrail * rainDepthProps.TrailMultiplier;
                                     int screenOfsx = newX - oldX;
                                     int screenOfsy = newY - oldY;
-                                    
+
                                     if (screenOfsx >= shortLineLength)
                                         oldX = (int)(newX - shortLineLength);
                                     else if (screenOfsx <= -shortLineLength)
                                         oldX = (int)(newX + shortLineLength);
-                                    
+
                                     if (screenOfsy >= shortLineLength)
                                         oldY = (int)(newY - shortLineLength);
                                     else if (screenOfsy <= -shortLineLength)
                                         oldY = (int)(newY + shortLineLength);
-                                    
+
                                     Vector2 shortStart = new Vector2(oldX, oldY);
                                     Vector2 shortEnd = new Vector2(newX, newY);
-                                    
+
                                     // Apply color and alpha - keep rain distinctly blue
                                     // 25% blend towards tint
                                     Color shortLineColor = Color.Lerp(Color.Gray, rainDepthProps.ColorTint, 0.25f);
                                     // Boost alpha for visibility
                                     float shortLineAlpha = Math.Max(0.65f, rainDepthProps.AlphaMultiplier);
                                     shortLineColor *= shortLineAlpha;
-                                    
+
                                     // Apply line width with depth
                                     int shortLineWidth = Math.Max(1, (int)(2 * rainDepthProps.SizeMultiplier));
-                                    
+
                                     batcher.DrawLine
                                     (
                                         SolidColorTextureCache.GetTexture(shortLineColor),
@@ -1069,35 +1102,35 @@ namespace ClassicUO.Game
                                         layerDepth
                                     );
                                     break;
-                                
+
                                 case RainRenderStyle.LongBolts:
                                     // Calculate depth-adjusted trail length
                                     float boltBaseTrail = 1.75f;
                                     float longBoltLength = speedMagnitude * boltBaseTrail * rainDepthProps.TrailMultiplier;
                                     int boltOfsx = newX - oldX;
                                     int boltOfsy = newY - oldY;
-                                    
+
                                     if (boltOfsx >= longBoltLength)
                                         oldX = (int)(newX - longBoltLength);
                                     else if (boltOfsx <= -longBoltLength)
                                         oldX = (int)(newX + longBoltLength);
-                                    
+
                                     if (boltOfsy >= longBoltLength)
                                         oldY = (int)(newY - longBoltLength);
                                     else if (boltOfsy <= -longBoltLength)
                                         oldY = (int)(newY + longBoltLength);
-                                    
+
                                     Vector2 boltStart = new Vector2(oldX, oldY);
                                     Vector2 boltEnd = new Vector2(newX, newY);
-                                    
+
                                     Color boltColor = Color.Lerp(Color.Gray, rainDepthProps.ColorTint, 0.25f);
                                     // Boost alpha for dramatic effect
                                     float boltAlpha = Math.Max(0.75f, rainDepthProps.AlphaMultiplier);
                                     boltColor *= boltAlpha;
-                                    
+
                                     // Apply line width with depth
                                     int boltLineWidth = Math.Max(1, (int)(3 * rainDepthProps.SizeMultiplier));
-                                    
+
                                     batcher.DrawLine
                                     (
                                         SolidColorTextureCache.GetTexture(boltColor),

--- a/src/ClassicUO.Client/Game/Weather.cs
+++ b/src/ClassicUO.Client/Game/Weather.cs
@@ -37,7 +37,7 @@ namespace ClassicUO.Game
         private const int DENSITY_SHORT_LINES = 50;
         // Above 50 = long bolts
 
-        private const float BASE_RAIN_SPEED_Y = 15.0f;
+        private const float BASE_RAIN_SPEED_Y = 20.0f;
         private const float BASE_RAIN_SPEED_X = -2.5f;
         private const float BASE_STORM_APPROACH_SPEED_Y = 6.0f;
         private const float BASE_STORM_APPROACH_SPEED_X = 4.0f;
@@ -1036,7 +1036,7 @@ namespace ClassicUO.Game
                             {
                                 case RainRenderStyle.SmallDots:
                                     // Multi-layer rendering for soft, glowing rain drops
-                                    int smallDotSize = (int)(3 * rainDepthProps.SizeMultiplier);
+                                    int smallDotSize = (int)(2 * rainDepthProps.SizeMultiplier);
                                     smallDotSize = Math.Max(2, smallDotSize);
 
                                     // Base color for small rain drops - light blue
@@ -1135,8 +1135,8 @@ namespace ClassicUO.Game
 
                                 case RainRenderStyle.LargeDots:
                                     // Multi-layer rendering for soft, glowing rain drops
-                                    int largeDotSize = (int)(4 * rainDepthProps.SizeMultiplier);
-                                    largeDotSize = Math.Max(3, largeDotSize);
+                                    int largeDotSize = (int)(3 * rainDepthProps.SizeMultiplier);
+                                    largeDotSize = Math.Max(2, largeDotSize);
 
                                     // Base color for large rain drops - cornflower blue (more saturated)
                                     Color largeDotBaseColor = Color.Lerp(Color.CornflowerBlue, rainDepthProps.ColorTint, 0.2f);

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ClassicUO.IO.Audio;
 using ClassicUO.Game.Data;
+using ClassicUO.Game.Effects;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Map;
@@ -48,6 +49,7 @@ namespace ClassicUO.Game
             CommandManager = new CommandManager(this);
             Weather = new Weather(this);
             RippleEffect = new RippleEffect(this);
+            SplashEffect = new SplashEffect();
             InfoBars = new InfoBarManager(this);
         }
 
@@ -100,6 +102,8 @@ namespace ClassicUO.Game
         public Weather Weather { get; }
 
         public RippleEffect RippleEffect { get; }
+
+        public SplashEffect SplashEffect { get; }
 
         public InfoBarManager InfoBars { get; }
 

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -47,6 +47,7 @@ namespace ClassicUO.Game
             Macros = new MacroManager(this);
             CommandManager = new CommandManager(this);
             Weather = new Weather(this);
+            RippleEffect = new RippleEffect(this);
             InfoBars = new InfoBarManager(this);
         }
 
@@ -97,6 +98,8 @@ namespace ClassicUO.Game
         public CommandManager CommandManager { get; }
 
         public Weather Weather { get; }
+
+        public RippleEffect RippleEffect { get; }
 
         public InfoBarManager InfoBars { get; }
 

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -284,7 +284,16 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("AnimatedWaterEffect", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Weather effects (Splash & Ripples).
+        /// </summary>
+        public static string WeatherEffects {
+            get {
+                return ResourceManager.GetString("WeatherEffects", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Anisotropic Clamp.
         /// </summary>
@@ -3178,7 +3187,16 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("PlayFootsteps", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Play Rain Sound.
+        /// </summary>
+        public static string PlayRainSound {
+            get {
+                return ResourceManager.GetString("PlayRainSound", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Poisoned Color.
         /// </summary>

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -396,6 +396,9 @@
   <data name="PlayFootsteps" xml:space="preserve">
     <value>Play Footsteps</value>
   </data>
+  <data name="PlayRainSound" xml:space="preserve">
+    <value>Play Rain Sound</value>
+  </data>
   <data name="CombatMusic" xml:space="preserve">
     <value>Combat music</value>
   </data>
@@ -482,6 +485,9 @@
   </data>
   <data name="AnimatedWaterEffect" xml:space="preserve">
     <value>Animated water effect</value>
+  </data>
+  <data name="WeatherEffects" xml:space="preserve">
+    <value>Weather effects (Splash &amp; Ripples)</value>
   </data>
   <data name="UseXBREffectBETA" xml:space="preserve">
     <value>Use xBR effect [BETA]</value>

--- a/src/ClassicUO.IO/Audio/Sound.cs
+++ b/src/ClassicUO.IO/Audio/Sound.cs
@@ -168,5 +168,25 @@ namespace ClassicUO.IO.Audio
 
             AfterStop();
         }
+
+        /// <summary>
+        /// Submits additional buffers for seamless looping playback.
+        /// Should be called after Play() when looping is desired.
+        /// </summary>
+        /// <param name="bufferCount">Number of additional buffers to submit (recommended: 2-3 for smooth playback)</param>
+        public void SubmitAdditionalBuffers(int bufferCount)
+        {
+            if (SoundInstance != null && !SoundInstance.IsDisposed && SoundInstance.State == SoundState.Playing)
+            {
+                var buffer = GetBuffer();
+                if (buffer.Count > 0)
+                {
+                    for (int i = 0; i < bufferCount; i++)
+                    {
+                        SoundInstance.SubmitBuffer(buffer.Array, buffer.Offset, buffer.Count);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/ClassicUO.IO/Audio/UOSound.cs
+++ b/src/ClassicUO.IO/Audio/UOSound.cs
@@ -15,6 +15,7 @@ namespace ClassicUO.IO.Audio
         }
 
         public bool CalculateByDistance { get; set; }
+        public bool IsLooping { get; set; }
         public int X, Y;
 
         protected override void OnBufferNeeded(object sender, EventArgs e)
@@ -55,12 +56,22 @@ namespace ClassicUO.IO.Audio
 
             //    VolumeFactor = distanceFactor;
             //    Volume = volume;
-            //}
+            //}            
+
+            // If looping is enabled, resubmit the buffer to create seamless loop
+            if (IsLooping && SoundInstance != null && !SoundInstance.IsDisposed)
+            {
+                var buffer = GetBuffer();
+                if (buffer.Count > 0)
+                {
+                    SoundInstance.SubmitBuffer(buffer.Array, buffer.Offset, buffer.Count);
+                }
+            }
         }
 
         protected override ArraySegment<byte> GetBuffer()
         {
-            return _waveBuffer;
+            return new ArraySegment<byte>(_waveBuffer);
         }
     }
 }

--- a/tests/ClassicUO.UnitTests/Game/Effects/RippleEffectTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/Effects/RippleEffectTests.cs
@@ -1,0 +1,396 @@
+using ClassicUO.Game;
+using ClassicUO.Game.Effects;
+using FluentAssertions;
+using System.Reflection;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Effects
+{
+    public class RippleEffectTests
+    {
+        private int GetActiveRippleCount(RippleEffect rippleEffect)
+        {
+            var field = typeof(RippleEffect).GetField("_ripples", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field == null) return 0;
+
+            var ripples = field.GetValue(rippleEffect);
+            if (ripples == null) return 0;
+
+            var array = ripples as System.Array;
+            if (array == null) return 0;
+
+            int count = 0;
+            for (int i = 0; i < array.Length; i++)
+            {
+                var ripple = array.GetValue(i);
+                if (ripple == null) continue;
+
+                var activeField = ripple.GetType().GetField("Active");
+                if (activeField != null && (bool)activeField.GetValue(ripple))
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        private object GetFirstActiveRipple(RippleEffect rippleEffect)
+        {
+            var field = typeof(RippleEffect).GetField("_ripples", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field == null) return null;
+
+            var ripples = field.GetValue(rippleEffect);
+            if (ripples == null) return null;
+
+            var array = ripples as System.Array;
+            if (array == null) return null;
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                var ripple = array.GetValue(i);
+                if (ripple == null) continue;
+
+                var activeField = ripple.GetType().GetField("Active");
+                if (activeField != null && (bool)activeField.GetValue(ripple))
+                {
+                    return ripple;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Helper method to directly create a ripple for testing (bypasses map check).
+        /// Note: Since Ripple is a struct (value type), we need to get, modify, and set it back.
+        /// </summary>
+        private void CreateRippleDirectly(RippleEffect rippleEffect, float worldX, float worldY, int index = 0)
+        {
+            var field = typeof(RippleEffect).GetField("_ripples", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field == null) return;
+
+            var ripples = field.GetValue(rippleEffect);
+            if (ripples == null) return;
+
+            var array = ripples as System.Array;
+            if (array == null || index >= array.Length) return;
+
+            object ripple = array.GetValue(index);
+            if (ripple == null) return;
+
+            ripple.GetType().GetField("Active").SetValue(ripple, true);
+            ripple.GetType().GetField("WorldX").SetValue(ripple, worldX);
+            ripple.GetType().GetField("WorldY").SetValue(ripple, worldY);
+            ripple.GetType().GetField("LifeTime").SetValue(ripple, 0.0f);
+            ripple.GetType().GetField("MaxRadius").SetValue(ripple, 20.0f);
+            ripple.GetType().GetField("SeedID").SetValue(ripple, (uint)(1000 + index));
+
+            array.SetValue(ripple, index);
+        }
+
+        [Fact]
+        public void CreateRipple_Should_NotCreateRipple_When_MapIsNull()
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+
+            rippleEffect.CreateRipple(100.0f, 200.0f);
+
+            // No ripple should be created when map is null
+            int activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(0, "no ripple should be created when map is null");
+        }
+
+        [Fact]
+        public void CreateRipple_Should_CreateRipple_When_SlotAvailable()
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+            float worldX = 100.0f;
+            float worldY = 200.0f;
+
+            // Create ripple directly (bypassing map check for testing)
+            CreateRippleDirectly(rippleEffect, worldX, worldY, 0);
+
+            // Verify ripple was created
+            int activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(1, "exactly one ripple should be created");
+
+            // Verify ripple properties
+            var ripple = GetFirstActiveRipple(rippleEffect);
+            ripple.Should().NotBeNull("ripple should exist");
+
+            var worldXField = ripple.GetType().GetField("WorldX");
+            var worldYField = ripple.GetType().GetField("WorldY");
+            var lifetimeField = ripple.GetType().GetField("LifeTime");
+            var maxRadiusField = ripple.GetType().GetField("MaxRadius");
+
+            float storedWorldX = (float)worldXField.GetValue(ripple);
+            float storedWorldY = (float)worldYField.GetValue(ripple);
+            float lifetime = (float)lifetimeField.GetValue(ripple);
+            float maxRadius = (float)maxRadiusField.GetValue(ripple);
+
+            storedWorldX.Should().BeApproximately(worldX, 0.01f, "WorldX should be stored correctly");
+            storedWorldY.Should().BeApproximately(worldY, 0.01f, "WorldY should be stored correctly");
+            lifetime.Should().Be(0.0f, "initial lifetime should be 0");
+            maxRadius.Should().Be(20.0f, "MaxRadius should be 20.0f");
+        }
+
+        [Fact]
+        public void CreateRipple_Should_HandleFullPool_Gracefully()
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+
+            // Fill all slots (64 ripples) directly
+            for (int i = 0; i < 64; i++)
+            {
+                CreateRippleDirectly(rippleEffect, i * 10.0f, i * 10.0f, i);
+            }
+
+            // All slots should be filled
+            int activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(64, "all 64 ripple slots should be filled");
+
+            // Try to create one more (pool is full)
+            // Since we're using direct creation, we'll verify the pool is full
+            // In real usage, CreateRipple would find no available slot and not create a ripple
+            CreateRippleDirectly(rippleEffect, 1000.0f, 1000.0f, 0); // Overwrite first slot
+
+            // Count should still be 64 (overwrote existing, didn't create new)
+            activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(64, "pool should remain full");
+        }
+
+        [Theory]
+        [InlineData(0.01f)]
+        [InlineData(0.1f)]
+        [InlineData(0.5f)]
+        public void Update_Should_IncreaseLifetime(float deltaTime)
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+            CreateRippleDirectly(rippleEffect, 100.0f, 200.0f, 0);
+
+            var ripple = GetFirstActiveRipple(rippleEffect);
+            ripple.Should().NotBeNull("ripple should exist");
+
+            var lifetimeField = ripple.GetType().GetField("LifeTime");
+            float initialLifetime = (float)lifetimeField.GetValue(ripple);
+            initialLifetime.Should().Be(0f, "initial lifetime should be 0");
+
+            rippleEffect.Update(deltaTime, 0, 0, 1000, 1000);
+
+            // Lifetime should have increased
+            ripple = GetFirstActiveRipple(rippleEffect);
+            ripple.Should().NotBeNull("ripple should still exist after update");
+
+            float updatedLifetime = (float)lifetimeField.GetValue(ripple);
+            updatedLifetime.Should().BeGreaterThan(initialLifetime,
+                $"lifetime should increase after update with deltaTime={deltaTime}");
+
+            // RIPPLE_DURATION = 0.8f
+            float expectedLifetime = initialLifetime + (deltaTime / 0.8f);
+            updatedLifetime.Should().BeApproximately(expectedLifetime, 0.001f,
+                "lifetime should increase by deltaTime / RIPPLE_DURATION (0.8f)");
+
+            // Verify ripple is still active
+            int activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(1, "ripple should still be active");
+        }
+
+        [Fact]
+        public void Update_Should_DeactivateExpiredRipples()
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+            CreateRippleDirectly(rippleEffect, 100.0f, 200.0f, 0);
+
+            // Verify ripple is initially active
+            int initialActiveCount = GetActiveRippleCount(rippleEffect);
+            initialActiveCount.Should().Be(1, "ripple should be active initially");
+
+            // Update past duration (RIPPLE_DURATION = 0.8f)
+            float totalTime = 1.0f; // Exceeds RIPPLE_DURATION (0.8f), so lifetime = 1.0 / 0.8 = 1.25
+            rippleEffect.Update(totalTime, 0, 0, 1000, 1000);
+
+            // Ripple should be deactivated (lifetime >= 1.0)
+            int activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(0, "ripple should be deactivated after exceeding duration");
+
+            // Verify lifetime is >= 1.0 by checking all ripples
+            var field = typeof(RippleEffect).GetField("_ripples", BindingFlags.NonPublic | BindingFlags.Instance);
+            var ripples = field.GetValue(rippleEffect) as System.Array;
+
+            bool foundExpiredRipple = false;
+            for (int i = 0; i < ripples.Length; i++)
+            {
+                var ripple = ripples.GetValue(i);
+                if (ripple == null) continue;
+
+                var activeField = ripple.GetType().GetField("Active");
+                var lifetimeField = ripple.GetType().GetField("LifeTime");
+
+                if (activeField != null && lifetimeField != null)
+                {
+                    bool isActive = (bool)activeField.GetValue(ripple);
+                    float lifetime = (float)lifetimeField.GetValue(ripple);
+
+                    if (!isActive && lifetime >= 1.0f)
+                    {
+                        foundExpiredRipple = true;
+                        break;
+                    }
+                }
+            }
+
+            foundExpiredRipple.Should().BeTrue("should find an expired ripple with lifetime >= 1.0");
+        }
+
+        [Fact]
+        public void Update_Should_ConvertWorldToViewportCoordinates()
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+            float worldX = 150.0f;
+            float worldY = 250.0f;
+            CreateRippleDirectly(rippleEffect, worldX, worldY, 0);
+
+            int viewportOffsetX = 50;
+            int viewportOffsetY = 75;
+
+            rippleEffect.Update(0.01f, viewportOffsetX, viewportOffsetY, 1000, 1000);
+
+            // Coordinates should be converted: X = 150 - 50 = 100, Y = 250 - 75 = 175
+            var ripple = GetFirstActiveRipple(rippleEffect);
+            ripple.Should().NotBeNull("ripple should exist");
+
+            var xField = ripple.GetType().GetField("X");
+            var yField = ripple.GetType().GetField("Y");
+            var worldXField = ripple.GetType().GetField("WorldX");
+            var worldYField = ripple.GetType().GetField("WorldY");
+
+            float viewportX = (float)xField.GetValue(ripple);
+            float viewportY = (float)yField.GetValue(ripple);
+            float currentWorldX = (float)worldXField.GetValue(ripple);
+            float currentWorldY = (float)worldYField.GetValue(ripple);
+
+            viewportX.Should().BeApproximately(currentWorldX - viewportOffsetX, 0.01f,
+                "X should be converted to viewport coordinates: WorldX - viewportOffsetX");
+            viewportY.Should().BeApproximately(currentWorldY - viewportOffsetY, 0.01f,
+                "Y should be converted to viewport coordinates: WorldY - viewportOffsetY");
+        }
+
+        [Fact]
+        public void Update_Should_CullOffScreenRipples()
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+            CreateRippleDirectly(rippleEffect, 100.0f, 200.0f, 0);
+
+            // Ripple is initially active
+            int initialActiveCount = GetActiveRippleCount(rippleEffect);
+            initialActiveCount.Should().Be(1, "ripple should be active initially");
+
+            // Update with viewport that excludes ripple
+            // Ripple at (100, 200) with viewport offset (10000, 10000) 
+            // results in viewport coords (-9900, -9800) which is off-screen
+            // visibleRange is 100, so ripple at -9900 is outside [-100, 100] range
+            rippleEffect.Update(0.01f, 10000, 10000, 100, 100);
+
+            // Ripple should be culled (deactivated)
+            int activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(0, "ripple should be culled when off-screen");
+        }
+
+        [Fact]
+        public void Update_Should_HandleMultipleRipples()
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+            int rippleCount = 10;
+
+            // Create multiple ripples directly
+            for (int i = 0; i < rippleCount; i++)
+            {
+                CreateRippleDirectly(rippleEffect, i * 10.0f, i * 10.0f, i);
+            }
+
+            // All ripples should be created
+            int activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(rippleCount, $"all {rippleCount} ripples should be created");
+
+            // Update all ripples
+            rippleEffect.Update(0.05f, 0, 0, 1000, 1000);
+
+            // All ripples should still be active (not expired)
+            activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(rippleCount,
+                $"all {rippleCount} ripples should still be active after small update");
+
+            // Update again
+            rippleEffect.Update(0.05f, 0, 0, 1000, 1000);
+
+            // All ripples should still be active
+            activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(rippleCount,
+                $"all {rippleCount} ripples should still be active after second update");
+        }
+
+        [Fact]
+        public void Update_Should_HandleZeroDeltaTime()
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+            CreateRippleDirectly(rippleEffect, 100.0f, 200.0f, 0);
+
+            var ripple = GetFirstActiveRipple(rippleEffect);
+            ripple.Should().NotBeNull("ripple should exist");
+
+            var lifetimeField = ripple.GetType().GetField("LifeTime");
+            float initialLifetime = (float)lifetimeField.GetValue(ripple);
+
+            rippleEffect.Update(0.0f, 0, 0, 1000, 1000);
+
+            // Lifetime should not change with zero delta time
+            ripple = GetFirstActiveRipple(rippleEffect);
+            ripple.Should().NotBeNull("ripple should still exist after zero delta update");
+
+            float updatedLifetime = (float)lifetimeField.GetValue(ripple);
+            updatedLifetime.Should().BeApproximately(initialLifetime, 0.001f,
+                "lifetime should not change with zero delta time");
+
+            // Ripple is still active
+            int activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(1, "ripple should still be active");
+        }
+
+        [Fact]
+        public void Reset_Should_ClearAllRipples()
+        {
+            var world = new World();
+            var rippleEffect = new RippleEffect(world);
+
+            // Create some ripples directly
+            int rippleCount = 5;
+            for (int i = 0; i < rippleCount; i++)
+            {
+                CreateRippleDirectly(rippleEffect, i * 10.0f, i * 10.0f, i);
+            }
+
+            // Verify ripples are created
+            int initialActiveCount = GetActiveRippleCount(rippleEffect);
+            initialActiveCount.Should().Be(rippleCount, $"{rippleCount} ripples should be created");
+
+            rippleEffect.Reset();
+
+            // All ripples should be cleared
+            int activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(0, "all ripples should be cleared after Reset");
+
+            // Verify by updating - no active ripples should remain
+            rippleEffect.Update(0.1f, 0, 0, 1000, 1000);
+            activeCount = GetActiveRippleCount(rippleEffect);
+            activeCount.Should().Be(0, "no ripples should be active after reset and update");
+        }
+    }
+}

--- a/tests/ClassicUO.UnitTests/Game/Effects/SplashEffectTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/Effects/SplashEffectTests.cs
@@ -1,0 +1,453 @@
+using ClassicUO.Game.Effects;
+using FluentAssertions;
+using Microsoft.Xna.Framework;
+using System.Reflection;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Effects
+{
+    public class SplashEffectTests
+    {
+        /// <summary>
+        /// Helper method to get the active particle count using reflection.
+        /// </summary>
+        private int GetActiveParticleCount(SplashEffect splashEffect)
+        {
+            var field = typeof(SplashEffect).GetField("_particles", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field == null) return 0;
+
+            var particles = field.GetValue(splashEffect);
+            if (particles == null) return 0;
+
+            var array = particles as System.Array;
+            if (array == null) return 0;
+
+            int count = 0;
+            for (int i = 0; i < array.Length; i++)
+            {
+                var particle = array.GetValue(i);
+                if (particle == null) continue;
+
+                var activeField = particle.GetType().GetField("Active");
+                if (activeField != null && (bool)activeField.GetValue(particle))
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Helper method to get particle data using reflection.
+        /// </summary>
+        private object GetParticle(SplashEffect splashEffect, int index)
+        {
+            var field = typeof(SplashEffect).GetField("_particles", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field == null) return null;
+
+            var particles = field.GetValue(splashEffect);
+            if (particles == null) return null;
+
+            var array = particles as System.Array;
+            return array?.GetValue(index);
+        }
+
+        /// <summary>
+        /// Helper method to get the first active particle.
+        /// </summary>
+        private object GetFirstActiveParticle(SplashEffect splashEffect)
+        {
+            var field = typeof(SplashEffect).GetField("_particles", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field == null) return null;
+
+            var particles = field.GetValue(splashEffect);
+            if (particles == null) return null;
+
+            var array = particles as System.Array;
+            if (array == null) return null;
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                var particle = array.GetValue(i);
+                if (particle == null) continue;
+
+                var activeField = particle.GetType().GetField("Active");
+                if (activeField != null && (bool)activeField.GetValue(particle))
+                {
+                    return particle;
+                }
+            }
+            return null;
+        }
+
+        [Fact]
+        public void CreateSplash_Should_CreateParticle_When_SlotAvailable()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+
+            splashEffect.CreateSplash(100.0f, 200.0f, config);
+
+            int activeCount = GetActiveParticleCount(splashEffect);
+            activeCount.Should().Be(1, "exactly one particle should be created");
+        }
+
+        [Fact]
+        public void CreateSplash_Should_HandleFullPool_Gracefully()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+
+            for (int i = 0; i < 255; i++)
+            {
+                splashEffect.CreateSplash(i * 10.0f, i * 10.0f, config);
+            }
+
+            int activeCount = GetActiveParticleCount(splashEffect);
+            activeCount.Should().Be(255, "all 255 particle slots should be filled");
+
+            splashEffect.CreateSplash(1000.0f, 1000.0f, config);
+            
+            activeCount = GetActiveParticleCount(splashEffect);
+            activeCount.Should().Be(255, "pool should remain full when attempting to create beyond capacity");
+        }
+
+        [Fact]
+        public void CreateSplash_Should_StoreWorldCoordinates_When_UseWorldCoordinatesIsTrue()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+            config.UseWorldCoordinates = true;
+            config.RiseSpeed = 0.0f;
+            float worldX = 150.0f;
+            float worldY = 250.0f;
+
+            splashEffect.CreateSplash(worldX, worldY, config);
+
+            var particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should exist");
+
+            var worldXField = particle.GetType().GetField("WorldX");
+            var worldYField = particle.GetType().GetField("WorldY");
+            
+            float storedWorldX = (float)worldXField.GetValue(particle);
+            float storedWorldY = (float)worldYField.GetValue(particle);
+            
+            storedWorldX.Should().BeApproximately(worldX, 0.01f, "WorldX should be stored correctly");
+            storedWorldY.Should().BeApproximately(worldY, 0.01f, "WorldY should be stored correctly");
+
+            int viewportOffsetX = 50;
+            int viewportOffsetY = 75;
+            splashEffect.Update(0.01f, viewportOffsetX, viewportOffsetY, 1000, 1000);
+            
+            particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should still exist after update");
+            
+            var xField = particle.GetType().GetField("X");
+            var yField = particle.GetType().GetField("Y");
+            float currentWorldX = (float)worldXField.GetValue(particle);
+            float currentWorldY = (float)worldYField.GetValue(particle);
+            
+            float viewportX = (float)xField.GetValue(particle);
+            float viewportY = (float)yField.GetValue(particle);
+            
+            viewportX.Should().BeApproximately(currentWorldX - viewportOffsetX, 0.01f, 
+                "X should be converted to viewport coordinates");
+            viewportY.Should().BeApproximately(currentWorldY - viewportOffsetY, 0.01f, 
+                "Y should be converted to viewport coordinates");
+        }
+
+        [Fact]
+        public void CreateSplash_Should_StoreViewportCoordinates_When_UseWorldCoordinatesIsFalse()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+            config.UseWorldCoordinates = false;
+            float viewportX = 100.0f;
+            float viewportY = 200.0f;
+
+            splashEffect.CreateSplash(viewportX, viewportY, config);
+
+            var particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should exist");
+
+            var xField = particle.GetType().GetField("X");
+            var yField = particle.GetType().GetField("Y");
+            var worldXField = particle.GetType().GetField("WorldX");
+            var worldYField = particle.GetType().GetField("WorldY");
+            
+            float storedX = (float)xField.GetValue(particle);
+            float storedY = (float)yField.GetValue(particle);
+            float storedWorldX = (float)worldXField.GetValue(particle);
+            float storedWorldY = (float)worldYField.GetValue(particle);
+            
+            storedX.Should().BeApproximately(viewportX, 0.01f, "X should be stored directly");
+            storedY.Should().BeApproximately(viewportY, 0.01f, "Y should be stored directly");
+            storedWorldX.Should().Be(0f, "WorldX should be 0 in viewport mode");
+            storedWorldY.Should().Be(0f, "WorldY should be 0 in viewport mode");
+
+            splashEffect.Update(0.01f, 50, 75, 1000, 1000);
+            
+            particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should still exist after update");
+            
+            float updatedX = (float)xField.GetValue(particle);
+            float updatedY = (float)yField.GetValue(particle);
+            
+            updatedX.Should().BeApproximately(viewportX, 0.01f, 
+                "X should remain unchanged in viewport mode");
+            updatedY.Should().BeApproximately(viewportY, 0.01f, 
+                "Y should remain unchanged in viewport mode");
+        }
+
+        [Theory]
+        [InlineData(0.01f)]
+        [InlineData(0.05f)]
+        [InlineData(0.1f)]
+        public void Update_Should_IncreaseLifetime(float deltaTime)
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+            config.Duration = 0.15f;
+            splashEffect.CreateSplash(100.0f, 200.0f, config);
+
+            var particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should exist");
+            
+            var lifetimeField = particle.GetType().GetField("LifeTime");
+            float initialLifetime = (float)lifetimeField.GetValue(particle);
+            initialLifetime.Should().Be(0f, "initial lifetime should be 0");
+
+            splashEffect.Update(deltaTime, 0, 0, 1000, 1000);
+
+            // Lifetime should have increased
+            particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should still exist after update");
+            
+            float updatedLifetime = (float)lifetimeField.GetValue(particle);
+            updatedLifetime.Should().BeGreaterThan(initialLifetime, 
+                $"lifetime should increase after update with deltaTime={deltaTime}");
+            
+            float expectedLifetime = initialLifetime + (deltaTime / config.Duration);
+            updatedLifetime.Should().BeApproximately(expectedLifetime, 0.001f, 
+                "lifetime should increase by deltaTime / Duration");
+
+            int activeCount = GetActiveParticleCount(splashEffect);
+            activeCount.Should().Be(1, "particle should still be active");
+        }
+
+        [Fact]
+        public void Update_Should_DeactivateExpiredParticles()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+            config.Duration = 0.15f;
+            splashEffect.CreateSplash(100.0f, 200.0f, config);
+
+            int initialActiveCount = GetActiveParticleCount(splashEffect);
+            initialActiveCount.Should().Be(1, "particle should be active initially");
+
+            // Update past duration
+            float totalTime = config.Duration + 0.1f;
+            splashEffect.Update(totalTime, 0, 0, 1000, 1000);
+
+            // Particle should be deactivated (lifetime >= 1.0)
+            int activeCount = GetActiveParticleCount(splashEffect);
+            activeCount.Should().Be(0, "particle should be deactivated after exceeding duration");
+
+            // Verify lifetime is >= 1.0 by checking all particles
+            var field = typeof(SplashEffect).GetField("_particles", BindingFlags.NonPublic | BindingFlags.Instance);
+            var particles = field.GetValue(splashEffect) as System.Array;
+            
+            bool foundExpiredParticle = false;
+            for (int i = 0; i < particles.Length; i++)
+            {
+                var particle = particles.GetValue(i);
+                if (particle == null) continue;
+                
+                var activeField = particle.GetType().GetField("Active");
+                var lifetimeField = particle.GetType().GetField("LifeTime");
+                
+                if (activeField != null && lifetimeField != null)
+                {
+                    bool isActive = (bool)activeField.GetValue(particle);
+                    float lifetime = (float)lifetimeField.GetValue(particle);
+                    
+                    if (!isActive && lifetime >= 1.0f)
+                    {
+                        foundExpiredParticle = true;
+                        break;
+                    }
+                }
+            }
+            
+            foundExpiredParticle.Should().BeTrue("should find an expired particle with lifetime >= 1.0");
+        }
+
+        [Fact]
+        public void Update_Should_CullOffScreenParticles()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+            config.UseWorldCoordinates = true;
+            splashEffect.CreateSplash(100.0f, 200.0f, config);
+
+            // Verify particle is initially active
+            int initialActiveCount = GetActiveParticleCount(splashEffect);
+            initialActiveCount.Should().Be(1, "particle should be active initially");
+
+            // Update with viewport that excludes particle
+            // Particle at (100, 200) with viewport offset (10000, 10000) 
+            // results in viewport coords (-9900, -9800) which is off-screen
+            // visibleRange is 100, so particle at -9900 is outside [-100, 200] range
+            splashEffect.Update(0.01f, 10000, 10000, 100, 100);
+
+            // Particle should be culled (deactivated)
+            int activeCount = GetActiveParticleCount(splashEffect);
+            activeCount.Should().Be(0, "particle should be culled when off-screen");
+        }
+
+        [Fact]
+        public void Update_Should_ApplyPhysics_When_UseWorldCoordinatesIsTrue()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+            config.UseWorldCoordinates = true;
+            config.RiseSpeed = -3.0f; // Nagative = Upward velocity
+            float initialWorldY = 200.0f;
+            splashEffect.CreateSplash(100.0f, initialWorldY, config);
+
+            var particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should exist");
+            
+            var worldYField = particle.GetType().GetField("WorldY");
+            var velocityYField = particle.GetType().GetField("VelocityY");
+            float initialY = (float)worldYField.GetValue(particle);
+            float velocityY = (float)velocityYField.GetValue(particle);
+            
+            initialY.Should().BeApproximately(initialWorldY, 0.01f, "initial WorldY should match input");
+            velocityY.Should().BeApproximately(config.RiseSpeed, 0.01f, "VelocityY should match config");
+
+            float deltaTime = 0.1f;
+            splashEffect.Update(deltaTime, 0, 0, 1000, 1000);
+
+            // Physics should be applied (WorldY should change)
+            // Get particle again after update to ensure we read updated values
+            particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should still exist after update");
+            
+            float updatedY = (float)worldYField.GetValue(particle);
+            float expectedY = initialY + (config.RiseSpeed * deltaTime * 37.0f);
+            
+            updatedY.Should().BeApproximately(expectedY, 0.01f, 
+                "WorldY should change according to physics: WorldY += RiseSpeed * deltaTime * 37.0");
+            updatedY.Should().BeLessThan(initialY, 
+                "WorldY should decrease (move upward) with negative RiseSpeed");
+        }
+
+        [Fact]
+        public void Update_Should_NotApplyPhysics_When_UseWorldCoordinatesIsFalse()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+            config.UseWorldCoordinates = false;
+            config.RiseSpeed = -3.0f;
+            float initialY = 200.0f;
+            splashEffect.CreateSplash(100.0f, initialY, config);
+
+            var particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should exist");
+            
+            var yField = particle.GetType().GetField("Y");
+            var worldYField = particle.GetType().GetField("WorldY");
+            
+            float initialViewportY = (float)yField.GetValue(particle);
+            float initialWorldY = (float)worldYField.GetValue(particle);
+
+            splashEffect.Update(0.1f, 0, 0, 1000, 1000);
+
+            // No physics applied in viewport mode
+            // Get particle again after update
+            particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should still exist after update");
+            
+            float updatedViewportY = (float)yField.GetValue(particle);
+            float updatedWorldY = (float)worldYField.GetValue(particle);
+            
+            updatedViewportY.Should().BeApproximately(initialViewportY, 0.01f, 
+                "viewport Y should not change (no physics in viewport mode)");
+            updatedWorldY.Should().Be(initialWorldY, 
+                "WorldY should remain 0 in viewport mode");
+        }
+
+        [Fact]
+        public void Update_Should_ConvertWorldToViewportCoordinates()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+            config.UseWorldCoordinates = true;
+            config.RiseSpeed = 0.0f;
+            float worldX = 150.0f;
+            float worldY = 250.0f;
+            splashEffect.CreateSplash(worldX, worldY, config);
+
+            int viewportOffsetX = 50;
+            int viewportOffsetY = 75;
+
+            splashEffect.Update(0.01f, viewportOffsetX, viewportOffsetY, 1000, 1000);
+
+            // Coordinates should be converted: X = 150 - 50 = 100, Y = 250 - 75 = 175
+            var particle = GetFirstActiveParticle(splashEffect);
+            particle.Should().NotBeNull("particle should exist");
+            
+            var xField = particle.GetType().GetField("X");
+            var yField = particle.GetType().GetField("Y");
+            var worldXField = particle.GetType().GetField("WorldX");
+            var worldYField = particle.GetType().GetField("WorldY");
+            
+            float viewportX = (float)xField.GetValue(particle);
+            float viewportY = (float)yField.GetValue(particle);
+            float currentWorldX = (float)worldXField.GetValue(particle);
+            float currentWorldY = (float)worldYField.GetValue(particle);
+            
+            viewportX.Should().BeApproximately(currentWorldX - viewportOffsetX, 0.01f, 
+                "X should be converted to viewport coordinates: WorldX - viewportOffsetX");
+            viewportY.Should().BeApproximately(currentWorldY - viewportOffsetY, 0.01f, 
+                "Y should be converted to viewport coordinates: WorldY - viewportOffsetY");
+        }
+
+        [Fact]
+        public void Update_Should_HandleMultipleParticles()
+        {
+            var splashEffect = new SplashEffect();
+            var config = SplashConfig.WaterSplash();
+            int particleCount = 10;
+
+            // Create multiple particles
+            for (int i = 0; i < particleCount; i++)
+            {
+                splashEffect.CreateSplash(i * 10.0f, i * 10.0f, config);
+            }
+
+            // All particles should be created
+            int activeCount = GetActiveParticleCount(splashEffect);
+            activeCount.Should().Be(particleCount, $"all {particleCount} particles should be created");
+
+            // Update all particles
+            splashEffect.Update(0.05f, 0, 0, 1000, 1000);
+
+            // All particles should still be active
+            activeCount = GetActiveParticleCount(splashEffect);
+            activeCount.Should().Be(particleCount, 
+                $"all {particleCount} particles should still be active after small update");
+
+            // Update again
+            splashEffect.Update(0.05f, 0, 0, 1000, 1000);
+
+            // All particles should still be active
+            activeCount = GetActiveParticleCount(splashEffect);
+            activeCount.Should().Be(particleCount, 
+                $"all {particleCount} particles should still be active after second update");
+        }
+    }
+}

--- a/tests/ClassicUO.UnitTests/Game/Map/CoordinateHelperTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/Map/CoordinateHelperTests.cs
@@ -1,0 +1,66 @@
+using ClassicUO.Game.Map;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Map
+{
+    public class CoordinateHelperTest
+    {
+        [Theory]
+        [InlineData(0.0f, 0.0f, 0, 0)]
+        [InlineData(44.0f, 0.0f, 1, -1)]  // tileX = (44+0)/44 = 1, tileY = (0-44)/44 = -1
+        [InlineData(0.0f, 44.0f, 1, 1)]   // tileX = (0+44)/44 = 1, tileY = (44-0)/44 = 1
+        [InlineData(44.0f, 44.0f, 2, 0)]  // tileX = (44+44)/44 = 2, tileY = (44-44)/44 = 0
+        [InlineData(22.0f, 22.0f, 1, 0)]  // tileX = (22+22)/44 = 1, tileY = (22-22)/44 = 0
+        [InlineData(88.0f, 0.0f, 2, -2)]  // tileX = (88+0)/44 = 2, tileY = (0-88)/44 = -2
+        [InlineData(0.0f, 88.0f, 2, 2)]   // tileX = (0+88)/44 = 2, tileY = (88-0)/44 = 2
+        public void Should_ConvertIsometricToTileCoordinates(
+            float worldX, float worldY, int expectedTileX, int expectedTileY)
+        {
+            (int targetTileX, int targetTileY) = CoordinateHelper.IsometricToTile(worldX, worldY);
+
+            targetTileX.Should().Be(expectedTileX, 
+                $"worldX={worldX}, worldY={worldY} should convert to tileX={expectedTileX}");
+            targetTileY.Should().Be(expectedTileY,
+                $"worldX={worldX}, worldY={worldY} should convert to tileY={expectedTileY}");
+        }
+        
+        [Fact]
+        public void Should_HandleNegativeCoordinates()
+        {
+            float worldX = -44.0f;
+            float worldY = -44.0f;
+
+            (int targetTileX, int targetTileY) = CoordinateHelper.IsometricToTile(worldX, worldY);
+
+            targetTileX.Should().Be(-2);
+            targetTileY.Should().Be(0);
+        }
+        
+        [Fact]
+        public void Should_HandleLargeCoordinates()
+        {
+            float worldX = 4400.0f;
+            float worldY = 4400.0f;
+
+            (int targetTileX, int targetTileY) = CoordinateHelper.IsometricToTile(worldX, worldY);
+
+            targetTileX.Should().Be(200);
+            targetTileY.Should().Be(0);
+        }
+        
+        [Theory]
+        [InlineData(21.9f, 22.1f, 1, 0)]  // tileX = (21.9+22.1)/44 = 1, tileY = (22.1-21.9)/44 = 0
+        [InlineData(22.1f, 21.9f, 1, 0)]  // tileX = (22.1+21.9)/44 = 1, tileY = (21.9-22.1)/44 = 0
+        [InlineData(43.9f, 0.1f, 1, -1)]  // tileX = (43.9+0.1)/44 = 1, tileY = (0.1-43.9)/44 = -1
+        [InlineData(44.1f, 0.1f, 1, -1)]  // tileX = (44.1+0.1)/44 = 1, tileY = (0.1-44.1)/44 = -1
+        public void Should_HandleRoundingCorrectly(
+            float worldX, float worldY, int expectedTileX, int expectedTileY)
+        {
+            (int targetTileX, int targetTileY) = CoordinateHelper.IsometricToTile(worldX, worldY);
+
+            targetTileX.Should().Be(expectedTileX);
+            targetTileY.Should().Be(expectedTileY);
+        }
+    }
+}

--- a/tests/ClassicUO.UnitTests/Game/WeatherTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/WeatherTests.cs
@@ -1,0 +1,306 @@
+using ClassicUO.Game;
+using ClassicUO.Renderer;
+using FluentAssertions;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game
+{
+    /// <summary>
+    /// Unit tests for Weather class defensive programming patterns.
+    /// Tests focus on graceful degradation and error handling.
+    /// </summary>
+    public class WeatherTests
+    {
+        #region Helper Methods
+
+        private static Texture2D GetWhiteTexture()
+        {
+            var property = typeof(Weather).GetProperty("WhiteTexture", BindingFlags.NonPublic | BindingFlags.Static);
+            return property?.GetValue(null) as Texture2D;
+        }
+
+        private static bool GetWhiteTextureInitFailed()
+        {
+            var field = typeof(Weather).GetField("_whiteTextureInitFailed", BindingFlags.NonPublic | BindingFlags.Static);
+            return field != null && (bool)field.GetValue(null);
+        }
+
+        private static void SetWhiteTextureInitFailed(bool value)
+        {
+            var field = typeof(Weather).GetField("_whiteTextureInitFailed", BindingFlags.NonPublic | BindingFlags.Static);
+            field?.SetValue(null, value);
+        }
+
+        private static void SetWhiteTexture(Texture2D texture)
+        {
+            var field = typeof(Weather).GetField("_whiteTexture", BindingFlags.NonPublic | BindingFlags.Static);
+            field?.SetValue(null, texture);
+        }
+
+        private static void ResetWarningState()
+        {
+            var field = typeof(Weather).GetField("_whiteTextureWarningLogged", BindingFlags.NonPublic | BindingFlags.Static);
+            field?.SetValue(null, false);
+        }
+
+        private static Vector3 InvokeColorToVector3(Color color)
+        {
+            var method = typeof(Weather).GetMethod("ColorToVector3", BindingFlags.NonPublic | BindingFlags.Static);
+            return (Vector3)method.Invoke(null, new object[] { color });
+        }
+
+        private static bool InvokeSafeDraw(UltimaBatcher2D batcher, Texture2D texture, Rectangle rect, Vector3 color, float depth)
+        {
+            var method = typeof(Weather).GetMethod("SafeDraw", BindingFlags.NonPublic | BindingFlags.Static);
+            return (bool)method.Invoke(null, new object[] { batcher, texture, rect, color, depth });
+        }
+
+        private static bool InvokeSafeDrawLine(UltimaBatcher2D batcher, Texture2D texture, Vector2 start, Vector2 end, Vector3 color, int width, float depth)
+        {
+            var method = typeof(Weather).GetMethod("SafeDrawLine", BindingFlags.NonPublic | BindingFlags.Static);
+            return (bool)method.Invoke(null, new object[] { batcher, texture, start, end, color, width, depth });
+        }
+
+        #endregion
+
+        #region ColorToVector3 Tests
+
+        [Fact]
+        public void ColorToVector3_Should_ConvertValidColor_Correctly()
+        {
+            var color = new Color(255, 128, 64, 255);
+
+            Vector3 result = InvokeColorToVector3(color);
+
+            result.X.Should().BeApproximately(1.0f, 0.01f, "Red should be 255/255 = 1.0");
+            result.Y.Should().BeApproximately(0.502f, 0.01f, "Green should be 128/255 ≈ 0.502");
+            result.Z.Should().BeApproximately(0.251f, 0.01f, "Blue should be 64/255 ≈ 0.251");
+        }
+
+        [Fact]
+        public void ColorToVector3_Should_ClampNegativeValues_ToZero()
+        {
+            var color = new Color(-1, -1, -1, -255);
+
+            Vector3 result = InvokeColorToVector3(color);
+
+            result.X.Should().BeGreaterOrEqualTo(0f, "Red should be clamped to >= 0");
+            result.Y.Should().BeGreaterOrEqualTo(0f, "Green should be clamped to >= 0");
+            result.Z.Should().BeGreaterOrEqualTo(0f, "Blue should be clamped to >= 0");
+        }
+
+        [Fact]
+        public void ColorToVector3_Should_ClampValues_ToValidRange()
+        {
+            var color = new Color(260, 260, 260, 260);
+
+            Vector3 result = InvokeColorToVector3(color);
+
+            result.X.Should().BeLessOrEqualTo(1f, "Red should be clamped to <= 1.0");
+            result.Y.Should().BeLessOrEqualTo(1f, "Green should be clamped to <= 1.0");
+            result.Z.Should().BeLessOrEqualTo(1f, "Blue should be clamped to <= 1.0");
+        }
+
+        [Fact]
+        public void ColorToVector3_Should_HandleWhiteColor()
+        {
+            var color = Color.White;
+
+            Vector3 result = InvokeColorToVector3(color);
+
+            result.Should().Be(new Vector3(1f, 1f, 1f), "White color should convert to (1, 1, 1)");
+        }
+        #endregion
+
+        #region SafeDraw Tests
+
+        [Fact]
+        public void SafeDraw_Should_ReturnFalse_When_TextureIsNull()
+        {
+            UltimaBatcher2D batcher = null; 
+            Texture2D texture = null;
+            Rectangle rect = new Rectangle(0, 0, 10, 10);
+            Vector3 color = Vector3.One;
+            float depth = 0.5f;
+
+            bool result = InvokeSafeDraw(batcher, texture, rect, color, depth);
+
+            result.Should().BeFalse("SafeDraw should return false when texture is null");
+        }
+
+        [Fact]
+        public void SafeDraw_Should_ReturnFalse_When_BatcherIsNull()
+        {
+            UltimaBatcher2D batcher = null;
+            Texture2D texture = null;
+            Rectangle rect = new Rectangle(0, 0, 10, 10);
+            Vector3 color = Vector3.One;
+            float depth = 0.5f;
+
+            bool result = InvokeSafeDraw(batcher, texture, rect, color, depth);
+
+            result.Should().BeFalse("SafeDraw should return false when batcher is null");
+        }
+
+        #endregion
+
+        #region SafeDrawLine Tests
+
+        [Fact]
+        public void SafeDrawLine_Should_ReturnFalse_When_TextureIsNull()
+        {
+            UltimaBatcher2D batcher = null;
+            Texture2D texture = null;
+            Vector2 start = new Vector2(0, 0);
+            Vector2 end = new Vector2(10, 10);
+            Vector3 color = Vector3.One;
+            int width = 2;
+            float depth = 0.5f;
+
+            bool result = InvokeSafeDrawLine(batcher, texture, start, end, color, width, depth);
+
+            result.Should().BeFalse("SafeDrawLine should return false when texture is null");
+        }
+
+        [Fact]
+        public void SafeDrawLine_Should_ReturnFalse_When_BatcherIsNull()
+        {
+            UltimaBatcher2D batcher = null;
+            Texture2D texture = null;
+            Vector2 start = new Vector2(0, 0);
+            Vector2 end = new Vector2(10, 10);
+            Vector3 color = Vector3.One;
+            int width = 2;
+            float depth = 0.5f;
+
+            bool result = InvokeSafeDrawLine(batcher, texture, start, end, color, width, depth);
+
+            result.Should().BeFalse("SafeDrawLine should return false when batcher is null");
+        }
+
+        #endregion
+
+        #region WhiteTexture Initialization Tests
+
+        [Fact]
+        public void WhiteTexture_Should_ReturnNull_When_InitializationFailed()
+        {
+            SetWhiteTexture(null);
+            SetWhiteTextureInitFailed(true);
+            ResetWarningState();
+
+            Texture2D result = GetWhiteTexture();
+
+            result.Should().BeNull("WhiteTexture should return null when initialization previously failed");
+
+            SetWhiteTextureInitFailed(false);
+        }
+
+        [Fact]
+        public void WhiteTexture_Should_TrackFailureState_WhenInitFails()
+        {
+            SetWhiteTexture(null);
+            SetWhiteTextureInitFailed(false);
+            ResetWarningState();
+
+            SetWhiteTextureInitFailed(true);
+            bool failureState = GetWhiteTextureInitFailed();
+
+            failureState.Should().BeTrue("Failure state should be tracked");
+
+            SetWhiteTextureInitFailed(false);
+        }
+
+        #endregion
+
+        #region Integration Tests
+
+        [Fact]
+        public void Weather_Should_HandleNullWorld_Gracefully()
+        {
+            World world = null;
+
+            Action act = () => new Weather(world);
+
+            act.Should().NotThrow("Weather constructor should handle null world gracefully");
+        }
+
+        [Fact]
+        public void ColorToVector3_Should_HandleMultipleColors_Consistently()
+        {
+            var colors = new[]
+            {
+                Color.Red,
+                Color.Green,
+                Color.Blue,
+                Color.Yellow,
+                Color.Magenta,
+                Color.Cyan
+            };
+
+            foreach (var color in colors)
+            {
+                Vector3 result = InvokeColorToVector3(color);
+
+                result.X.Should().BeInRange(0f, 1f, $"{color} X component should be in valid range");
+                result.Y.Should().BeInRange(0f, 1f, $"{color} Y component should be in valid range");
+                result.Z.Should().BeInRange(0f, 1f, $"{color} Z component should be in valid range");
+            }
+        }
+
+        #endregion
+
+        #region Warning Logging Tests
+
+        [Fact]
+        public void LogWarning_Should_OnlyLogOnce()
+        {
+            ResetWarningState();
+
+            var warningLoggedField = typeof(Weather).GetField("_whiteTextureWarningLogged", BindingFlags.NonPublic | BindingFlags.Static);
+            bool initialState = (bool)warningLoggedField.GetValue(null);
+
+            initialState.Should().BeFalse("Warning state should be reset initially");
+        }
+
+        #endregion
+
+        #region Edge Case Tests
+
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(128, 128, 128)]
+        [InlineData(255, 255, 255)]
+        [InlineData(64, 128, 192)]
+        public void ColorToVector3_Should_HandleVariousRGBValues(byte r, byte g, byte b)
+        {
+            var color = new Color(r, g, b);
+
+            Vector3 result = InvokeColorToVector3(color);
+
+            result.X.Should().BeApproximately(r / 255f, 0.01f, "Red conversion should be accurate");
+            result.Y.Should().BeApproximately(g / 255f, 0.01f, "Green conversion should be accurate");
+            result.Z.Should().BeApproximately(b / 255f, 0.01f, "Blue conversion should be accurate");
+        }
+
+        [Fact]
+        public void SafeDraw_And_SafeDrawLine_Should_HandleNullGracefully()
+        {
+            UltimaBatcher2D nullBatcher = null;
+            Texture2D nullTexture = null;
+
+            bool drawResult = InvokeSafeDraw(nullBatcher, nullTexture, Rectangle.Empty, Vector3.Zero, 0f);
+            drawResult.Should().BeFalse("SafeDraw should gracefully handle null parameters");
+
+            bool drawLineResult = InvokeSafeDrawLine(nullBatcher, nullTexture, Vector2.Zero, Vector2.Zero, Vector3.Zero, 1, 0f);
+            drawLineResult.Should().BeFalse("SafeDrawLine should gracefully handle null parameters");
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Description

This PR addresses a weather particle positioning bug and proposals a configurable weather rendering enhancements (configirations haven't been implemented)

[Demo Video on Youtube](https://youtu.be/wIwxsSMqvAc?si=PUjoajL4rxuJVSMD)

---

## Scope & PR Structure Note

I understand that best practice is to separate a core bug fix and visual/immersive enhancements into two independent PRs. In this case, the immersive weather changes are included only as a proposal for discussion and review, not as a requirement for merging.

If maintainers prefer, I am very happy to:

+ Extract the weather particle positioning fix into a separate, bug-fix-only PR

+ Submit the immersive weather enhancements as a follow-up PR, or keep them purely conceptual until scope is confirmed

Please feel free to advise on the preferred approach.

---

## 🐛 Bug Fix

### Issue

Rain and snow particles were incorrectly following the player around. It looked like a raining/snowing buble was stuck to the player instead of being part of the actual game world. 

### Solution

Fixed it by:
- Implementing a proper world-space coordinate system using isometric world coordinates
- Adding viewport offset calculations to convert between world space and viewport space
- Making sure particles maintain their position in the game world regardless of player movement
- Fixing particle respawn logic to use world coordinates instead of viewport-relative positions

### Impact

✅ Weather particles now behave correctly and exist independently in world space  

---

## ✨ Immersive Weather Enhancements (Proposal)

### 🌧️ Rain Effects

#### Three-Layer Depth System

It adds a depth system that makes rain look way more realistic:
- **Background Layer** (0-30% viewport height): Distant particles that fade out early - gives that atmospheric depth feel
- **Middle Layer** (31-70% viewport height): Mid-range particles that fade out in middle range of the screen
- **Foreground Layer** (71-100% viewport height): Close particles that have a 50% chance to never fade - for the realistic raining view on screen perspective

#### Dynamic Splash Effects

Rain now creates water splashes when it hits the ground.

Splash sizing is also depth-aware - distant splashes are smaller (3 droplets), middle ones are medium (6 droplets), and close ones are larger (10 droplets)

- ~~[ ] I might remove this feature later if it doesn't add much value (To be honestly the splash sizing is not really noticeable in practice)~~
- [x] Avoid splash when rain drops on building / floor tiles.

#### Ripple Effects on Water

When rain hits water tiles, it creates ripples on the surface. 

#### Density-Based Rendering Styles

The visual style adapts to how heavy the rain is:
- **Small Dots** (0-10): Light drizzle
- **Large Dots** (11-30): Moderate rain
- **Short Lines** (31-50): Heavy rain streaks
- **Long Bolts** (50-70): Full-on storm conditions

Speed also scales with density

#### Density-Based Raining Sound Effects
0-50: 0x011
50-70: 0x010

#### UI Toggles:
Options -> Video -> Misc -> Weather effects (Splash & Ripples)
Opitons -> Sounds -> Play Rain Sound

### ❄️ Snow Effects

#### Three-Layer Depth System

Same depth layer system as rain, so everything stays consistent. Particles fade naturally as they reach ground level, which creates a nice snow accumulation visual effect.

#### Vertical Fall with Wind Influence

Snow now falls down. Wind adds horizontal drift with a 0.8x strength multiplier. Removed the old oscillating angle system that made snow drift around weirdly - now it stays mostly vertical with just a subtle wind influence. 

#### Density-Based Rendering

Snow scales with intensity just like rain:
- **Light Flakes** (0-17): Small, slow particles
- **Medium Flakes** (18-35): Moderate size and speed
- **Heavy Flakes** (36-52): Larger, faster particles
- **Blizzard** (53-70): Biggest, fastest particles

Both size and speed multiplier go from 1.0x to 2.0x based on density.

#### Semi-Transparent Soft Edges

Each snowflake gets rendered with a four-layer gradient to create soft, circular edges. The alpha goes from 25% (transparent outer edge) → 45% → 70% → 100% (opaque core). This makes the edges blend naturally into the background and gives it a much more polished look. 

---

## ⚠️ Scope & Performance Considerations

### Immersive Enhancement Scope

**Question for Review**: These enhancements look great and really improve immersion, but I’m not sure whether they are within the scope of the ClassicUO project. If they are in scope, should they be placed behind configuration flags in the Settings? I think they should probably be optional, especially for web client users. Another concern is that some users may be annoyed by the particle effects and therefore prefer to disable them.

### Performance Impact

Here's what to expect:
- Additional rendering layers per particle (3-4 draw calls per snowflake for the soft edge effect - can be toggled off if necessary)
- Splash and ripple effect systems add some overhead (though particle counts limited in 256)
- Depth-based calculations are pretty minimal - shouldn't be a big deal for modern CPU
- Modern desktop hardware should handle this fine, but **I have a bit concerned about web client performance**

~~### Fallback Behavior~~

~~When enhanced effects are disabled, it could apply simplified rendering:~~
~~- Single-layer particles (no depth system)~~
~~- No splash/ripple effects~~
~~- Solid snow particles (no gradient)~~