### PR TITLE
Fix 14 confirmed bugs across IO, utility, network, and bootstrap layers

### DIFF
--- a/src/ClassicUO.Bootstrap/src/LibraryLoader.cs
+++ b/src/ClassicUO.Bootstrap/src/LibraryLoader.cs
@@ -138,7 +138,7 @@ namespace ClassicUO
 
             public override int FreeLibrary(IntPtr module)
             {
-                return m_useLibdl1 ? Libdl1.dlerror() : Libdl2.dlerror();
+                return m_useLibdl1 ? Libdl1.dlclose(module) : Libdl2.dlclose(module);
             }
         }
     }

--- a/src/ClassicUO.Bootstrap/src/Program.cs
+++ b/src/ClassicUO.Bootstrap/src/Program.cs
@@ -236,7 +236,7 @@ sealed class ClassicUOHost : IPluginHandler
             fixed (IntPtr* argvPtr = argv)
                 initializeMethod(argvPtr, args.Length, mem);
 
-            if (mem != null)
+            if (mem != IntPtr.Zero)
                 Marshal.FreeHGlobal(mem);
         }
     }

--- a/src/ClassicUO.Client/Game/Managers/CommandManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/CommandManager.cs
@@ -123,10 +123,13 @@ namespace ClassicUO.Game.Managers
             if (entity != null)
             {
                 _world.TargetManager.Target(entity);
+                Mouse.LastLeftButtonClickTime = 0;
+                GameActions.Print(_world, string.Format(ResGeneral.ItemID0Hue1, entity.Graphic, entity.Hue));
             }
-
-            Mouse.LastLeftButtonClickTime = 0;
-            GameActions.Print(_world, string.Format(ResGeneral.ItemID0Hue1, entity.Graphic, entity.Hue));
+            else
+            {
+                Mouse.LastLeftButtonClickTime = 0;
+            }
         }
     }
 }

--- a/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
+++ b/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
@@ -32,8 +32,24 @@ sealed class WebSocketWrapper : SocketWrapper
 
     public override void Connect(Uri uri) => ConnectAsync(uri, _tokenSource).Wait();
 
-    public override void Send(byte[] buffer, int offset, int count) =>
-        _webSocket.SendAsync(buffer.AsMemory().Slice(offset, count), WebSocketMessageType.Binary, true, _tokenSource.Token);
+    public override void Send(byte[] buffer, int offset, int count)
+    {
+        var copy = Shared.Rent(count);
+        Buffer.BlockCopy(buffer, offset, copy, 0, count);
+        SendCopyAsync(copy, count);
+    }
+
+    private async void SendCopyAsync(byte[] copy, int count)
+    {
+        try
+        {
+            await _webSocket.SendAsync(copy.AsMemory().Slice(0, count), WebSocketMessageType.Binary, true, _tokenSource.Token);
+        }
+        finally
+        {
+            Shared.Return(copy);
+        }
+    }
 
     public override int Read(byte[] buffer)
     {
@@ -195,8 +211,15 @@ sealed class WebSocketWrapper : SocketWrapper
         if (!IsConnected)
             return;
 
-        _tokenSource?.Cancel();
-        _webSocket?.CloseAsync(WebSocketCloseStatus.NormalClosure, "Disconnect", _tokenSource?.Token ?? default);
+        try
+        {
+            _webSocket?.CloseAsync(WebSocketCloseStatus.NormalClosure, "Disconnect", CancellationToken.None)
+                .ContinueWith(_ => _tokenSource?.Cancel());
+        }
+        catch
+        {
+            _tokenSource?.Cancel();
+        }
     }
 
     public override void Dispose()

--- a/src/ClassicUO.IO/MMFileReader.cs
+++ b/src/ClassicUO.IO/MMFileReader.cs
@@ -36,11 +36,11 @@ namespace ClassicUO.IO
                     _file = new BinaryReader(new UnmanagedMemoryStream(ptr, Length));
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
 
-                throw new Exception("Something went wrong...");
+                throw new InvalidOperationException("Failed to acquire memory-mapped file pointer.", ex);
             }
         }
 

--- a/src/ClassicUO.IO/UOFile.cs
+++ b/src/ClassicUO.IO/UOFile.cs
@@ -13,11 +13,6 @@ namespace ClassicUO.IO
             Entries = Array.Empty<UOFileIndex>();
 
             Log.Trace($"Loading file:\t\t{filepath}");
-
-            if (!File.Exists(filepath))
-            {
-                Log.Error($"{filepath} not exists.");
-            }
         }
 
 

--- a/src/ClassicUO.IO/UOFileIndex.cs
+++ b/src/ClassicUO.IO/UOFileIndex.cs
@@ -54,7 +54,7 @@ namespace ClassicUO.IO
 
         public bool Equals(UOFileIndex other)
         {
-            return (File, Offset, Length, DecompressedLength) == (File, other.Offset, other.Length, other.DecompressedLength);
+            return (File, Offset, Length, DecompressedLength) == (other.File, other.Offset, other.Length, other.DecompressedLength);
         }
     }
 

--- a/src/ClassicUO.Utility/AverageOverTime.cs
+++ b/src/ClassicUO.Utility/AverageOverTime.cs
@@ -40,7 +40,7 @@ namespace ClassicUO.Utility
         /// <param name="currentTicks">The current time used for comparison.</param>
         private void RemoveOldValues(uint currentTicks)
         {
-            while (_values.Count > 0 && (currentTicks - _values.Peek().Timestamp) > (currentTicks - _timeWindow.TotalMilliseconds))
+            while (_values.Count > 0 && (currentTicks - _values.Peek().Timestamp) > _timeWindow.TotalMilliseconds)
             {
                 var oldItem = _values.Dequeue();
                 _sum -= oldItem.Value;

--- a/src/ClassicUO.Utility/Collections/Bag.cs
+++ b/src/ClassicUO.Utility/Collections/Bag.cs
@@ -71,12 +71,13 @@ namespace ClassicUO.Utility.Collections
                 return;
             }
 
+            int previousCount = Count;
             Count = 0;
 
             // non-primitive types are cleared so the garbage collector can release them
             if (!_isPrimitive)
             {
-                Array.Clear(_items, 0, Count);
+                Array.Clear(_items, 0, previousCount);
             }
         }
 

--- a/src/ClassicUO.Utility/Collections/ReadOnlyArrayView.cs
+++ b/src/ClassicUO.Utility/Collections/ReadOnlyArrayView.cs
@@ -67,7 +67,7 @@ namespace ClassicUO.Utility.Collections
             public Enumerator(ReadOnlyArrayView<T> view)
             {
                 _view = view;
-                _currentIndex = (int) view._start;
+                _currentIndex = (int) view._start - 1;
             }
 
             public T Current => _view._items[_currentIndex];
@@ -75,19 +75,14 @@ namespace ClassicUO.Utility.Collections
 
             public bool MoveNext()
             {
-                if (_currentIndex != _view._start + _view.Count - 1)
-                {
-                    _currentIndex += 1;
+                _currentIndex += 1;
 
-                    return true;
-                }
-
-                return false;
+                return _currentIndex < _view._start + _view.Count;
             }
 
             public void Reset()
             {
-                _currentIndex = (int) _view._start;
+                _currentIndex = (int) _view._start - 1;
             }
 
             public void Dispose()

--- a/src/ClassicUO.Utility/Logging/LogFile.cs
+++ b/src/ClassicUO.Utility/Logging/LogFile.cs
@@ -32,11 +32,12 @@ namespace ClassicUO.Utility.Logging
 
         public void Write(string message)
         {
-            byte[] buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(message.Length);
+            int maxByteCount = Encoding.UTF8.GetMaxByteCount(message.Length);
+            byte[] buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(maxByteCount);
 
             try
             {
-                Encoding.UTF8.GetBytes
+                int byteCount = Encoding.UTF8.GetBytes
                 (
                     message,
                     0,
@@ -45,7 +46,7 @@ namespace ClassicUO.Utility.Logging
                     0
                 );
 
-                logStream.Write(buffer, 0, message.Length);
+                logStream.Write(buffer, 0, byteCount);
                 logStream.WriteByte((byte) '\n');
                 logStream.Flush();
             }
@@ -57,11 +58,12 @@ namespace ClassicUO.Utility.Logging
 
         public async Task WriteAsync(string message)
         {
-            byte[] buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(message.Length);
+            int maxByteCount = Encoding.UTF8.GetMaxByteCount(message.Length);
+            byte[] buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(maxByteCount);
 
             try
             {
-                Encoding.UTF8.GetBytes
+                int byteCount = Encoding.UTF8.GetBytes
                 (
                     message,
                     0,
@@ -70,7 +72,7 @@ namespace ClassicUO.Utility.Logging
                     0
                 );
 
-                await logStream.WriteAsync(buffer, 0, message.Length);
+                await logStream.WriteAsync(buffer, 0, byteCount);
                 logStream.WriteByte((byte) '\n');
                 await logStream.FlushAsync();
             }

--- a/src/ClassicUO.Utility/Logging/LogTypes.cs
+++ b/src/ClassicUO.Utility/Logging/LogTypes.cs
@@ -14,7 +14,7 @@ namespace ClassicUO.Utility.Logging
         Warning = 0x08,
         Error = 0x10,
         Panic = 0x20,
-        Table = 0x30,
+        Table = 0x40,
         All = byte.MaxValue
     }
 }

--- a/src/ClassicUO.Utility/UnsafeMemoryManager.cs
+++ b/src/ClassicUO.Utility/UnsafeMemoryManager.cs
@@ -25,13 +25,23 @@ namespace ClassicUO.Utility
 
         public static void Memset(void* ptr, byte value, int count)
         {
+            // Fill the 8-byte pattern with the value in every byte
+            long fill = (long)value * 0x0101010101010101L;
+
             long* c = (long*) ptr;
+            int longCount = count / 8;
 
-            count /= 8;
-
-            for (int i = 0; i < count; ++i)
+            for (int i = 0; i < longCount; ++i)
             {
-                *c++ = (long) value;
+                *c++ = fill;
+            }
+
+            // Handle trailing bytes
+            byte* tail = (byte*) c;
+            int remaining = count % 8;
+            for (int i = 0; i < remaining; ++i)
+            {
+                *tail++ = value;
             }
         }
 


### PR DESCRIPTION
- UOFileIndex.Equals: compare other.File instead of self
- LibraryLoader.FreeLibrary: call dlclose() instead of dlerror() on Unix
- Bag.Clear(): save count before zeroing so Array.Clear clears correctly
- ReadOnlyArrayView.Enumerator: fix off-by-one skipping first element
- CommandManager.OnHueTarget: null-check entity before accessing members
- WebSocketWrapper.Send: copy buffer before async send to prevent reuse
- WebSocketWrapper.Disconnect: close socket before cancelling token
- MMFileReader: preserve original exception instead of swallowing it
- UOFile: remove dead File.Exists check after File.Open
- LogFile.Write: use UTF-8 byte count instead of char count for buffer
- LogTypes.Table: fix overlapping flag value (0x30 -> 0x40)
- AverageOverTime.RemoveOldValues: fix nonsensical timestamp comparison
- UnsafeMemoryManager.Memset: fill all 8 bytes of pattern + trailing bytes
- Program.cs: compare IntPtr to IntPtr.Zero instead of null