### PR TITLE
Add adaptive walk coalescing and fast rotation option

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -148,6 +148,7 @@ namespace ClassicUO.Configuration
         public bool UseShiftToPathfind { get; set; }
         public bool AlwaysRun { get; set; }
         public bool AlwaysRunUnlessHidden { get; set; }
+        public bool FastRotation { get; set; }
         public bool SmoothMovements { get; set; } = true;
         public bool HoldDownKeyTab { get; set; } = true;
         public bool HoldShiftForContext { get; set; } = false;

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -14,7 +14,7 @@ namespace ClassicUO.Game
         public const int ITEM_EFFECT_ANIMATION_DELAY = 50;
 
         public const int MAX_STEP_COUNT = 5;
-        public const int TURN_DELAY = 100; // original client 12.5 fps = 80ms delay. Edit --> it causes throttling
+        public const int TURN_DELAY = 80;
         public const int TURN_DELAY_FAST = 45;
         public const int WALKING_DELAY = 150; // 750
         public const int PLAYER_WALKING_DELAY = 150;

--- a/src/ClassicUO.Client/Game/Data/MovementSpeed.cs
+++ b/src/ClassicUO.Client/Game/Data/MovementSpeed.cs
@@ -11,6 +11,9 @@ namespace ClassicUO.Game.Data
         public const int STEP_DELAY_RUN = 200;
         public const int STEP_DELAY_WALK = 400;
 
+        public static bool FastRotation;
+        public static int TurnDelay => FastRotation ? Constants.TURN_DELAY_FAST : Constants.TURN_DELAY;
+
         public static int TimeToCompleteMovement(bool run, bool mounted)
         {
             if (mounted)

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -560,7 +560,7 @@ namespace ClassicUO.Game.GameObjects
             }
 
             sbyte oldZ = z;
-            ushort walkTime = Constants.TURN_DELAY;
+            ushort walkTime = (ushort)MovementSpeed.TurnDelay;
 
             if ((oldDirection & Direction.Mask) == (direction & Direction.Mask))
             {
@@ -618,7 +618,7 @@ namespace ClassicUO.Game.GameObjects
             // Adaptive coalescing: only suppress direction-only packets when the server
             // is falling behind (3+ unconfirmed packets). This allows full-speed spinning
             // when the connection is healthy and automatically backs off under congestion.
-            if (walkTime == Constants.TURN_DELAY && Walker.UnacceptedPacketsCount >= 3)
+            if (walkTime == (ushort)MovementSpeed.TurnDelay && Walker.UnacceptedPacketsCount >= 3)
             {
                 Direction = direction;
                 Walker.LastStepRequestTime = Time.Ticks + walkTime;
@@ -683,26 +683,7 @@ namespace ClassicUO.Game.GameObjects
 
             AddToTile();
 
-            int nowDelta = 0;
-
-            //if (_lastDir == (int) direction && _lastMount == IsMounted && _lastRun == run)
-            //{
-            //    nowDelta = (int) (Time.Ticks - _lastStepTime - walkTime + _lastDelta);
-
-            //    if (Math.Abs(nowDelta) > 70)
-            //        nowDelta = 0;
-            //    _lastDelta = nowDelta;
-            //}
-            //else
-            //    _lastDelta = 0;
-
-            //_lastStepTime = (int) Time.Ticks;
-            //_lastRun = run;
-            //_lastMount = IsMounted;
-            //_lastDir = (int) direction;
-
-
-            Walker.LastStepRequestTime = Time.Ticks + walkTime - nowDelta;
+            Walker.LastStepRequestTime = Time.Ticks + walkTime;
             GetGroupForAnimation(this, 0, true);
 
             return true;

--- a/src/ClassicUO.Client/Game/Managers/WalkerManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/WalkerManager.cs
@@ -1,5 +1,26 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+// UO Movement System
+//
+// Turns (direction changes) have no delay. The client sends a 0x02 walk request
+// with the new direction and the server confirms it immediately. Both turns and
+// tile movements use the same packet (0x02) and confirmation (0x22).
+//
+// Movement speeds (retail):
+//   Walking:       400ms per tile  (2.5 tiles/sec)
+//   Running:       200ms per tile  (5.0 tiles/sec)
+//   Mounted walk:  200ms per tile  (5.0 tiles/sec)
+//   Mounted run:   100ms per tile  (10.0 tiles/sec)
+//
+// The client may queue up to 5 unconfirmed walk packets (MaxStepCount).
+// The Enhanced Client (EC) allows 4 queued moves including the initial turn.
+// If the server falls behind on confirmations and the queue fills, the client
+// must wait before sending more movement packets.
+//
+// Each walk request carries a sequence byte (0-255, wrapping). The server echoes
+// the sequence in its 0x22 confirmation. If a confirmation arrives for an unknown
+// sequence, the client triggers a resync (0x22 "bad step" path).
+
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Network;
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -123,6 +123,7 @@ namespace ClassicUO.Game.Scenes
             NetClient.Socket.Disconnected += SocketOnDisconnected;
             _world.MessageManager.MessageReceived += ChatOnMessageReceived;
             UIManager.ContainerScale = ProfileManager.CurrentProfile.ContainersScale / 100f;
+            Data.MovementSpeed.FastRotation = ProfileManager.CurrentProfile.FastRotation;
 
             SDL.SDL_SetWindowMinimumSize(Client.Game.Window.Handle, Client.Game.ScaleWithDpi(640), Client.Game.ScaleWithDpi(480));
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -80,6 +80,7 @@ namespace ClassicUO.Game.UI.Gumps
                          _useShiftPathfind,
                          _alwaysRun,
                          _alwaysRunUnlessHidden,
+                         _fastRotation,
                          _showHpMobile,
                          _highlightByPoisoned,
                          _highlightByParalyzed,
@@ -517,6 +518,18 @@ namespace ClassicUO.Game.UI.Gumps
                     null,
                     ResGumps.AlwaysRunHidden,
                     _currentProfile.AlwaysRunUnlessHidden,
+                    startX,
+                    startY
+                )
+            );
+
+            section.Add
+            (
+                _fastRotation = AddCheckBox
+                (
+                    null,
+                    "Fast rotation",
+                    _currentProfile.FastRotation,
                     startX,
                     startY
                 )
@@ -3789,6 +3802,8 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.UseShiftToPathfind = _useShiftPathfind.IsChecked;
             _currentProfile.AlwaysRun = _alwaysRun.IsChecked;
             _currentProfile.AlwaysRunUnlessHidden = _alwaysRunUnlessHidden.IsChecked;
+            _currentProfile.FastRotation = _fastRotation.IsChecked;
+            MovementSpeed.FastRotation = _fastRotation.IsChecked;
             _currentProfile.ShowMobilesHP = _showHpMobile.IsChecked;
             _currentProfile.HighlightMobilesByPoisoned = _highlightByPoisoned.IsChecked;
             _currentProfile.HighlightMobilesByParalize = _highlightByParalyzed.IsChecked;


### PR DESCRIPTION
Suppress direction-only walk packets when 3+ are unconfirmed to reduce server congestion. Add FastRotation profile option (80ms normal, 45ms fast turn delay) with UI checkbox in movement options.