### PR TITLE
Fix animation, lighting, and selection for chunk-meshed statics

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Views/MultiView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MultiView.cs
@@ -92,7 +92,7 @@ namespace ClassicUO.Game.GameObjects
 
             DrawStaticAnimated(batcher, graphic, posX, posY, hueVec, false, depth);
 
-            if (ItemData.IsLight)
+            if (ItemData.IsLight && !InChunkMesh)
             {
                 Client.Game.GetScene<GameScene>().AddLight(this, this, posX + 22, posY + 22);
             }

--- a/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
@@ -82,7 +82,7 @@ namespace ClassicUO.Game.GameObjects
                 ProfileManager.CurrentProfile.AnimatedWaterEffect && ItemData.IsWet
             );
 
-            if (ItemData.IsLight)
+            if (ItemData.IsLight && !InChunkMesh)
             {
                 Client.Game.GetScene<GameScene>().AddLight(this, this, posX + 22, posY + 22);
             }

--- a/src/ClassicUO.Client/Game/Map/ChunkMesh.cs
+++ b/src/ClassicUO.Client/Game/Map/ChunkMesh.cs
@@ -382,8 +382,7 @@ namespace ClassicUO.Game.Map
             if (itemData.IsInternal)
                 return true;
 
-            ref UOFileIndex index = ref Client.Game.UO.FileManager.Arts.File.GetValidRefEntry(graphic + 0x4000);
-            if (index.AnimOffset != 0)
+            if (itemData.IsAnimated)
                 return true;
 
             if (itemData.IsFoliage)

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
@@ -565,6 +565,11 @@ namespace ClassicUO.Game.Scenes
                 mesh.Statics.SetVisible(obj.MeshSpriteIndex, obj.AlphaHue, cot);
                 ApplyMeshHue(obj, mesh.Statics);
 
+                if (itemData.IsLight)
+                {
+                    AddLight(obj, obj, obj.RealScreenPosition.X + 22, obj.RealScreenPosition.Y + 22);
+                }
+
                 if (allowSelection && !(cot && IsMouseInsideCotCircle()) && obj.AllowedToDraw && obj.CheckMouseSelection())
                 {
                     if (SelectedObject.Object is GameObject prev)
@@ -839,6 +844,12 @@ namespace ClassicUO.Game.Scenes
                         && obj.TransparentTest(_world.Player.Z + 5);
                     mesh.Statics.SetVisible(obj.MeshSpriteIndex, obj.AlphaHue, meshCot);
                     ApplyMeshHue(obj, mesh.Statics);
+
+                    if (meshItemData.IsLight)
+                    {
+                        AddLight(obj, obj, obj.RealScreenPosition.X + 22, obj.RealScreenPosition.Y + 22);
+                    }
+
                     TrySelectObject(obj, meshAllowSelection && !(meshCot && IsMouseInsideCotCircle()));
                     continue;
                 }


### PR DESCRIPTION
  - Use TileFlag.Animation (itemData.IsAnimated) instead of runtime AnimOffset to exclude animated statics from chunk mesh, restoring their animation cycle
  - Register light sources for meshed statics/multis in both the fast path and ProcessStaticLikeTail visibility paths
  - Prevent double light registration when selecting a meshed object by skipping AddLight in Draw() for InChunkMesh objects