### PR TITLE
fix: wide item render being overwritten by southern statics

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Views/View.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/View.cs
@@ -240,6 +240,11 @@ namespace ClassicUO.Game.GameObjects
                 index.Width = (short)((artInfo.UV.Width >> 1) - 22);
                 index.Height = (short)(artInfo.UV.Height - 44);
 
+                if (index.Width > 0)
+                {
+                    depth += index.Width / 22f;
+                }
+
                 x -= index.Width;
                 y -= index.Height;
 


### PR DESCRIPTION
Fixes this issue in the screenshot which has been present since at least 2021 and the fix matches it with the OSI view.

<img width="1376" height="488" alt="image" src="https://github.com/user-attachments/assets/f8960172-e5d0-458a-b780-3ef38644cc9e" />

Testing involved walking around the world looking for incorrect renders, such as stairs, multis, boats, clumped trees and house placements. No visible problems.