### PR TITLE
TargetSystem changes

### DIFF
--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -304,12 +304,16 @@ namespace ClassicUO.Game
                 Attack(world, serial);
             }
             else
-            {
+            {   
                 Socket.Send_DoubleClick(serial);
             }
 
             if (SerialHelper.IsItem(serial) || (SerialHelper.IsMobile(serial) && (world.Mobiles.Get(serial)?.IsHuman ?? false)))
             {
+                if (SerialHelper.IsMobile(serial))
+                {
+                    world.TargetManager.NewTargetSystemSerial = serial;
+                }
                 world.LastObject = serial;
             }
             else

--- a/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
@@ -198,7 +198,9 @@ namespace ClassicUO.Game.Managers
                     ? Notoriety.GetHue(mobile.NotorietyFlag)
                     : Notoriety.GetHue(NotorietyFlag.Gray);
 
-            Vector3 hueVec = ShaderHueTranslator.GetHueVector(hue, false, alpha);
+            //Vector3 hueVec = ShaderHueTranslator.GetHueVector(hue, false, alpha);
+            Vector3 hueVecZero = ShaderHueTranslator.GetHueVector(0, false, alpha);
+            Vector3 hueVecNoto = ShaderHueTranslator.GetHueVector(hue, false, alpha);
 
             if (mobile == null)
             {
@@ -224,7 +226,30 @@ namespace ClassicUO.Game.Managers
 
                 uint topGump;
                 uint bottomGump;
-                uint gumpHue = 0x7570;
+                //uint gumpHue = 0x7570;
+                uint gumpHue = 0x7572; // gray
+
+                if (mobile != null)
+                {
+                    if (mobile.NotorietyFlag == NotorietyFlag.Innocent)
+                        gumpHue = 0x7570; // blue
+
+                    else if (mobile.NotorietyFlag == NotorietyFlag.Ally)
+                        gumpHue = 0x7571; // green
+
+                    else if (mobile.NotorietyFlag == NotorietyFlag.Criminal || mobile.NotorietyFlag == NotorietyFlag.Gray)
+                        gumpHue = 0x7572; // grey
+
+                    else if (mobile.NotorietyFlag == NotorietyFlag.Enemy)
+                        gumpHue = 0x7573; // orange
+
+                    if (mobile.NotorietyFlag == NotorietyFlag.Invulnerable)
+                        gumpHue = 0x7575; // yellow
+
+                    else if (mobile.NotorietyFlag == NotorietyFlag.Murderer)
+                        gumpHue = 0x7577; // red
+                }
+
                 if (width >= 80)
                 {
                     topGump = 0x756D;
@@ -251,7 +276,7 @@ namespace ClassicUO.Game.Managers
                         newTargGumpInfo.Texture,
                         new Vector2(targetX, y - topTargetY),
                         newTargGumpInfo.UV,
-                        hueVec,
+                        hueVecZero,
                         layerDepth
                     );
 
@@ -260,7 +285,7 @@ namespace ClassicUO.Game.Managers
                         hueGumpInfo.Texture,
                         new Vector2(targetX, y - topTargetY),
                         hueGumpInfo.UV,
-                        hueVec,
+                        hueVecZero,
                         layerDepth
                     );
 
@@ -272,7 +297,7 @@ namespace ClassicUO.Game.Managers
                         newTargGumpInfo.Texture,
                         new Vector2(targetX, y - 1 - newTargGumpInfo.UV.Height / 2f),
                         newTargGumpInfo.UV,
-                        hueVec,
+                        hueVecZero,
                         layerDepth
                     );
             }
@@ -284,11 +309,11 @@ namespace ClassicUO.Game.Managers
                 gumpInfo.Texture,
                 new Rectangle(x, y, gumpInfo.UV.Width * MULTIPLER, gumpInfo.UV.Height * MULTIPLER),
                 gumpInfo.UV,
-                hueVec,
+                hueVecNoto,
                 layerDepth
             );
 
-            hueVec.X = 0x21;
+            hueVecNoto.X = 0x21;
 
             if (entity.Hits != entity.HitsMax || entity.HitsMax == 0)
             {
@@ -310,7 +335,7 @@ namespace ClassicUO.Game.Managers
                         gumpInfo.UV.Height * MULTIPLER
                     ),
                     gumpInfo.UV,
-                    hueVec,
+                    hueVecNoto,
                     layerDepth
                 );
             }
@@ -331,14 +356,14 @@ namespace ClassicUO.Game.Managers
                     }
                 }
 
-                hueVec.X = hue;
+                hueVecNoto.X = hue;
 
                 gumpInfo = ref Client.Game.UO.Gumps.GetGump(HP_GRAPHIC);
                 batcher.DrawTiled(
                     gumpInfo.Texture,
                     new Rectangle(x, y, per * MULTIPLER, gumpInfo.UV.Height * MULTIPLER),
                     gumpInfo.UV,
-                    hueVec,
+                    hueVecNoto,
                     layerDepth
                 );
             }

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -1258,7 +1258,17 @@ namespace ClassicUO.Game.Managers
 
                 case MacroType.TargetSystemOnOff:
 
-                    GameActions.Print(_world, ResGeneral.TargetSystemNotImplemented);
+                    if (ProfileManager.CurrentProfile.UseNewTargetSystem)
+                    {
+                        ProfileManager.CurrentProfile.UseNewTargetSystem = false;
+                        GameActions.Print(_world, "Target System: Off");
+                    }
+                    else
+                    {
+                        ProfileManager.CurrentProfile.UseNewTargetSystem = true;
+                        GameActions.Print(_world, "Target System: On");
+                    }
+                    //GameActions.Print(_world, ResGeneral.TargetSystemNotImplemented);
 
                     break;
 


### PR DESCRIPTION
The "on/off still incomplete" message for the new target system macro has been fixed.

The new target system wasn't working as it should in the OSI; the gumps designated for the target system were being painted, but this shouldn't have been the case. Only the top point gump should have changed according to the Noto color.
OSI;
<img width="67" height="138" alt="image" src="https://github.com/user-attachments/assets/abb871e8-47ab-4672-8746-8eda5225f010" />
<img width="107" height="167" alt="image" src="https://github.com/user-attachments/assets/86d3618d-90f9-41a9-a650-25a9607c96a1" />

CUO (current);
<img width="132" height="202" alt="image" src="https://github.com/user-attachments/assets/898c23f7-5831-41c4-9186-64383f8bf8c0" />


CUO (after the change);
<img width="119" height="164" alt="image" src="https://github.com/user-attachments/assets/776d8963-2a11-4636-92af-be555dbda3f3" />
<img width="116" height="156" alt="image" src="https://github.com/user-attachments/assets/0d77abfb-007e-479d-81a7-b31af5f48ca9" />




Furthermore, the target system needed to be marked not only when attacking via warmod, but also when double-clicking normally.