### PR TITLE
Fix: bulletin board container overflow

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/BulletinBoardGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/BulletinBoardGump.cs
@@ -74,7 +74,7 @@ namespace ClassicUO.Game.UI.Gumps
                 127,
                 159,
                 241,
-                195,
+                BulletinBoardObject.ITEM_HEIGHT * 9,
                 false
             );
 
@@ -484,12 +484,14 @@ namespace ClassicUO.Game.UI.Gumps
 
     internal class BulletinBoardObject : Control
     {
+        public const int ITEM_HEIGHT = 18;
+
         public BulletinBoardObject(uint serial, string text)
         {
             LocalSerial = serial; //board
             CanMove = true;
             Width = 230;
-            Height = 18;
+            Height = ITEM_HEIGHT;
 
             Add(new GumpPic(0, 0, 0x1523, 0));
 


### PR DESCRIPTION
Bulletin board shows too many messages which causes an overflow outside of the parent container, set it to 9 as per the official client which works perfectly

AFTER image is scrolled to show where the cutoffs are

<img width="1747" height="716" alt="image" src="https://github.com/user-attachments/assets/0417cb51-000b-48e3-8b0a-5b20b715a60b" />
