### PR TITLE
Screen scale

### DIFF
--- a/src/ClassicUO.Client/Configuration/Settings.cs
+++ b/src/ClassicUO.Client/Configuration/Settings.cs
@@ -56,6 +56,8 @@ namespace ClassicUO.Configuration
 
         [JsonPropertyName("fps")] public int FPS { get; set; } = 60;
 
+        [JsonPropertyName("screen_scale")] public float ScreenScale { get; set; } = 1f;
+
         [JsonConverter(typeof(NullablePoint2Converter))] [JsonPropertyName("window_position")] public Point? WindowPosition { get; set; }
         [JsonConverter(typeof(NullablePoint2Converter))] [JsonPropertyName("window_size")] public Point? WindowSize { get; set; }
 

--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -80,8 +80,8 @@ namespace ClassicUO.Game
             {
                 OptionsGump optionsGump = new OptionsGump(world)
                 {
-                    X = (Client.Game.Window.ClientBounds.Width >> 1) - 300,
-                    Y = (Client.Game.Window.ClientBounds.Height >> 1) - 250
+                    X = (Client.Game.ClientBounds.Width >> 1) - 300,
+                    Y = (Client.Game.ClientBounds.Height >> 1) - 250
                 };
 
                 UIManager.Add(optionsGump);

--- a/src/ClassicUO.Client/Game/GameCursor.cs
+++ b/src/ClassicUO.Client/Game/GameCursor.cs
@@ -91,6 +91,10 @@ namespace ClassicUO.Game
             _tooltip = new Tooltip(world);
             _aura = new Aura(30);
 
+            CreateGraphic(dpiScale);
+        }
+
+        public void CreateGraphic(float dpiScale) {
             for (int i = 0; i < 3; i++)
             {
                 for (int j = 0; j < 16; j++)
@@ -117,6 +121,7 @@ namespace ClassicUO.Game
                     }
                 }
             }
+            _needGraphicUpdate = true;
         }
 
         public ushort Graphic

--- a/src/ClassicUO.Client/Game/Managers/ContainerManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ContainerManager.cs
@@ -72,7 +72,7 @@ namespace ClassicUO.Game.Managers
                                 break;
 
                             case 1:
-                                X = Client.Game.Window.ClientBounds.Width - width;
+                                X = Client.Game.ClientBounds.Width - width;
                                 Y = 0;
 
                                 break;
@@ -93,12 +93,12 @@ namespace ClassicUO.Game.Managers
                                 break;
                         }
 
-                        if (X + width > Client.Game.Window.ClientBounds.Width)
+                        if (X + width > Client.Game.ClientBounds.Width)
                         {
                             X -= width;
                         }
 
-                        if (Y + height > Client.Game.Window.ClientBounds.Height)
+                        if (Y + height > Client.Game.ClientBounds.Height)
                         {
                             Y -= height;
                         }
@@ -111,14 +111,14 @@ namespace ClassicUO.Game.Managers
                         {
                             if (
                                 X + width + Constants.CONTAINER_RECT_STEP
-                                > Client.Game.Window.ClientBounds.Width
+                                > Client.Game.ClientBounds.Width
                             )
                             {
                                 X = Constants.CONTAINER_RECT_DEFAULT_POSITION;
 
                                 if (
                                     Y + height + Constants.CONTAINER_RECT_LINESTEP
-                                    > Client.Game.Window.ClientBounds.Height
+                                    > Client.Game.ClientBounds.Height
                                 )
                                 {
                                     Y = Constants.CONTAINER_RECT_DEFAULT_POSITION;
@@ -130,12 +130,12 @@ namespace ClassicUO.Game.Managers
                             }
                             else if (
                                 Y + height + Constants.CONTAINER_RECT_STEP
-                                > Client.Game.Window.ClientBounds.Height
+                                > Client.Game.ClientBounds.Height
                             )
                             {
                                 if (
                                     X + width + Constants.CONTAINER_RECT_LINESTEP
-                                    > Client.Game.Window.ClientBounds.Width
+                                    > Client.Game.ClientBounds.Width
                                 )
                                 {
                                     X = Constants.CONTAINER_RECT_DEFAULT_POSITION;

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -602,8 +602,8 @@ namespace ClassicUO.Game.Managers
 
                                     if (party == null)
                                     {
-                                        int x = Client.Game.Window.ClientBounds.Width / 2 - 272;
-                                        int y = Client.Game.Window.ClientBounds.Height / 2 - 240;
+                                        int x = Client.Game.ClientBounds.Width / 2 - 272;
+                                        int y = Client.Game.ClientBounds.Height / 2 - 240;
                                         UIManager.Add(new PartyGump(_world, x, y, _world.Party.CanLoot));
                                     }
                                     else

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -325,8 +325,8 @@ namespace ClassicUO.Game.Scenes
             _world.MessageManager.MessageReceived -= ChatOnMessageReceived;
 
             Settings.GlobalSettings.WindowSize = new Point(
-                Client.Game.Window.ClientBounds.Width,
-                Client.Game.Window.ClientBounds.Height
+                Client.Game.ClientBounds.Width,
+                Client.Game.ClientBounds.Height
             );
 
             Settings.GlobalSettings.IsWindowMaximized = Client.Game.IsWindowMaximized();

--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -13,6 +13,7 @@ using ClassicUO.Resources;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
+using SDL3;
 using System;
 using System.IO;
 using System.Net;
@@ -90,7 +91,10 @@ namespace ClassicUO.Game.Scenes
                 Client.Game.RestoreWindow();
             }
 
-            Client.Game.SetWindowSize(Client.Game.ScaleWithDpi(640), Client.Game.ScaleWithDpi(480));
+            int width = Client.Game.ScaleWithDpi(640);
+            int height = Client.Game.ScaleWithDpi(480);
+            SDL.SDL_SetWindowMinimumSize(Client.Game.Window.Handle, width, height);
+            Client.Game.SetWindowSize(width, height);
         }
 
 

--- a/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
@@ -131,9 +131,9 @@ namespace ClassicUO.Game.UI.Controls
             {
                 comboY = 0;
             }
-            else if (comboY + _maxHeight > Client.Game.Window.ClientBounds.Height)
+            else if (comboY + _maxHeight > Client.Game.ClientBounds.Height)
             {
-                comboY = Client.Game.Window.ClientBounds.Height - _maxHeight;
+                comboY = Client.Game.ClientBounds.Height - _maxHeight;
             }
 
             UIManager.Add

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -134,14 +134,14 @@ namespace ClassicUO.Game.UI.Controls
             X = Mouse.Position.X + 5;
             Y = Mouse.Position.Y - 20;
 
-            if (X + _background.Width > Client.Game.Window.ClientBounds.Width)
+            if (X + _background.Width > Client.Game.ClientBounds.Width)
             {
-                X = Client.Game.Window.ClientBounds.Width - _background.Width;
+                X = Client.Game.ClientBounds.Width - _background.Width;
             }
 
-            if (Y + _background.Height > Client.Game.Window.ClientBounds.Height)
+            if (Y + _background.Height > Client.Game.ClientBounds.Height)
             {
-                Y = Client.Game.Window.ClientBounds.Height - _background.Height;
+                Y = Client.Game.ClientBounds.Height - _background.Height;
             }
 
             foreach (ContextMenuItem mitem in FindControls<ContextMenuItem>())

--- a/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
@@ -72,7 +72,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public void SetInScreen()
         {
-            Rectangle windowBounds = Client.Game.Window.ClientBounds;
+            Rectangle windowBounds = Client.Game.ClientBounds;
             Rectangle bounds = Bounds;
             bounds.X += windowBounds.X;
             bounds.Y += windowBounds.Y;
@@ -115,14 +115,14 @@ namespace ClassicUO.Game.UI.Gumps
                 position.Y = -halfHeight;
             }
 
-            if (X > Client.Game.Window.ClientBounds.Width - (Width - halfWidth))
+            if (X > Client.Game.ClientBounds.Width - (Width - halfWidth))
             {
-                position.X = Client.Game.Window.ClientBounds.Width - (Width - halfWidth);
+                position.X = Client.Game.ClientBounds.Width - (Width - halfWidth);
             }
 
-            if (Y > Client.Game.Window.ClientBounds.Height - (Height - halfHeight))
+            if (Y > Client.Game.ClientBounds.Height - (Height - halfHeight))
             {
-                position.Y = Client.Game.Window.ClientBounds.Height - (Height - halfHeight);
+                position.Y = Client.Game.ClientBounds.Height - (Height - halfHeight);
             }
 
             Location = position;

--- a/src/ClassicUO.Client/Game/UI/Gumps/LocationGoGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/LocationGoGump.cs
@@ -111,8 +111,8 @@ internal partial class LocationGoGump : Gump
             }
         );
 
-        X = (Client.Game.Window.ClientBounds.Width - Width) >> 1;
-        Y = (Client.Game.Window.ClientBounds.Height - Height) >> 1;
+        X = (Client.Game.ClientBounds.Width - Width) >> 1;
+        Y = (Client.Game.ClientBounds.Height - Height) >> 1;
     }
 
     private bool ParsePoint(string text, out Point point)

--- a/src/ClassicUO.Client/Game/UI/Gumps/MessageBoxGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MessageBoxGump.cs
@@ -72,8 +72,8 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             );
 
-            X = (Client.Game.Window.ClientBounds.Width - Width) >> 1;
-            Y = (Client.Game.Window.ClientBounds.Height - Height) >> 1;
+            X = (Client.Game.ClientBounds.Width - Width) >> 1;
+            Y = (Client.Game.ClientBounds.Height - Height) >> 1;
 
             // OK
             Button b;
@@ -223,8 +223,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             Add(_textBox);
 
-            X = (Client.Game.Window.ClientBounds.Width - Width) >> 1;
-            Y = (Client.Game.Window.ClientBounds.Height - Height) >> 1;
+            X = (Client.Game.ClientBounds.Width - Width) >> 1;
+            Y = (Client.Game.ClientBounds.Height - Height) >> 1;
 
 
             // OK

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -4019,7 +4019,7 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     if (vp != null)
                     {
-                        var size = new Point(Client.Game.Window.ClientBounds.Width, Client.Game.Window.ClientBounds.Height);
+                        var size = new Point(Client.Game.ClientBounds.Width, Client.Game.ClientBounds.Height);
                         n = vp.ResizeGameWindow(size);
                         vp.SetGameWindowPosition(new Point(-5, -5));
                         _currentProfile.GameWindowPosition = vp.Location;

--- a/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
@@ -350,8 +350,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (party == null)
                 {
-                    int x = Client.Game.Window.ClientBounds.Width / 2 - 272;
-                    int y = Client.Game.Window.ClientBounds.Height / 2 - 240;
+                    int x = Client.Game.ClientBounds.Width / 2 - 272;
+                    int y = Client.Game.ClientBounds.Height / 2 - 240;
                     UIManager.Add(new PartyGump(World, x, y, World.Party.CanLoot));
                 }
                 else

--- a/src/ClassicUO.Client/Game/UI/Gumps/QuestionGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/QuestionGump.cs
@@ -44,8 +44,8 @@ namespace ClassicUO.Game.UI.Gumps
             CanMove = false;
             IsModal = true;
 
-            X = (Client.Game.Window.ClientBounds.Width - Width) >> 1;
-            Y = (Client.Game.Window.ClientBounds.Height - Height) >> 1;
+            X = (Client.Game.ClientBounds.Width - Width) >> 1;
+            Y = (Client.Game.ClientBounds.Height - Height) >> 1;
 
             WantUpdateSize = false;
             _result = result;

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
@@ -125,14 +125,14 @@ namespace ClassicUO.Game.UI.Gumps
                         h = targetHeight;
                     }
 
-                    if (w > Client.Game.Window.ClientBounds.Width - BORDER_WIDTH)
+                    if (w > Client.Game.ClientBounds.Width - BORDER_WIDTH)
                     {
-                        w = Client.Game.Window.ClientBounds.Width - BORDER_WIDTH;
+                        w = Client.Game.ClientBounds.Width - BORDER_WIDTH;
                     }
 
-                    if (h > Client.Game.Window.ClientBounds.Height - BORDER_WIDTH)
+                    if (h > Client.Game.ClientBounds.Height - BORDER_WIDTH)
                     {
-                        h = Client.Game.Window.ClientBounds.Height - BORDER_WIDTH;
+                        h = Client.Game.ClientBounds.Height - BORDER_WIDTH;
                     }
 
                     _lastSize.X = w;
@@ -160,9 +160,9 @@ namespace ClassicUO.Game.UI.Gumps
 
             Point position = Location;
 
-            if (position.X + Width - BORDER_WIDTH > Client.Game.Window.ClientBounds.Width)
+            if (position.X + Width - BORDER_WIDTH > Client.Game.ClientBounds.Width)
             {
-                position.X = Client.Game.Window.ClientBounds.Width - (Width - BORDER_WIDTH);
+                position.X = Client.Game.ClientBounds.Width - (Width - BORDER_WIDTH);
             }
 
             if (position.X < -BORDER_WIDTH)
@@ -170,9 +170,9 @@ namespace ClassicUO.Game.UI.Gumps
                 position.X = -BORDER_WIDTH;
             }
 
-            if (position.Y + Height - BORDER_WIDTH > Client.Game.Window.ClientBounds.Height)
+            if (position.Y + Height - BORDER_WIDTH > Client.Game.ClientBounds.Height)
             {
-                position.Y = Client.Game.Window.ClientBounds.Height - (Height - BORDER_WIDTH);
+                position.Y = Client.Game.ClientBounds.Height - (Height - BORDER_WIDTH);
             }
 
             if (position.Y < -BORDER_WIDTH)

--- a/src/ClassicUO.Client/Game/UI/Tooltip.cs
+++ b/src/ClassicUO.Client/Game/UI/Tooltip.cs
@@ -136,18 +136,18 @@ namespace ClassicUO.Game.UI
             {
                 x = 0;
             }
-            else if (x > Client.Game.Window.ClientBounds.Width - z_width)
+            else if (x > Client.Game.ClientBounds.Width - z_width)
             {
-                x = Client.Game.Window.ClientBounds.Width - z_width;
+                x = Client.Game.ClientBounds.Width - z_width;
             }
 
             if (y < 0)
             {
                 y = 0;
             }
-            else if (y > Client.Game.Window.ClientBounds.Height - z_height)
+            else if (y > Client.Game.ClientBounds.Height - z_height)
             {
-                y = Client.Game.Window.ClientBounds.Height - z_height;
+                y = Client.Game.ClientBounds.Height - z_height;
             }
 
 

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -67,6 +67,15 @@ namespace ClassicUO
         public UltimaOnline UO { get; } = new UltimaOnline();
         public IPluginHost PluginHost { get; private set; }
         public GraphicsDeviceManager GraphicManager { get; }
+
+        public Rectangle ClientBounds
+        {
+            get
+            {
+                return Window.ClientBounds;
+            }
+        }
+
         public readonly uint[] FrameDelay = new uint[2];
 
         private readonly List<(uint, Action)> _queuedActions = new ();

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -527,9 +527,11 @@ namespace ClassicUO
             base.Draw(gameTime);
         }
 
+        public float ScreenScale { get; set; } = Settings.GlobalSettings.ScreenScale;
+
         public float DpiScale
         {
-            get => SDL_GetWindowDisplayScale(Window.Handle);
+            get => SDL_GetWindowDisplayScale(Window.Handle) * ScreenScale;
         }
 
         public int ScaleWithDpi(int value)

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -527,7 +527,16 @@ namespace ClassicUO
             base.Draw(gameTime);
         }
 
-        public float ScreenScale { get; set; } = Settings.GlobalSettings.ScreenScale;
+        private float _screenScale = Settings.GlobalSettings.ScreenScale;
+        public float ScreenScale {
+            get => _screenScale;
+            set {
+                if (value != _screenScale) {
+                    _screenScale = value;
+                    UO.GameCursor?.CreateGraphic(DpiScale);
+                }
+            }
+        }
 
         public float DpiScale
         {

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -72,7 +72,13 @@ namespace ClassicUO
         {
             get
             {
-                return Window.ClientBounds;
+                var window_rectangle = Window.ClientBounds;
+                return new Rectangle(
+                    window_rectangle.X,
+                    window_rectangle.Y,
+                    (int)((float)(window_rectangle.Width) / DpiScale),
+                    (int)((float)(window_rectangle.Height) / DpiScale)
+                );
             }
         }
 

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -2541,8 +2541,8 @@ namespace ClassicUO.Network
                             );
                             bulletinBoard?.Dispose();
 
-                            int x = (Client.Game.Window.ClientBounds.Width >> 1) - 245;
-                            int y = (Client.Game.Window.ClientBounds.Height >> 1) - 205;
+                            int x = (Client.Game.ClientBounds.Width >> 1) - 245;
+                            int y = (Client.Game.ClientBounds.Height >> 1) - 205;
 
                             bulletinBoard = new BulletinBoardGump(world, item, x, y, p.ReadUTF8(22, true)); //p.ReadASCII(22));
                             UIManager.Add(bulletinBoard);
@@ -3007,8 +3007,8 @@ namespace ClassicUO.Network
             {
                 GrayMenuGump gump = new GrayMenuGump(world, serial, id, name)
                 {
-                    X = (Client.Game.Window.ClientBounds.Width >> 1) - 200,
-                    Y = (Client.Game.Window.ClientBounds.Height >> 1) - ((121 + count * 21) >> 1)
+                    X = (Client.Game.ClientBounds.Width >> 1) - 200,
+                    Y = (Client.Game.ClientBounds.Height >> 1) - ((121 + count * 21) >> 1)
                 };
 
                 int offsetY = 35 + gump.Height;
@@ -3248,8 +3248,8 @@ namespace ClassicUO.Network
 
             ref readonly var gumpInfo = ref Client.Game.UO.Gumps.GetGump(0x0906);
 
-            int x = (Client.Game.Window.ClientBounds.Width >> 1) - (gumpInfo.UV.Width >> 1);
-            int y = (Client.Game.Window.ClientBounds.Height >> 1) - (gumpInfo.UV.Height >> 1);
+            int x = (Client.Game.ClientBounds.Width >> 1) - (gumpInfo.UV.Width >> 1);
+            int y = (Client.Game.ClientBounds.Height >> 1) - (gumpInfo.UV.Height >> 1);
 
             ColorPickerGump gump = UIManager.GetGump<ColorPickerGump>(serial);
 

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -1158,6 +1158,15 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("Decline", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Screen zoom:.
+        /// </summary>
+        public static string ScreenZoom {
+            get {
+                return ResourceManager.GetString("ScreenZoom", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Default zoom:.

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -417,6 +417,9 @@
   <data name="GamePlayWindowPosition" xml:space="preserve">
     <value>Game Play Window Position: </value>
   </data>
+  <data name="ScreenZoom" xml:space="preserve">
+    <value>Screen zoom:</value>
+  </data>
   <data name="DefaultZoom" xml:space="preserve">
     <value>Default zoom:</value>
   </data>

--- a/src/ClassicUO.Renderer/Arts/Art.cs
+++ b/src/ClassicUO.Renderer/Arts/Art.cs
@@ -147,6 +147,8 @@ namespace ClassicUO.Renderer.Arts
                 short curY = 0;
                 Color c = default;
 
+                int dpiScaleInt = (int)Math.Ceiling(dpiScale);
+
                 while (pixels_ptr < p_img_end)
                 {
                     curX = 0;
@@ -155,20 +157,20 @@ namespace ClassicUO.Renderer.Arts
                     {
                         if (*pixels_ptr != 0 && *pixels_ptr != 0xFF_00_00_00)
                         {
-                            if (curX >= width - 1 || curY >= height - 1)
+                            if (curX >= width - dpiScaleInt || curY >= height - dpiScaleInt)
                             {
                                 *pixels_ptr = 0;
                             }
-                            else if (curX == 0 || curY == 0)
+                            else if (curX < dpiScaleInt || curY < dpiScaleInt)
                             {
                                 if (*pixels_ptr == 0xFF_00_FF_00)
                                 {
-                                    if (curX == 0)
+                                    if (curX < dpiScaleInt)
                                     {
                                         hotY = curY;
                                     }
 
-                                    if (curY == 0)
+                                    if (curY < dpiScaleInt)
                                     {
                                         hotX = curX;
                                     }


### PR DESCRIPTION
### Feature

Add a "screen zoom" setting that rescales the entire window.

<img width="477" height="138" alt="image" src="https://github.com/user-attachments/assets/357cb4bc-102e-4cd4-b678-eae6f63dd615" />

### Fixes

- Fix gumps not being centered correctly depending on DPI
- Fix cursor showing blue borders depending on DPI

### Further notes

I built on @Lichtblitz's DpiScale and added a settings entry to make it configurable. It is a scale that goes from -20 to 20, where -20 = 0.5x, 0 = 1.0x, and 20 = 2.0x.

During the processes, I also fixed some bugs that were happening to me.

This setting is useful for people who have monitors with different resolutions. If you don’t want to merge the settings entry, I can reopen the PR with only the bug fixes.
