### PR TITLE
Updated Mount Visuals

### DIFF
--- a/src/ClassicUO.Client/Game/Data/Mounts.cs
+++ b/src/ClassicUO.Client/Game/Data/Mounts.cs
@@ -65,7 +65,7 @@ internal static class Mounts
         _mounts[0x3ED2] = new(0x05F6, 0x3ED2, 9); // war boar
         _mounts[0x3ECD] = new(0x0580, 0x3ECD, 0); // Palomino
         _mounts[0x3ECF] = new(0x05A0, 0x3ECF, 9); // Eowmu
-        _mounts[0x3ED3] = new(0x05F7, 0x3ED3, 18); // capybara
+        _mounts[0x3ED3] = new(0x05F7, 0x3ED3, 11); // capybara
         _mounts[0x3ED4] = new(0x060A, 0x3ED4, 0); // (no description provided)
         _mounts[0x3ED5] = new(0x060B, 0x3ED5, 0); // a wolf
         _mounts[0x3ED6] = new(0x060C, 0x3ED6, 0); // an orange dog 2?
@@ -73,8 +73,8 @@ internal static class Mounts
         _mounts[0x3ED8] = new(0x060F, 0x3ED8, 0); // a black dog?
         _mounts[0x3ED9] = new(0x0610, 0x3ED9, 0); // a doberman?
         _mounts[0x3EDA] = new(0x0590, 0x3EDA, 9); // Frostmites Beetles
-        _mounts[0x3EDB] = new(0x0611, 0x3EDB, 0); // Manticore
-        _mounts[0x3EDC] = new(0x0666, 0x3EDC, 0); // Bear Zombie
+        _mounts[0x3EDB] = new(0x0611, 0x3EDB, 14); // Manticore
+        _mounts[0x3EDC] = new(0x0666, 0x3EDC, 12); // Bear Zombie
         _mounts[0x3EDD] = new(0x0581, 0x3EDD, 0); // Dragon_Hildebrandt
         _mounts[0x3EDE] = new(0x0673, 0x3EDE, 0); // Horse_Clydesdale
         _mounts[0x3EDF] = new(0x0674, 0x3EDF, 0); // Horse_Elemental_Earth

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -778,17 +778,27 @@ namespace ClassicUO.Game.GameObjects
                     }
                     else
                     {
-                        int diffY = (spriteInfo.UV.Height + spriteInfo.Center.Y) - mountOffset;
+                        // Some mounted creature bodies do not render correctly with ClassicUO's
+                        // default vertical slice-based depth layering used for mount occlusion.
+                        // On these bodies, the generic depth slicing can cause rider legs or other
+                        // character parts to clip through the mount torso due to the artwork not
+                        // matching the assumptions of the standard mounted depth model.
+                        //
+                        // For the listed mounted body IDs, draw the mount as a single layer instead.
+                        // This avoids incorrect rider/mount occlusion while leaving normal mount
+                        // rendering behavior unchanged for all other bodies.
+                        bool drawMountAsSingleLayer =
+                            isMount &&
+                            (
+                                id == 0x04E6 || // tiger
+                                id == 0x04E7 || // tiger
+                                id == 0x0611 || // Manticore
+                                id == 0x05F7 || // capybara
+                                id == 0x0666 || // Bear Zombie
+                                id == 0x05A1 // cat skeleton
+                            );
 
-                        int value = Math.Max(1, diffY);
-                        int count = Math.Max((spriteInfo.UV.Height / value) + 1, 2);
-
-                        rect.Height = Math.Min(value, rect.Height);
-                        int remains = spriteInfo.UV.Height - rect.Height;
-
-                        int tiles = (byte)owner.Direction % 2 == 0 ? 2 : 2;
-
-                        for (int i = 0; i < count; ++i)
+                        if (drawMountAsSingleLayer)
                         {
                             batcher.Draw(
                                 spriteInfo.Texture,
@@ -799,13 +809,40 @@ namespace ClassicUO.Game.GameObjects
                                 Vector2.Zero,
                                 1f,
                                 mirror ? SpriteEffects.FlipHorizontally : SpriteEffects.None,
-                                depth + 1f + (i * tiles)
+                                depth + 1f
                             );
+                        }
+                        else
+                        {
+                            int diffY = (spriteInfo.UV.Height + spriteInfo.Center.Y) - mountOffset;
 
-                            pos.Y += rect.Height;
-                            rect.Y += rect.Height;
-                            rect.Height = remains;
-                            remains -= rect.Height;
+                            int value = Math.Max(1, diffY);
+                            int count = Math.Max((spriteInfo.UV.Height / value) + 1, 2);
+
+                            rect.Height = Math.Min(value, rect.Height);
+                            int remains = spriteInfo.UV.Height - rect.Height;
+
+                            int tiles = (byte)owner.Direction % 2 == 0 ? 2 : 2;
+
+                            for (int i = 0; i < count; ++i)
+                            {
+                                batcher.Draw(
+                                    spriteInfo.Texture,
+                                    pos,
+                                    rect,
+                                    hueVec,
+                                    0f,
+                                    Vector2.Zero,
+                                    1f,
+                                    mirror ? SpriteEffects.FlipHorizontally : SpriteEffects.None,
+                                    depth + 1f + (i * tiles)
+                                );
+
+                                pos.Y += rect.Height;
+                                rect.Y += rect.Height;
+                                rect.Height = remains;
+                                remains -= rect.Height;
+                            }
                         }
                     }
 


### PR DESCRIPTION
Implemented a special rendering path for select mounted body IDs that were exhibiting rider clipping issues in ClassicUO. Normally, mounted creatures are drawn using a vertical slice-based depth layering system intended to improve front/back occlusion between the rider and mount. While this works for most standard mounts, some newer or nonstandard mounted bodies do not match the assumptions of that depth model. As a result, parts of the rider most notably legs could render incorrectly through the mount’s torso or ribs.

For the affected mounts, rendering is now forced to use a single-layer draw instead of the generic slice-based depth pass. This preserves proper visual composition for these bodies and eliminates obvious clipping artifacts without changing rendering behavior for normal mounts.

Affected mounted body IDs:

0x04E6 Tiger
0x04E7 Tiger (alternate)
0x0611  Manticore
0x05F7 Capybara
0x0666  Bear Zombie
0x05A1 Skeletal Cat