### PR TITLE
Use a proper UnmanagedType for tiledata name so we can correctly get marshalled size

### DIFF
--- a/src/ClassicUO.Assets/TileDataLoader.cs
+++ b/src/ClassicUO.Assets/TileDataLoader.cs
@@ -355,7 +355,7 @@ namespace ClassicUO.Assets
     {
         public uint Flags;
         public ushort TexID;
-        [MarshalAs(UnmanagedType.LPStr, SizeConst = 20)]
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 20)]
         public string Name;
     }
 
@@ -378,7 +378,7 @@ namespace ClassicUO.Assets
         public ushort Hue;
         public ushort LightIndex;
         public byte Height;
-        [MarshalAs(UnmanagedType.LPStr, SizeConst = 20)]
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 20)]
         public string Name;
     }
 
@@ -397,7 +397,7 @@ namespace ClassicUO.Assets
     {
         public TileFlag Flags;
         public ushort TexID;
-        [MarshalAs(UnmanagedType.LPStr, SizeConst = 20)]
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 20)]
         public string Name;
     }
 
@@ -420,7 +420,7 @@ namespace ClassicUO.Assets
         public ushort Hue;
         public ushort LightIndex;
         public byte Height;
-        [MarshalAs(UnmanagedType.LPStr, SizeConst = 20)]
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 20)]
         public string Name;
     }
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshalasattribute.sizeconst?view=net-10.0#remarks
https://learn.microsoft.com/en-us/dotnet/framework/interop/default-marshalling-for-strings#strings-used-in-structures
