### PR TITLE
Fixes offset for firing bow/xbow/heavy-xbow & directed spells

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -7,6 +7,7 @@ using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
 using Microsoft.Xna.Framework;
 using System;
+using ClassicUO.Renderer.Animations;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -498,7 +499,7 @@ namespace ClassicUO.Game.GameObjects
                 bool mirror = false;
 
                 var animations = Client.Game.UO.Animations;
-                animations.GetAnimDirection(ref dir, ref mirror);
+                Animations.GetAnimDirection(ref dir, ref mirror);
 
                 if (id < animations.MaxAnimationCount && dir < 5)
                 {

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -351,6 +351,7 @@ namespace ClassicUO.Game.GameObjects
             bool fromServer = false
         )
         {
+            Console.WriteLine($"{this} is doing animation {id}");
             _animationGroup = id;
             AnimIndex = (byte)(forward ? 0 : frameCount);
             _animationInterval = interval;

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -10,6 +10,7 @@ using ClassicUO.Utility;
 using ClassicUO.Utility.Collections;
 using Microsoft.Xna.Framework;
 using System;
+using ClassicUO.Renderer.Animations;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -351,7 +352,6 @@ namespace ClassicUO.Game.GameObjects
             bool fromServer = false
         )
         {
-            Console.WriteLine($"{this} is doing animation {id}");
             _animationGroup = id;
             AnimIndex = (byte)(forward ? 0 : frameCount);
             _animationInterval = interval;
@@ -579,7 +579,7 @@ namespace ClassicUO.Game.GameObjects
             byte action = GetGroupForAnimation(this, id, true);
 
             bool mirror = false;
-            animations.GetAnimDirection(ref dir, ref mirror);
+            Animations.GetAnimDirection(ref dir, ref mirror);
             int currentDelay = Constants.CHARACTER_ANIMATION_DELAY;
 
             if (id < animations.MaxAnimationCount && dir < 5)

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -100,6 +100,7 @@ namespace ClassicUO.Game.GameObjects
         private long _lastAnimationIdleDelay;
         private bool _isAnimationForwardDirection;
         private byte _animationGroup = 0xFF;
+        public byte AnimationGroup => _animationGroup;
         private byte _animationInterval;
         private bool _animationRepeat;
         private ushort _animationRepeateMode = 1;

--- a/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
@@ -1,7 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using System;
-using ClassicUO.Assets;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using Microsoft.Xna.Framework;
@@ -73,29 +72,38 @@ namespace ClassicUO.Game.GameObjects
 
         private void ApplyProjectileOffset(Mobile mobile, byte layer)
         {
+            if (layer != 1 && layer != 0xFF)
+                return;
+
             var dir = mobile.Direction & Direction.Mask;
-            var animGroup = mobile.AnimationGroup;
             float ox, oy;
 
-            switch (layer)
+            // Detect projectile type by effect graphic (animation group is unreliable
+            // because the animation packet arrives after the effect packet)
+            switch (Graphic)
             {
-                default: return;
-
-                // Explicit RightHand from 0xC7 packet
-                case 1:
-
-                // No layer info (0xC0 packet) — heuristic
-                case 0xFF:
-                    (ox, oy) = animGroup switch
-                    {
-                        (byte)PeopleAnimationGroup.AttackBow => GetRangedAttackOffset(dir, false),
-                        (byte)PeopleAnimationGroup.OnmountAttackBow => GetRangedAttackOffset(dir, true),
-                        (byte)PeopleAnimationGroup.AttackCrossbow => GetRangedXBowAttackOffset(dir, false),
-                        (byte)PeopleAnimationGroup.OnmountAttackCrossbow => GetRangedXBowAttackOffset(dir, true),
-                        (byte)PeopleAnimationGroup.CastDirected => GetSpellCastOffset(dir),
-                        _ => (0, 0)
-                    };
+                case 0x36E4: // Magic Arrow
+                case 0x36D4: // Fireball
+                case 0x379F: // Energy Bolt
+                    (ox, oy) = GetSpellCastOffset(dir);
                     break;
+
+                case 0xF42:  // Arrow (Bow, Composite, Elven Composite, Magical Shortbow, Yumi)
+                    if (layer != 1)
+                        return;
+
+                    (ox, oy) = GetRangedAttackOffset(dir, mobile.IsMounted);
+                    break;
+
+                case 0x1BFE: // Bolt (Crossbow, Heavy Crossbow, Repeating Crossbow)
+                    if (layer != 1)
+                        return;
+
+                    (ox, oy) = GetRangedXBowAttackOffset(dir, mobile.IsMounted);
+                    break;
+
+                default:
+                    return;
             }
 
             Offset.X += ox;

--- a/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
@@ -51,10 +51,10 @@ namespace ClassicUO.Game.GameObjects
                 SetSource(xSource, ySource, zSource);
             }
 
-            // Apply hand offset for ranged weapon projectiles
+            // Apply hand offset for projectiles (ranged weapons + directed spells)
             if (source is Mobile mobile)
             {
-                ApplyRangedAttackOffset(mobile, layer);
+                ApplyProjectileOffset(mobile, layer);
             }
 
             Entity target = World.Get(trg);
@@ -71,118 +71,115 @@ namespace ClassicUO.Game.GameObjects
 
         public readonly bool FixedDir;
 
-        private void ApplyRangedAttackOffset(Mobile mobile, byte layer)
+        private void ApplyProjectileOffset(Mobile mobile, byte layer)
         {
-            byte animGroup = mobile.AnimationGroup;
-            bool isBow = false, isXBow = false;
-
-            if (layer == 1) // Explicit RightHand from 0xC7 packet
-            {
-                switch (animGroup)
-                {
-                    case (byte)PeopleAnimationGroup.AttackCrossbow:
-                    case (byte)PeopleAnimationGroup.OnmountAttackCrossbow:
-                        isXBow = true;
-                        break;
-                    default:
-                        isBow = true;
-                        break;
-                }
-            }
-            else if (layer == 0xFF) // No layer info (0xC0 packet) — heuristic
-            {
-                switch (animGroup)
-                {
-                    case (byte)PeopleAnimationGroup.AttackBow:
-                    case (byte)PeopleAnimationGroup.OnmountAttackBow:
-                        isBow = true;
-                        break;
-                    case (byte)PeopleAnimationGroup.AttackCrossbow:
-                    case (byte)PeopleAnimationGroup.OnmountAttackCrossbow:
-                        isXBow = true;
-                        break;
-                }
-            }
-
-            if (!isBow && !isXBow)
-                return;
-
             var dir = mobile.Direction & Direction.Mask;
-            bool mounted = mobile.IsMounted;
-            var (ox, oy) = GetRangedAttackOffset(dir, mounted, isXBow);
+            var animGroup = mobile.AnimationGroup;
+            float ox, oy;
+
+            switch (layer)
+            {
+                default: return;
+
+                // Explicit RightHand from 0xC7 packet
+                case 1:
+
+                // No layer info (0xC0 packet) — heuristic
+                case 0xFF:
+                    (ox, oy) = animGroup switch
+                    {
+                        (byte)PeopleAnimationGroup.AttackBow => GetRangedAttackOffset(dir, false),
+                        (byte)PeopleAnimationGroup.OnmountAttackBow => GetRangedAttackOffset(dir, true),
+                        (byte)PeopleAnimationGroup.AttackCrossbow => GetRangedXBowAttackOffset(dir, false),
+                        (byte)PeopleAnimationGroup.OnmountAttackCrossbow => GetRangedXBowAttackOffset(dir, true),
+                        (byte)PeopleAnimationGroup.CastDirected => GetSpellCastOffset(dir),
+                        _ => (0, 0)
+                    };
+                    break;
+            }
 
             Offset.X += ox;
             Offset.Y += oy;
         }
 
-        private static (float x, float y) GetRangedAttackOffset(Direction dir, bool mounted, bool isXBow)
+        private static (float x, float y) GetRangedXBowAttackOffset(Direction dir, bool mounted)
         {
-            if (isXBow)
+            if (mounted)
             {
-                if (mounted)
+                return dir switch
                 {
-                    return dir switch
-                    {
-                        Direction.North => (-10, -57),
-                        Direction.Right => (-17, -62),
-                        Direction.East  => (-16, -68),
-                        Direction.Down  => (-5, -73),
-                        Direction.South => (8, -73),
-                        Direction.Left  => (5, -73),
-                        Direction.West  => (16, -68),
-                        Direction.Up    => (17, -62),
-                        _ => (0, 0)
-                    };
-                }
-                else
-                {
-                    return dir switch
-                    {
-                        Direction.North => (-1, -36),
-                        Direction.Right => (-10, -39),
-                        Direction.East  => (-13, -43),
-                        Direction.Down  => (-9, -48),
-                        Direction.South => (1, -50),
-                        Direction.Left  => (9, -48),
-                        Direction.West  => (13, -43),
-                        Direction.Up    => (10, -39),
-                        _ => (0, 0)
-                    };
-                }
+                    Direction.North => (-10, -57),
+                    Direction.Right => (-17, -62),
+                    Direction.East  => (-16, -68),
+                    Direction.Down  => (-5, -73),
+                    Direction.South => (8, -73),
+                    Direction.Left  => (5, -73),
+                    Direction.West  => (16, -68),
+                    Direction.Up    => (17, -62),
+                    _ => (0, 0)
+                };
             }
-            else
+
+            return dir switch
             {
-                if (mounted)
+                Direction.North => (-1, -36),
+                Direction.Right => (-10, -39),
+                Direction.East  => (-13, -43),
+                Direction.Down  => (-9, -48),
+                Direction.South => (1, -50),
+                Direction.Left  => (9, -48),
+                Direction.West  => (13, -43),
+                Direction.Up    => (10, -39),
+                _ => (0, 0)
+            };
+        }
+
+        private static (float x, float y) GetRangedAttackOffset(Direction dir, bool mounted)
+        {
+            if (mounted)
+            {
+                return dir switch
                 {
-                    return dir switch
-                    {
-                        Direction.North => (4, -61),
-                        Direction.Right => (-8, -52),
-                        Direction.East  => (-23, -57),
-                        Direction.Down  => (-25, -68),
-                        Direction.South => (-11, -75),
-                        Direction.Left  => (25, -68),
-                        Direction.West  => (23, -57),
-                        Direction.Up    => (8, -52),
-                        _ => (0, 0)
-                    };
-                }
-                else
-                {
-                    return dir switch
-                    {
-                        Direction.North => (-3, -40),
-                        Direction.Right => (-15, -39),
-                        Direction.East  => (-20, -44),
-                        Direction.Down  => (-12, -48),
-                        Direction.South => (4, -50),
-                        Direction.Left  => (12, -48),
-                        Direction.West  => (20, -44),
-                        Direction.Up    => (15, -39),
-                        _ => (0, 0)
-                    };
-                }
+                    Direction.North => (4, -61),
+                    Direction.Right => (-8, -52),
+                    Direction.East  => (-23, -57),
+                    Direction.Down  => (-25, -68),
+                    Direction.South => (-11, -75),
+                    Direction.Left  => (25, -68),
+                    Direction.West  => (23, -57),
+                    Direction.Up    => (8, -52),
+                    _ => (0, 0)
+                };
             }
+
+            return dir switch
+            {
+                Direction.North => (-3, -40),
+                Direction.Right => (-15, -39),
+                Direction.East  => (-20, -44),
+                Direction.Down  => (-12, -48),
+                Direction.South => (4, -50),
+                Direction.Left  => (12, -48),
+                Direction.West  => (20, -44),
+                Direction.Up    => (15, -39),
+                _ => (0, 0)
+            };
+        }
+
+        private static (float x, float y) GetSpellCastOffset(Direction dir)
+        {
+            return dir switch
+            {
+                Direction.North => (0, -15),
+                Direction.Right => (-28, -23),  // NE
+                Direction.East  => (-38, -36),
+                Direction.Down  => (-25, -48),  // SE
+                Direction.South => (1, -50),
+                Direction.Left  => (25, -48),   // SW
+                Direction.West  => (38, -36),
+                Direction.Up    => (28, -23),   // NW
+                _ => (0, 0)
+            };
         }
 
         public override void Update()

--- a/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
@@ -127,28 +127,18 @@ namespace ClassicUO.Game.GameObjects
                     else
                         (ax, ay) = GetRangedXBowAttackOffset(dir, mobile.IsMounted);
 
-                    // Rotation compensation: place the sprite reference point at
-                    // the grip. The sprite rotates around its top-left anchor, so
-                    // the reference ends up at anchor + rotated(refX, refY).
-                    // Solve: anchor = grip - rotated(refX, refY).
-                    //
-                    // Reference point in unrotated sprite coords (44x44).
-                    // At angle=0 (Left dir) the arrowhead is at (0,22).
-                    const float refX = 0f;
-                    const float refY = 22f;
-
-                    // Actual angle from source→target so compensation stays
-                    // accurate even when targets move off-angle.
+                    // Rotation compensation: the sprite rotates around its top-left
+                    // anchor. The reference point (0,22) in unrotated coords lands at
+                    // anchor + rotated(0,22) after rotation. Solve for anchor = grip - rotated.
+                    // Since refX=0, rotation simplifies to (-22*sin, 22*cos).
                     float dTileX = targetX - mobile.X;
                     float dTileY = targetY - mobile.Y;
                     float screenDX = (dTileX - dTileY) * 22f;
                     float screenDY = (dTileX + dTileY) * 22f;
                     float angle = MathF.Atan2(-screenDY, -screenDX);
 
-                    float rotRefX = refX * MathF.Cos(angle) - refY * MathF.Sin(angle);
-                    float rotRefY = refX * MathF.Sin(angle) + refY * MathF.Cos(angle);
-                    ax -= rotRefX;
-                    ay -= rotRefY;
+                    ax += 22f * MathF.Sin(angle);
+                    ay -= 22f * MathF.Cos(angle);
                     break;
                 }
 
@@ -176,9 +166,44 @@ namespace ClassicUO.Game.GameObjects
         }
 
         /// <summary>
+        /// Per-direction (X, Y) offsets for bow projectiles.
+        /// </summary>
+        private static (float x, float y) GetRangedAttackOffset(Direction dir, bool mounted)
+        {
+            if (mounted)
+            {
+                // MountedShootBow (group 27)
+                return dir switch
+                {
+                    Direction.North => (25, -49),
+                    Direction.Right => (23, -38),
+                    Direction.East  => (8, -33),
+                    Direction.Down  => (9, -22),
+                    Direction.South => (-8, -33),
+                    Direction.Left  => (-23, -38),
+                    Direction.West  => (-25, -49),
+                    Direction.Up    => (-11, -56),
+                    _               => (0, 0)
+                };
+            }
+
+            // ShootBow (group 18)
+            return dir switch
+            {
+                Direction.North => (12, -29),
+                Direction.Right => (20, -25),
+                Direction.East  => (15, -20),
+                Direction.Down  => (-3, 4),
+                Direction.South => (-15, -20),
+                Direction.Left  => (-20, -25),
+                Direction.West  => (-12, -29),
+                Direction.Up    => (4, -31),
+                _               => (0, 0)
+            };
+        }
+
+        /// <summary>
         /// Per-direction (X, Y) offsets for crossbow/heavy-xbow projectiles.
-        /// Same NOCK-BASED convention as bow offsets.
-        /// Computed analytically: ax = gripX, ay = gripY + 19.
         /// </summary>
         private static (float x, float y) GetRangedXBowAttackOffset(Direction dir, bool mounted)
         {
@@ -214,52 +239,9 @@ namespace ClassicUO.Game.GameObjects
             };
         }
 
-        /// <summary>
-        /// Per-direction (X, Y) offsets for bow projectiles.
-        /// NOCK-BASED: (ax, ay) = desired screen position of the arrow nock relative
-        /// to the source tile anchor. Rotation compensation applied automatically.
-        /// Computed analytically: ax = gripX, ay = gripY + 19 (MobileView gap).
-        /// Grip data from AnimFrameAnalyzer averaged across all bow types.
-        /// CUO dir → Analyzer dir remap: (d+5)%8.
-        /// Mirror pairs: North↔West, Right↔Left, East↔South (negate X, same Y).
-        /// </summary>
-        private static (float x, float y) GetRangedAttackOffset(Direction dir, bool mounted)
-        {
-            if (mounted)
-            {
-                // MountedShootBow (group 27)
-                return dir switch
-                {
-                    Direction.North => (25, -49),
-                    Direction.Right => (23, -38),
-                    Direction.East  => (8, -33),
-                    Direction.Down  => (9, -22),
-                    Direction.South => (-8, -33),
-                    Direction.Left  => (-23, -38),
-                    Direction.West  => (-25, -49),
-                    Direction.Up    => (-11, -56),
-                    _ => (0, 0)
-                };
-            }
-
-            // ShootBow (group 18)
-            return dir switch
-            {
-                Direction.North => (12, -29),
-                Direction.Right => (20, -25),
-                Direction.East  => (15, -20),
-                Direction.Down  => (-3, 4),
-                Direction.South => (-15, -20),
-                Direction.Left  => (-20, -25),
-                Direction.West  => (-12, -29),
-                Direction.Up    => (4, -31),
-                _ => (0, 0)
-            };
-        }
-
         private static (float x, float y) GetSpellCastOffset(Direction dir)
         {
-            // CastDirected (group 16) — remapped: CUO dir → Analyzer dir (d+5)%8
+            // CastDirected (group 16)
             return dir switch
             {
                 Direction.North => (25, -48),
@@ -279,7 +261,6 @@ namespace ClassicUO.Game.GameObjects
             base.Update();
             UpdateOffset();
         }
-
 
         private void UpdateOffset()
         {

--- a/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
@@ -107,58 +107,60 @@ namespace ClassicUO.Game.GameObjects
             var dir = mobile.Direction & Direction.Mask;
             float ax, ay;
 
-            // Graphic-based detection (animation group is unreliable because
-            // the animation packet arrives after the effect packet).
-            switch (Graphic)
+            if (Graphic is 0xF42 or 0x1BFE)
             {
-                case 0x36E4: // Magic Arrow
-                case 0x36D4: // Fireball
-                case 0x379F: // Energy Bolt
-                    (ax, ay) = GetSpellCastOffset(dir);
-                    break;
+                // Arrow (0xF42) or Bolt (0x1BFE) — use per-direction grip offsets.
+                if (Graphic == 0xF42)
+                    (ax, ay) = GetRangedAttackOffset(dir, mobile.IsMounted);
+                else
+                    (ax, ay) = GetRangedXBowAttackOffset(dir, mobile.IsMounted);
 
-                case 0xF42:  // Arrow (all bows)
-                case 0x1BFE: // Bolt (all crossbows)
+                // Rotation compensation: the sprite rotates around its top-left
+                // anchor. The reference point (0,22) in unrotated coords lands at
+                // anchor + rotated(0,22) after rotation. Solve for anchor = grip - rotated.
+                // Since refX=0, rotation simplifies to (-22*sin, 22*cos).
+                float dTileX = targetX - mobile.X;
+                float dTileY = targetY - mobile.Y;
+                float screenDX = (dTileX - dTileY) * 22f;
+                float screenDY = (dTileX + dTileY) * 22f;
+                float angle = MathF.Atan2(-screenDY, -screenDX);
+
+                ax += 22f * MathF.Sin(angle);
+                ay -= 22f * MathF.Cos(angle);
+            }
+            else
+            {
+                // All other projectiles (spells, etc.) — head-level anchor.
+                // Character is idle when spells fire, so no pose-specific offset.
+                Client.Game.UO.Animations.GetAnimationDimensions(
+                    0,
+                    mobile.GetGraphicForAnimation(),
+                    0, 0,
+                    mobile.IsMounted,
+                    0,
+                    out _,
+                    out int headCenterY,
+                    out _,
+                    out int headHeight
+                );
+
+                ax = 0;
+                ay = -(headHeight + headCenterY) + 19;
+
+                // Push the sprite forward along the flight path so the tail
+                // starts at the head rather than the head starting there.
+                const float SpellForwardShift = 25f;
+                float dTileX = targetX - mobile.X;
+                float dTileY = targetY - mobile.Y;
+                float screenDX = (dTileX - dTileY) * 22f;
+                float screenDY = (dTileX + dTileY) * 22f;
+                float dist = MathF.Sqrt(screenDX * screenDX + screenDY * screenDY);
+
+                if (dist > 0f)
                 {
-                    bool isBow = Graphic == 0xF42;
-
-                    if (isBow)
-                        (ax, ay) = GetRangedAttackOffset(dir, mobile.IsMounted);
-                    else
-                        (ax, ay) = GetRangedXBowAttackOffset(dir, mobile.IsMounted);
-
-                    // Rotation compensation: the sprite rotates around its top-left
-                    // anchor. The reference point (0,22) in unrotated coords lands at
-                    // anchor + rotated(0,22) after rotation. Solve for anchor = grip - rotated.
-                    // Since refX=0, rotation simplifies to (-22*sin, 22*cos).
-                    float dTileX = targetX - mobile.X;
-                    float dTileY = targetY - mobile.Y;
-                    float screenDX = (dTileX - dTileY) * 22f;
-                    float screenDY = (dTileX + dTileY) * 22f;
-                    float angle = MathF.Atan2(-screenDY, -screenDX);
-
-                    ax += 22f * MathF.Sin(angle);
-                    ay -= 22f * MathF.Cos(angle);
-                    break;
+                    ax += screenDX / dist * SpellForwardShift;
+                    ay += screenDY / dist * SpellForwardShift;
                 }
-
-                default:
-                    // Unknown projectile — fall back to generic head anchor.
-                    Client.Game.UO.Animations.GetAnimationDimensions(
-                        0,
-                        mobile.GetGraphicForAnimation(),
-                        0, 0,
-                        mobile.IsMounted,
-                        0,
-                        out _,
-                        out int headCenterY,
-                        out _,
-                        out int headHeight
-                    );
-
-                    ax = 0;
-                    ay = -(headHeight + headCenterY);
-                    break;
             }
 
             Offset.X += ax;
@@ -235,23 +237,6 @@ namespace ClassicUO.Game.GameObjects
                 Direction.Left  => (-13, -24),
                 Direction.West  => (-9, -29),
                 Direction.Up    => (1, -31),
-                _ => (0, 0)
-            };
-        }
-
-        private static (float x, float y) GetSpellCastOffset(Direction dir)
-        {
-            // CastDirected (group 16)
-            return dir switch
-            {
-                Direction.North => (25, -48),
-                Direction.Right => (38, -36),
-                Direction.East  => (28, -23),
-                Direction.Down  => (0, -15),
-                Direction.South => (-28, -23),
-                Direction.Left  => (-38, -36),
-                Direction.West  => (-25, -48),
-                Direction.Up    => (1, -50),
                 _ => (0, 0)
             };
         }

--- a/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
@@ -5,6 +5,8 @@ using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using Microsoft.Xna.Framework;
 
+using MathF = System.MathF;
+
 namespace ClassicUO.Game.GameObjects
 {
     internal sealed class MovingEffect : GameEffect
@@ -50,12 +52,6 @@ namespace ClassicUO.Game.GameObjects
                 SetSource(xSource, ySource, zSource);
             }
 
-            // Apply hand offset for projectiles (ranged weapons + directed spells)
-            if (source is Mobile mobile)
-            {
-                ApplyProjectileOffset(mobile, layer);
-            }
-
             Entity target = World.Get(trg);
 
             if (SerialHelper.IsValid(trg) && target != null)
@@ -66,126 +62,214 @@ namespace ClassicUO.Game.GameObjects
             {
                 SetTarget(xTarget, yTarget, zTarget);
             }
+
+            // Apply hand offset for projectiles (ranged weapons + directed spells).
+            // Must be after SetTarget so we can compute the actual angle to target.
+            if (source is Mobile mobile)
+            {
+                ushort tgtX = target != null ? target.X : xTarget;
+                ushort tgtY = target != null ? target.Y : yTarget;
+                ApplyProjectileOffset(mobile, layer, tgtX, tgtY);
+            }
+
+            // Compute target center offset so the arrow flies to chest level
+            // rather than feet. MobileView draws at RSP.Y + 19, so target center
+            // in effect space = 19 - (Height + CenterY) / 2.
+            if (target is Mobile targetMobile)
+            {
+                Client.Game.UO.Animations.GetAnimationDimensions(
+                    0,
+                    targetMobile.GetGraphicForAnimation(),
+                    0, 0,
+                    targetMobile.IsMounted,
+                    0,
+                    out _,
+                    out int tCenterY,
+                    out _,
+                    out int tHeight
+                );
+                
+                _targetOffsetY = 19 - (tHeight + tCenterY) / 2f;
+            }
         }
 
         public readonly bool FixedDir;
 
-        private void ApplyProjectileOffset(Mobile mobile, byte layer)
+        // Y offset applied to the target position so the arrow flies to
+        // the target's center/chest rather than their feet (tile anchor).
+        private float _targetOffsetY;
+
+        private void ApplyProjectileOffset(Mobile mobile, byte layer, ushort targetX, ushort targetY)
         {
             if (layer != 1 && layer != 0xFF)
                 return;
 
             var dir = mobile.Direction & Direction.Mask;
-            float ox, oy;
+            float ax, ay;
 
-            // Detect projectile type by effect graphic (animation group is unreliable
-            // because the animation packet arrives after the effect packet)
+            // Graphic-based detection (animation group is unreliable because
+            // the animation packet arrives after the effect packet).
             switch (Graphic)
             {
                 case 0x36E4: // Magic Arrow
                 case 0x36D4: // Fireball
                 case 0x379F: // Energy Bolt
-                    (ox, oy) = GetSpellCastOffset(dir);
+                    (ax, ay) = GetSpellCastOffset(dir);
                     break;
 
-                case 0xF42:  // Arrow (Bow, Composite, Elven Composite, Magical Shortbow, Yumi)
-                    if (layer != 1)
-                        return;
+                case 0xF42:  // Arrow (all bows)
+                case 0x1BFE: // Bolt (all crossbows)
+                {
+                    bool isBow = Graphic == 0xF42;
 
-                    (ox, oy) = GetRangedAttackOffset(dir, mobile.IsMounted);
+                    if (isBow)
+                        (ax, ay) = GetRangedAttackOffset(dir, mobile.IsMounted);
+                    else
+                        (ax, ay) = GetRangedXBowAttackOffset(dir, mobile.IsMounted);
+
+                    // Rotation compensation: place the sprite reference point at
+                    // the grip. The sprite rotates around its top-left anchor, so
+                    // the reference ends up at anchor + rotated(refX, refY).
+                    // Solve: anchor = grip - rotated(refX, refY).
+                    //
+                    // Reference point in unrotated sprite coords (44x44).
+                    // At angle=0 (Left dir) the arrowhead is at (0,22).
+                    const float refX = 0f;
+                    const float refY = 22f;
+
+                    // Actual angle from source→target so compensation stays
+                    // accurate even when targets move off-angle.
+                    float dTileX = targetX - mobile.X;
+                    float dTileY = targetY - mobile.Y;
+                    float screenDX = (dTileX - dTileY) * 22f;
+                    float screenDY = (dTileX + dTileY) * 22f;
+                    float angle = MathF.Atan2(-screenDY, -screenDX);
+
+                    float rotRefX = refX * MathF.Cos(angle) - refY * MathF.Sin(angle);
+                    float rotRefY = refX * MathF.Sin(angle) + refY * MathF.Cos(angle);
+                    ax -= rotRefX;
+                    ay -= rotRefY;
                     break;
-
-                case 0x1BFE: // Bolt (Crossbow, Heavy Crossbow, Repeating Crossbow)
-                    if (layer != 1)
-                        return;
-
-                    (ox, oy) = GetRangedXBowAttackOffset(dir, mobile.IsMounted);
-                    break;
+                }
 
                 default:
-                    return;
+                    // Unknown projectile — fall back to generic head anchor.
+                    Client.Game.UO.Animations.GetAnimationDimensions(
+                        0,
+                        mobile.GetGraphicForAnimation(),
+                        0, 0,
+                        mobile.IsMounted,
+                        0,
+                        out _,
+                        out int headCenterY,
+                        out _,
+                        out int headHeight
+                    );
+
+                    ax = 0;
+                    ay = -(headHeight + headCenterY);
+                    break;
             }
 
-            Offset.X += ox;
-            Offset.Y += oy;
+            Offset.X += ax;
+            Offset.Y += ay;
         }
 
+        /// <summary>
+        /// Per-direction (X, Y) offsets for crossbow/heavy-xbow projectiles.
+        /// Same NOCK-BASED convention as bow offsets.
+        /// Computed analytically: ax = gripX, ay = gripY + 19.
+        /// </summary>
         private static (float x, float y) GetRangedXBowAttackOffset(Direction dir, bool mounted)
         {
             if (mounted)
             {
+                // MountedShootXBow (group 28)
                 return dir switch
                 {
-                    Direction.North => (-10, -57),
-                    Direction.Right => (-17, -62),
-                    Direction.East  => (-16, -68),
-                    Direction.Down  => (-5, -73),
-                    Direction.South => (8, -73),
-                    Direction.Left  => (5, -73),
-                    Direction.West  => (16, -68),
-                    Direction.Up    => (17, -62),
+                    Direction.North => (25, -64),
+                    Direction.Right => (36, -49),
+                    Direction.East  => (27, -23),
+                    Direction.Down  => (-10, -18),
+                    Direction.South => (-37, -28),
+                    Direction.Left  => (-36, -49),
+                    Direction.West  => (-25, -64),
+                    Direction.Up    => (8, -54),
                     _ => (0, 0)
                 };
             }
 
+            // ShootXBow (group 19)
             return dir switch
             {
-                Direction.North => (-1, -36),
-                Direction.Right => (-10, -39),
-                Direction.East  => (-13, -43),
-                Direction.Down  => (-9, -48),
-                Direction.South => (1, -50),
-                Direction.Left  => (9, -48),
-                Direction.West  => (13, -43),
-                Direction.Up    => (10, -39),
+                Direction.North => (9, -29),
+                Direction.Right => (13, -24),
+                Direction.East  => (10, -20),
+                Direction.Down  => (-1, 3),
+                Direction.South => (-10, -20),
+                Direction.Left  => (-13, -24),
+                Direction.West  => (-9, -29),
+                Direction.Up    => (1, -31),
                 _ => (0, 0)
             };
         }
 
+        /// <summary>
+        /// Per-direction (X, Y) offsets for bow projectiles.
+        /// NOCK-BASED: (ax, ay) = desired screen position of the arrow nock relative
+        /// to the source tile anchor. Rotation compensation applied automatically.
+        /// Computed analytically: ax = gripX, ay = gripY + 19 (MobileView gap).
+        /// Grip data from AnimFrameAnalyzer averaged across all bow types.
+        /// CUO dir → Analyzer dir remap: (d+5)%8.
+        /// Mirror pairs: North↔West, Right↔Left, East↔South (negate X, same Y).
+        /// </summary>
         private static (float x, float y) GetRangedAttackOffset(Direction dir, bool mounted)
         {
             if (mounted)
             {
+                // MountedShootBow (group 27)
                 return dir switch
                 {
-                    Direction.North => (4, -61),
-                    Direction.Right => (-8, -52),
-                    Direction.East  => (-23, -57),
-                    Direction.Down  => (-25, -68),
-                    Direction.South => (-11, -75),
-                    Direction.Left  => (25, -68),
-                    Direction.West  => (23, -57),
-                    Direction.Up    => (8, -52),
+                    Direction.North => (25, -49),
+                    Direction.Right => (23, -38),
+                    Direction.East  => (8, -33),
+                    Direction.Down  => (9, -22),
+                    Direction.South => (-8, -33),
+                    Direction.Left  => (-23, -38),
+                    Direction.West  => (-25, -49),
+                    Direction.Up    => (-11, -56),
                     _ => (0, 0)
                 };
             }
 
+            // ShootBow (group 18)
             return dir switch
             {
-                Direction.North => (-3, -40),
-                Direction.Right => (-15, -39),
-                Direction.East  => (-20, -44),
-                Direction.Down  => (-12, -48),
-                Direction.South => (4, -50),
-                Direction.Left  => (12, -48),
-                Direction.West  => (20, -44),
-                Direction.Up    => (15, -39),
+                Direction.North => (12, -29),
+                Direction.Right => (20, -25),
+                Direction.East  => (15, -20),
+                Direction.Down  => (-3, 4),
+                Direction.South => (-15, -20),
+                Direction.Left  => (-20, -25),
+                Direction.West  => (-12, -29),
+                Direction.Up    => (4, -31),
                 _ => (0, 0)
             };
         }
 
         private static (float x, float y) GetSpellCastOffset(Direction dir)
         {
+            // CastDirected (group 16) — remapped: CUO dir → Analyzer dir (d+5)%8
             return dir switch
             {
-                Direction.North => (0, -15),
-                Direction.Right => (-28, -23),  // NE
-                Direction.East  => (-38, -36),
-                Direction.Down  => (-25, -48),  // SE
-                Direction.South => (1, -50),
-                Direction.Left  => (25, -48),   // SW
-                Direction.West  => (38, -36),
-                Direction.Up    => (28, -23),   // NW
+                Direction.North => (25, -48),
+                Direction.Right => (38, -36),
+                Direction.East  => (28, -23),
+                Direction.Down  => (0, -15),
+                Direction.South => (-28, -23),
+                Direction.Left  => (-38, -36),
+                Direction.West  => (-25, -48),
+                Direction.Up    => (1, -50),
                 _ => (0, 0)
             };
         }
@@ -226,6 +310,8 @@ namespace ClassicUO.Game.GameObjects
             source.Y += Offset.Y;
 
             Vector2 target = new Vector2((offsetTargetX - offsetTargetY) * 22, (offsetTargetX + offsetTargetY) * 22 - offsetTargetZ * 4);
+
+            target.Y += _targetOffsetY;
 
             var offset = target - source;
             var distance = offset.Length();

--- a/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MovingEffect.cs
@@ -1,6 +1,8 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using System;
+using ClassicUO.Assets;
+using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using Microsoft.Xna.Framework;
 
@@ -24,7 +26,8 @@ namespace ClassicUO.Game.GameObjects
             ushort hue,
             bool fixedDir,
             int duration,
-            byte speed
+            byte speed,
+            byte layer = 0xFF
         ) : base(world, manager, graphic, hue, 0, speed)
         {
             FixedDir = fixedDir;
@@ -48,6 +51,11 @@ namespace ClassicUO.Game.GameObjects
                 SetSource(xSource, ySource, zSource);
             }
 
+            // Apply hand offset for ranged weapon projectiles
+            if (source is Mobile mobile)
+            {
+                ApplyRangedAttackOffset(mobile, layer);
+            }
 
             Entity target = World.Get(trg);
 
@@ -63,6 +71,119 @@ namespace ClassicUO.Game.GameObjects
 
         public readonly bool FixedDir;
 
+        private void ApplyRangedAttackOffset(Mobile mobile, byte layer)
+        {
+            byte animGroup = mobile.AnimationGroup;
+            bool isBow = false, isXBow = false;
+
+            if (layer == 1) // Explicit RightHand from 0xC7 packet
+            {
+                switch (animGroup)
+                {
+                    case (byte)PeopleAnimationGroup.AttackCrossbow:
+                    case (byte)PeopleAnimationGroup.OnmountAttackCrossbow:
+                        isXBow = true;
+                        break;
+                    default:
+                        isBow = true;
+                        break;
+                }
+            }
+            else if (layer == 0xFF) // No layer info (0xC0 packet) — heuristic
+            {
+                switch (animGroup)
+                {
+                    case (byte)PeopleAnimationGroup.AttackBow:
+                    case (byte)PeopleAnimationGroup.OnmountAttackBow:
+                        isBow = true;
+                        break;
+                    case (byte)PeopleAnimationGroup.AttackCrossbow:
+                    case (byte)PeopleAnimationGroup.OnmountAttackCrossbow:
+                        isXBow = true;
+                        break;
+                }
+            }
+
+            if (!isBow && !isXBow)
+                return;
+
+            var dir = mobile.Direction & Direction.Mask;
+            bool mounted = mobile.IsMounted;
+            var (ox, oy) = GetRangedAttackOffset(dir, mounted, isXBow);
+
+            Offset.X += ox;
+            Offset.Y += oy;
+        }
+
+        private static (float x, float y) GetRangedAttackOffset(Direction dir, bool mounted, bool isXBow)
+        {
+            if (isXBow)
+            {
+                if (mounted)
+                {
+                    return dir switch
+                    {
+                        Direction.North => (-10, -57),
+                        Direction.Right => (-17, -62),
+                        Direction.East  => (-16, -68),
+                        Direction.Down  => (-5, -73),
+                        Direction.South => (8, -73),
+                        Direction.Left  => (5, -73),
+                        Direction.West  => (16, -68),
+                        Direction.Up    => (17, -62),
+                        _ => (0, 0)
+                    };
+                }
+                else
+                {
+                    return dir switch
+                    {
+                        Direction.North => (-1, -36),
+                        Direction.Right => (-10, -39),
+                        Direction.East  => (-13, -43),
+                        Direction.Down  => (-9, -48),
+                        Direction.South => (1, -50),
+                        Direction.Left  => (9, -48),
+                        Direction.West  => (13, -43),
+                        Direction.Up    => (10, -39),
+                        _ => (0, 0)
+                    };
+                }
+            }
+            else
+            {
+                if (mounted)
+                {
+                    return dir switch
+                    {
+                        Direction.North => (4, -61),
+                        Direction.Right => (-8, -52),
+                        Direction.East  => (-23, -57),
+                        Direction.Down  => (-25, -68),
+                        Direction.South => (-11, -75),
+                        Direction.Left  => (25, -68),
+                        Direction.West  => (23, -57),
+                        Direction.Up    => (8, -52),
+                        _ => (0, 0)
+                    };
+                }
+                else
+                {
+                    return dir switch
+                    {
+                        Direction.North => (-3, -40),
+                        Direction.Right => (-15, -39),
+                        Direction.East  => (-20, -44),
+                        Direction.Down  => (-12, -48),
+                        Direction.South => (4, -50),
+                        Direction.Left  => (12, -48),
+                        Direction.West  => (20, -44),
+                        Direction.Up    => (15, -39),
+                        _ => (0, 0)
+                    };
+                }
+            }
+        }
 
         public override void Update()
         {

--- a/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
@@ -9,6 +9,7 @@ using ClassicUO.Game.Scenes;
 using ClassicUO.IO;
 using ClassicUO.Assets;
 using ClassicUO.Renderer;
+using ClassicUO.Renderer.Animations;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MathHelper = ClassicUO.Utility.MathHelper;
@@ -170,7 +171,7 @@ namespace ClassicUO.Game.GameObjects
             posY += 22;
 
             byte direction = (byte)((byte)Layer & 0x7F & 7);
-            Client.Game.UO.Animations.GetAnimDirection(ref direction, ref IsFlipped);
+            Animations.GetAnimDirection(ref direction, ref IsFlipped);
 
             byte animIndex = (byte)AnimIndex;
             ushort graphic = GetGraphicForAnimation();
@@ -533,7 +534,7 @@ namespace ClassicUO.Game.GameObjects
                 position.Y += 22;
 
                 byte direction = (byte)((byte)Layer & 0x7F & 7);
-                animations.GetAnimDirection(ref direction, ref IsFlipped);
+                Animations.GetAnimDirection(ref direction, ref IsFlipped);
                 byte animIndex = AnimIndex;
                 bool ishuman =
                     MathHelper.InRange(Amount, 0x0190, 0x0193)

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -10,6 +10,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using ClassicUO.Renderer.Animations;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -151,7 +152,7 @@ namespace ClassicUO.Game.GameObjects
             ProcessSteps(out byte dir);
             byte layerDir = dir;
 
-            Client.Game.UO.Animations.GetAnimDirection(ref dir, ref IsFlipped);
+            Animations.GetAnimDirection(ref dir, ref IsFlipped);
 
             ushort graphic = GetGraphicForAnimation();
             byte animGroup = GetGroupForAnimation(this, graphic, true);
@@ -991,7 +992,7 @@ namespace ClassicUO.Game.GameObjects
 
             ProcessSteps(out byte dir);
             bool isFlipped = IsFlipped;
-            animations.GetAnimDirection(ref dir, ref isFlipped);
+            Animations.GetAnimDirection(ref dir, ref isFlipped);
 
             ushort graphic = GetGraphicForAnimation();
             byte animGroup = GetGroupForAnimation(this, graphic, true);

--- a/src/ClassicUO.Client/Game/Managers/EffectManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/EffectManager.cs
@@ -52,7 +52,8 @@ namespace ClassicUO.Game.Managers
             bool fixedDir,
             bool doesExplode,
             bool hasparticles,
-            GraphicEffectBlendMode blendmode
+            GraphicEffectBlendMode blendmode,
+            byte layer = 0xFF
         )
         {
             if (hasparticles)
@@ -99,7 +100,8 @@ namespace ClassicUO.Game.Managers
                         hue,
                         fixedDir,
                         duration,
-                        speed
+                        speed,
+                        layer
                     )
                     {
                         Blend = blendmode,

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -595,7 +595,8 @@ namespace ClassicUO.Game
             bool fixedDir,
             bool doesExplode,
             bool hasparticles,
-            GraphicEffectBlendMode blendmode
+            GraphicEffectBlendMode blendmode,
+            byte layer = 0xFF
         )
         {
             _effectManager.CreateEffect
@@ -616,7 +617,8 @@ namespace ClassicUO.Game
                 fixedDir,
                 doesExplode,
                 hasparticles,
-                blendmode
+                blendmode,
+                layer
             );
         }
 

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -2475,6 +2475,7 @@ namespace ClassicUO.Network
             bool doesExplode = p.ReadBool();
             uint hue = 0;
             GraphicEffectBlendMode blendmode = 0;
+            byte effectLayer = 0xFF;
 
             if (p[0] == 0x70) { }
             else
@@ -2488,7 +2489,7 @@ namespace ClassicUO.Network
                     var explodeEffect = p.ReadUInt16BE();
                     var explodeSound = p.ReadUInt16BE();
                     var serial = p.ReadUInt32BE();
-                    var layer = p.ReadUInt8();
+                    effectLayer = p.ReadUInt8();
                     p.Skip(2);
                 }
             }
@@ -2510,7 +2511,8 @@ namespace ClassicUO.Network
                 fixedDirection,
                 doesExplode,
                 false,
-                blendmode
+                blendmode,
+                effectLayer
             );
         }
 

--- a/src/ClassicUO.Renderer/Animations/Animation.cs
+++ b/src/ClassicUO.Renderer/Animations/Animation.cs
@@ -73,7 +73,7 @@ namespace ClassicUO.Renderer.Animations
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void GetAnimDirection(ref byte dir, ref bool mirror)
+        public static void GetAnimDirection(ref byte dir, ref bool mirror)
         {
             switch (dir)
             {
@@ -99,11 +99,13 @@ namespace ClassicUO.Renderer.Animations
                     break;
 
                 case 3:
+                    mirror = false;
                     dir = 0;
 
                     break;
 
                 case 7:
+                    mirror = false;
                     dir = 4;
 
                     break;


### PR DESCRIPTION
### Problem

When a character fires a bow/crossbow or casts a directed spell, the moving effect originates from the character's **tile anchor point (feet)**. In certain directions (especially South, SE, SW), this makes projectiles appear to fire from the ground rather than from the character's hand.

The 0xC7 (`HuedEffect`/`ParticleEffect`) packet includes a `layer` byte that tells the client which body part the effect originates from (e.g., `RightHand = 1`). ClassicUO reads this byte but **discards it** — it is never passed to the effect pipeline.

### Solution

**Two detection paths** for maximum compatibility:

1. **Explicit (0xC7 packet)**: When the server sends `layer = 1` (RightHand), apply hand offsets. The animation group distinguishes bow, crossbow, and directed spell.
2. **Heuristic (0xC0 packet)**: When no layer info is present, check if the source mobile is currently playing a ranged attack or directed cast animation. This enables the fix for legacy servers that only send 0xC0.

Pixel offsets are applied in `MovingEffect` as additions to `Offset.X`/`Offset.Y`, the same mechanism already used for the baseline `+22` half-tile centering.

### Offset derivation

#### Ranged weapons (bow/crossbow)

The offset table was produced by a purpose-built [AnimFrameAnalyzer](https://discord.com/channels/751317910504603701/1479366801916821628) (Can be found on the [ModernUO Discord](https://muo.gg/discord)) tool that composites body 400 (human male) with each weapon's equipment overlay from `anim.mul`–`anim5.mul` at the **release frame** of each attack animation.

Results can be downloaded here: [Averaged-Grip-Contacts.zip](https://github.com/user-attachments/files/25787747/Averaged-Grip-Contacts.zip)

**Method** (extremity-biased weighted centroid, averaged across weapons):

1. For each weapon x direction x mounted state, composite body + equipment at the release frame using ClassicUO's Y anchor formula: `screenY = pixelY - (Height + CenterY)`
2. Find **contact points** — equipment pixels adjacent (within radius 2) to body pixels in screen space (the grip zone)
3. Compute a **bias direction** from the body center toward the equipment's visual centroid
4. **Weight** each contact point by its projection along the bias direction using quadratic falloff — contacts toward the weapon tip (front hand / arrow release point) receive exponentially more weight:
   ```
   bias = normalize(equipmentCentroid - bodyCenter)
   projection = dot(contact, bias)
   t = (projection - min) / range       // 0 = body side, 1 = weapon tip
   weight = 0.1 + t^2
   ```
5. **Average** the weighted grip points across all weapons sharing the same action, producing 4 universal tables:
   - **ShootBow** (5 bows: Bow, Composite, Elven Composite, Magical Shortbow, Yumi)
   - **MountedShootBow** (same 5)
   - **ShootXBow** (3 crossbows: Crossbow, Heavy Crossbow, Repeating Crossbow)
   - **MountedShootXBow** (same 3)

The max deviation of any individual weapon from its group average is ~5px — imperceptible in-game. New weapons using the same animation groups get correct offsets automatically.

#### Example Heuristic Screenshots
<img width="140" height="143" alt="AVG_Bow_ShootBow_dir6_West_f3_RELEASE" src="https://github.com/user-attachments/assets/4f4a131c-d828-49ed-8b27-1f3adfbff4e2" />
<img width="140" height="140" alt="AVG_Bow_MountedShootBow_dir2_East_f2_RELEASE" src="https://github.com/user-attachments/assets/d26242d2-cff1-455b-8f6a-a72152e8a815" />

#### Directed spells (Magic Arrow, Fireball, Energy Bolt)

The spell offset table was produced by a SpellFrameAnalyzer, a tool similar to the AnimFrameAnalyzer that renders body 400 at the **release frame** of the CastDirected animation (group 16), then **hand-tuned** by visually placing offset markers on the casting hand in each of the 8 directions.

Dirs 5–7 are horizontal mirrors of dirs 3–1 (X negated, Y identical), matching UO's animation storage format. Only unmounted offsets are needed — the server does not send cast animation while mounted (`Spell.cs:917`).

#### Example Tuned Screenshots
<img width="160" height="151" alt="CastDirected_dir3_SE_f3_RELEASE" src="https://github.com/user-attachments/assets/bcac840d-015a-452d-b718-219c51a8d654" />
<img width="160" height="152" alt="CastDirected_dir2_East_f3_RELEASE" src="https://github.com/user-attachments/assets/3d3771dd-9213-47e9-a183-7347227af273" />

### Design notes

- **No body-type check needed**: `PeopleAnimationGroup` values only match human animation groups, so non-human mobiles firing projectiles naturally skip the offset logic.
- **Default parameter (`0xFF`)**: All existing callers are unaffected — the layer defaults to "no info" which triggers the heuristic path only.
- **Explicit path is precise**: With `layer = 1`, each animation group is explicitly matched (`AttackBow`, `AttackCrossbow`, `CastDirected`). Unrecognized animations receive zero offset — no default-to-bow fallback.
- **Heuristic path detects all three types**: `AttackBow`/`OnmountAttackBow`, `AttackCrossbow`/`OnmountAttackCrossbow`, and `CastDirected` are all checked in the 0xC0 path for legacy server compatibility.
- **Other spells unaffected**: Spells using `CastArea` (group 17) or non-projectile effects (Lightning, Heal, etc.) don't match any detected animation group and receive zero offset.

### Test plan

- [ ] Fire bow/crossbow unmounted in all 8 directions — arrows originate near hand
- [ ] Fire bow/crossbow mounted in all 8 directions — arrows originate near hand
- [ ] Cast Magic Arrow in all 8 directions — projectile originates near casting hand
- [ ] Cast Fireball in all 8 directions — projectile originates near casting hand
- [ ] Cast Energy Bolt in all 8 directions — projectile originates near casting hand
- [ ] Spell projectiles track moving targets (homing preserved)
- [ ] Spell reflect — projectile originates from defender's hand
- [ ] NPC archers/casters — offsets apply to their projectiles too
- [ ] Non-projectile spell effects (Lightning, Heal, etc.) — no visual change
- [ ] Drag effects / other moving effects — no visual change
- [ ] Cast while mounted — no offset applied (expected, no animation sent)
- [ ] Test with 0xC0-only server (legacy) — heuristic detection still works
