### PR TITLE
Fixes keep alive on server select / character creation

### DIFF
--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -161,7 +161,7 @@ namespace ClassicUO.Game.Scenes
                 }
             }
 
-            if ((CurrentLoginStep == LoginSteps.CharacterCreation || CurrentLoginStep == LoginSteps.CharacterSelection) && Time.Ticks > _pingTime)
+            if ((CurrentLoginStep == LoginSteps.CharacterCreation || CurrentLoginStep == LoginSteps.CharacterSelection || CurrentLoginStep == LoginSteps.ServerSelection) && Time.Ticks > _pingTime)
             {
                 // Note that this will not be an ICMP ping, so it's better that this *not* be affected by -no_server_ping.
 
@@ -170,7 +170,7 @@ namespace ClassicUO.Game.Scenes
                     NetClient.Socket.Statistics.SendPing();
                 }
 
-                _pingTime = Time.Ticks + 60000;
+                _pingTime = Time.Ticks + 10000;
             }
         }
 
@@ -209,12 +209,12 @@ namespace ClassicUO.Game.Scenes
                 case LoginSteps.CharacterSelection: return new CharacterSelectionGump(_world);
 
                 case LoginSteps.ServerSelection:
-                    _pingTime = Time.Ticks + 60000; // reset ping timer
+                    _pingTime = Time.Ticks + 10000; // reset ping timer
 
                     return new ServerSelectionGump(_world);
 
                 case LoginSteps.CharacterCreation:
-                    _pingTime = Time.Ticks + 60000; // reset ping timer
+                    _pingTime = Time.Ticks + 10000; // reset ping timer
 
                     return new CharCreationGump(_world,this);
             }


### PR DESCRIPTION
### Summary

The ping time for server selection, character creation etc is too long. ModernUO no longer waits 90s for DDoS/attack reasons and now only waits 30s, expecting a nominal ping every few seconds. While we don't need pings every 1s like in-game, 10s should suffice, otherwise players designing their character will get booted for inactivity after some time.

I can understand if we don't want to send pings during server selection, it shouldn't take that long to choose a server. Let me know what you think and I can change it, or you are welcome to update this PR.