### PR TITLE
Add HP bar on object handles and per-notoriety filters

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -212,6 +212,8 @@ namespace ClassicUO.Configuration
         public bool DragSelectAsAnchor { get; set; } = false;
         public NameOverheadTypeAllowed NameOverheadTypeAllowed { get; set; } = NameOverheadTypeAllowed.All;
         public bool NameOverheadToggled { get; set; } = false;
+        public bool NameOverheadShowGump { get; set; } = true;
+        public bool NameOverheadShowHpBar { get; set; } = true;
         public bool ShowTargetRangeIndicator { get; set; }
         public bool PartyInviteGump { get; set; }
         public bool CustomBarsToggled { get; set; }

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -44,6 +44,7 @@ namespace ClassicUO.Game
         public const int MAX_OBJECT_HANDLES = 200;
         public const int OBJECT_HANDLES_GUMP_WIDTH = 100;
         public const int OBJECT_HANDLES_GUMP_HEIGHT = 18;
+        public const int OBJECT_HANDLES_HP_BAR_HEIGHT = 3;
 
         public const int SPELLBOOK_1_SPELLS_COUNT = 64;
         public const int SPELLBOOK_2_SPELLS_COUNT = 17;

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -969,7 +969,9 @@ namespace ClassicUO.Game.GameObjects
 
             if (ObjectHandlesStatus == ObjectHandlesStatus.DISPLAYING)
             {
-                p.Y -= Constants.OBJECT_HANDLES_GUMP_HEIGHT;
+                p.Y -= Constants.OBJECT_HANDLES_GUMP_HEIGHT
+                    + (ProfileManager.CurrentProfile.NameOverheadShowHpBar
+                        ? Constants.OBJECT_HANDLES_HP_BAR_HEIGHT + 1 : 0);
             }
 
             if (

--- a/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
@@ -124,8 +124,11 @@ namespace ClassicUO.Game.Managers
 
                                 if (mobile.ObjectHandlesStatus == ObjectHandlesStatus.DISPLAYING)
                                 {
-                                    p1.Y -= Constants.OBJECT_HANDLES_GUMP_HEIGHT + 5;
-                                    offsetY += Constants.OBJECT_HANDLES_GUMP_HEIGHT + 5;
+                                    int ohHeight = Constants.OBJECT_HANDLES_GUMP_HEIGHT
+                                        + (ProfileManager.CurrentProfile.NameOverheadShowHpBar
+                                            ? Constants.OBJECT_HANDLES_HP_BAR_HEIGHT + 1 : 0);
+                                    p1.Y -= ohHeight + 5;
+                                    offsetY += ohHeight + 5;
                                 }
 
                                 if (

--- a/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
@@ -1,7 +1,8 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 using System;
 using ClassicUO.Configuration;
+using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.UI.Gumps;
 
@@ -10,11 +11,18 @@ namespace ClassicUO.Game.Managers
     [Flags]
     internal enum NameOverheadTypeAllowed
     {
-        All,
-        Mobiles,
-        Items,
-        Corpses,
-        MobilesCorpses = Mobiles | Corpses
+        None = 0,
+        Items = 1 << 0,
+        Corpses = 1 << 1,
+        Innocent = 1 << 2,
+        Ally = 1 << 3,
+        Gray = 1 << 4,
+        Criminal = 1 << 5,
+        Enemy = 1 << 6,
+        Murderer = 1 << 7,
+        Invulnerable = 1 << 8,
+        AllMobiles = Innocent | Ally | Gray | Criminal | Enemy | Murderer | Invulnerable,
+        All = Items | Corpses | AllMobiles
     }
 
     internal sealed class NameOverHeadManager
@@ -36,31 +44,34 @@ namespace ClassicUO.Game.Managers
             set => ProfileManager.CurrentProfile.NameOverheadToggled = value;
         }
 
-        public bool IsAllowed(Entity serial)
+        public bool IsAllowed(Entity entity)
         {
-            if (serial == null)
+            if (entity == null)
             {
                 return false;
             }
 
-            if (TypeAllowed == NameOverheadTypeAllowed.All)
+            if (SerialHelper.IsItem(entity.Serial))
             {
-                return true;
+                if (entity is Item item && item.IsCorpse)
+                    return TypeAllowed.HasFlag(NameOverheadTypeAllowed.Corpses);
+
+                return TypeAllowed.HasFlag(NameOverheadTypeAllowed.Items);
             }
 
-            if (SerialHelper.IsItem(serial.Serial) && TypeAllowed == NameOverheadTypeAllowed.Items)
+            if (SerialHelper.IsMobile(entity.Serial) && entity is Mobile mobile)
             {
-                return true;
-            }
-
-            if (SerialHelper.IsMobile(serial.Serial) && TypeAllowed.HasFlag(NameOverheadTypeAllowed.Mobiles))
-            {
-                return true;
-            }
-
-            if (TypeAllowed.HasFlag(NameOverheadTypeAllowed.Corpses) && SerialHelper.IsItem(serial.Serial) && _world.Items.Get(serial)?.IsCorpse == true)
-            {
-                return true;
+                return mobile.NotorietyFlag switch
+                {
+                    NotorietyFlag.Innocent => TypeAllowed.HasFlag(NameOverheadTypeAllowed.Innocent),
+                    NotorietyFlag.Ally => TypeAllowed.HasFlag(NameOverheadTypeAllowed.Ally),
+                    NotorietyFlag.Gray => TypeAllowed.HasFlag(NameOverheadTypeAllowed.Gray),
+                    NotorietyFlag.Criminal => TypeAllowed.HasFlag(NameOverheadTypeAllowed.Criminal),
+                    NotorietyFlag.Enemy => TypeAllowed.HasFlag(NameOverheadTypeAllowed.Enemy),
+                    NotorietyFlag.Murderer => TypeAllowed.HasFlag(NameOverheadTypeAllowed.Murderer),
+                    NotorietyFlag.Invulnerable => TypeAllowed.HasFlag(NameOverheadTypeAllowed.Invulnerable),
+                    _ => true
+                };
             }
 
             return false;
@@ -76,6 +87,14 @@ namespace ClassicUO.Game.Managers
 
             _gump.IsEnabled = true;
             _gump.IsVisible = true;
+        }
+
+        public void SetMenuVisible(bool visible)
+        {
+            if (_gump != null && !_gump.IsDisposed)
+            {
+                _gump.IsVisible = visible;
+            }
         }
 
         public void Close()

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -583,18 +583,27 @@ namespace ClassicUO.Game.Scenes
 
             GetViewPort();
 
-            var useObjectHandles = _world.NameOverHeadManager.IsToggled || Keyboard.Ctrl && Keyboard.Shift;
+            var ctrlShiftHeld = Keyboard.Ctrl && Keyboard.Shift;
+            var useObjectHandles = _world.NameOverHeadManager.IsToggled || ctrlShiftHeld;
             if (useObjectHandles != _useObjectHandles)
             {
                 _useObjectHandles = useObjectHandles;
                 if (_useObjectHandles)
                 {
                     _world.NameOverHeadManager.Open();
+                    if (_world.NameOverHeadManager.IsToggled && !ctrlShiftHeld)
+                    {
+                        _world.NameOverHeadManager.SetMenuVisible(false);
+                    }
                 }
                 else
                 {
                     _world.NameOverHeadManager.Close();
                 }
+            }
+            else if (_useObjectHandles && _world.NameOverHeadManager.IsToggled)
+            {
+                _world.NameOverHeadManager.SetMenuVisible(ctrlShiftHeld);
             }
 
             _rectanglePlayer.X = (int)(

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -36,9 +36,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             LayerOrder = UILayer.Over;
 
-            RadioButton all, mobiles, items, mobilesCorpses;
             AlphaBlendControl alpha;
-            Checkbox stayActive;
+            Checkbox stayActive, cbAll, cbItems, cbCorpses, cbInnocent, cbAlly, cbGray, cbCriminal, cbEnemy, cbMurderer, cbInvulnerable;
 
             Add
             (
@@ -63,107 +62,95 @@ namespace ClassicUO.Game.UI.Gumps
             );
             stayActive.ValueChanged += (sender, e) => world.NameOverHeadManager.IsToggled = stayActive.IsChecked;
 
-            Add
-            (
-                all = new RadioButton
-                (
-                    0,
-                    0x00D0,
-                    0x00D1,
-                    ResGumps.All,
-                    color: 0xFFFF
-                )
-                {
-                    IsChecked = World.NameOverHeadManager.TypeAllowed == NameOverheadTypeAllowed.All,
-                    Y = stayActive.Y + stayActive.Height
-                }
-            );
+            var typeAllowed = World.NameOverHeadManager.TypeAllowed;
 
-            Add
-            (
-                mobiles = new RadioButton
-                (
-                    0,
-                    0x00D0,
-                    0x00D1,
-                    ResGumps.MobilesOnly,
-                    color: 0xFFFF
-                )
-                {
-                    Y = all.Y + all.Height,
-                    IsChecked = World.NameOverHeadManager.TypeAllowed == NameOverheadTypeAllowed.Mobiles
-                }
-            );
+            int currentY = stayActive.Y + stayActive.Height;
+            int maxWidth = stayActive.Width;
 
-            Add
-            (
-                items = new RadioButton
-                (
-                    0,
-                    0x00D0,
-                    0x00D1,
-                    ResGumps.ItemsOnly,
-                    color: 0xFFFF
-                )
+            Checkbox MakeCheckbox(string label, bool isChecked, ref int y)
+            {
+                var cb = new Checkbox(0x00D2, 0x00D3, label, color: 0xFFFF)
                 {
-                    Y = mobiles.Y + mobiles.Height,
-                    IsChecked = World.NameOverHeadManager.TypeAllowed == NameOverheadTypeAllowed.Items
-                }
-            );
+                    IsChecked = isChecked,
+                    Y = y
+                };
+                y += cb.Height;
+                if (cb.Width > maxWidth)
+                    maxWidth = cb.Width;
+                return cb;
+            }
 
-            Add
-            (
-                mobilesCorpses = new RadioButton
-                (
-                    0,
-                    0x00D0,
-                    0x00D1,
-                    ResGumps.MobilesAndCorpsesOnly,
-                    color: 0xFFFF
-                )
-                {
-                    Y = items.Y + items.Height,
-                    IsChecked = World.NameOverHeadManager.TypeAllowed == NameOverheadTypeAllowed.MobilesCorpses
-                }
-            );
+            Add(cbAll = MakeCheckbox(ResGumps.All, typeAllowed == NameOverheadTypeAllowed.All, ref currentY));
+            Add(cbItems = MakeCheckbox("Items", typeAllowed.HasFlag(NameOverheadTypeAllowed.Items), ref currentY));
+            Add(cbCorpses = MakeCheckbox("Corpses", typeAllowed.HasFlag(NameOverheadTypeAllowed.Corpses), ref currentY));
+            Add(cbInnocent = MakeCheckbox("Innocent", typeAllowed.HasFlag(NameOverheadTypeAllowed.Innocent), ref currentY));
+            Add(cbAlly = MakeCheckbox("Ally", typeAllowed.HasFlag(NameOverheadTypeAllowed.Ally), ref currentY));
+            Add(cbGray = MakeCheckbox("Gray", typeAllowed.HasFlag(NameOverheadTypeAllowed.Gray), ref currentY));
+            Add(cbCriminal = MakeCheckbox("Criminal", typeAllowed.HasFlag(NameOverheadTypeAllowed.Criminal), ref currentY));
+            Add(cbEnemy = MakeCheckbox("Enemy", typeAllowed.HasFlag(NameOverheadTypeAllowed.Enemy), ref currentY));
+            Add(cbMurderer = MakeCheckbox("Murderer", typeAllowed.HasFlag(NameOverheadTypeAllowed.Murderer), ref currentY));
+            Add(cbInvulnerable = MakeCheckbox("Invulnerable", typeAllowed.HasFlag(NameOverheadTypeAllowed.Invulnerable), ref currentY));
 
-            alpha.Width = Math.Max(mobilesCorpses.Width, Math.Max(items.Width, Math.Max(all.Width, mobiles.Width)));
-            alpha.Height = stayActive.Height + all.Height + mobiles.Height + items.Height + mobilesCorpses.Height;
+            alpha.Width = maxWidth;
+            alpha.Height = currentY;
 
             Width = alpha.Width;
             Height = alpha.Height;
 
-            all.ValueChanged += (sender, e) =>
+            // Track individual checkboxes for "All" logic
+            var individualBoxes = new[]
             {
-                if (all.IsChecked)
-                {
-                    World.NameOverHeadManager.TypeAllowed = NameOverheadTypeAllowed.All;
-                }
+                (cb: cbItems, flag: NameOverheadTypeAllowed.Items),
+                (cb: cbCorpses, flag: NameOverheadTypeAllowed.Corpses),
+                (cb: cbInnocent, flag: NameOverheadTypeAllowed.Innocent),
+                (cb: cbAlly, flag: NameOverheadTypeAllowed.Ally),
+                (cb: cbGray, flag: NameOverheadTypeAllowed.Gray),
+                (cb: cbCriminal, flag: NameOverheadTypeAllowed.Criminal),
+                (cb: cbEnemy, flag: NameOverheadTypeAllowed.Enemy),
+                (cb: cbMurderer, flag: NameOverheadTypeAllowed.Murderer),
+                (cb: cbInvulnerable, flag: NameOverheadTypeAllowed.Invulnerable),
             };
 
-            mobiles.ValueChanged += (sender, e) =>
+            bool suppressCascade = false;
+
+            cbAll.ValueChanged += (sender, e) =>
             {
-                if (mobiles.IsChecked)
+                if (suppressCascade)
+                    return;
+
+                suppressCascade = true;
+
+                foreach (var (cb, _) in individualBoxes)
                 {
-                    World.NameOverHeadManager.TypeAllowed = NameOverheadTypeAllowed.Mobiles;
+                    cb.IsChecked = cbAll.IsChecked;
                 }
+
+                World.NameOverHeadManager.TypeAllowed = cbAll.IsChecked
+                    ? NameOverheadTypeAllowed.All
+                    : NameOverheadTypeAllowed.None;
+
+                suppressCascade = false;
             };
 
-            items.ValueChanged += (sender, e) =>
+            foreach (var (cb, flag) in individualBoxes)
             {
-                if (items.IsChecked)
+                cb.ValueChanged += (sender, e) =>
                 {
-                    World.NameOverHeadManager.TypeAllowed = NameOverheadTypeAllowed.Items;
-                }
-            };
+                    if (suppressCascade)
+                        return;
 
-            mobilesCorpses.ValueChanged += (sender, e) =>
-            {
-                if (mobilesCorpses.IsChecked)
-                {
-                    World.NameOverHeadManager.TypeAllowed = NameOverheadTypeAllowed.MobilesCorpses;
-                }
-            };
+                    suppressCascade = true;
+
+                    if (cb.IsChecked)
+                        World.NameOverHeadManager.TypeAllowed |= flag;
+                    else
+                        World.NameOverHeadManager.TypeAllowed &= ~flag;
+
+                    cbAll.IsChecked = World.NameOverHeadManager.TypeAllowed == NameOverheadTypeAllowed.All;
+
+                    suppressCascade = false;
+                };
+            }
         }
 
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -25,6 +25,7 @@ namespace ClassicUO.Game.UI.Gumps
             _leftMouseIsDown;
         private readonly RenderedText _renderedText;
         private Texture2D _borderColor = SolidColorTextureCache.GetTexture(Color.Black);
+        private bool _showHpBar;
 
         public NameOverheadGump(World world, uint serial) : base(world, serial, 0)
         {
@@ -121,7 +122,8 @@ namespace ClassicUO.Game.UI.Gumps
                 Client.Game.UO.FileManager.Fonts.RecalculateWidthByInfo = false;
                 Client.Game.UO.FileManager.Fonts.SetUseHTML(false);
 
-                Width = _background.Width = Math.Max(60, _renderedText.Width) + 4;
+                Width = _background.Width = Constants.OBJECT_HANDLES_GUMP_WIDTH + 4;
+                _showHpBar = false;
                 Height = _background.Height = Constants.OBJECT_HANDLES_GUMP_HEIGHT + 4;
 
                 WantUpdateSize = false;
@@ -153,8 +155,10 @@ namespace ClassicUO.Game.UI.Gumps
 
                 _renderedText.Text = t;
 
-                Width = _background.Width = Math.Max(60, _renderedText.Width) + 4;
-                Height = _background.Height = Constants.OBJECT_HANDLES_GUMP_HEIGHT + 4;
+                Width = _background.Width = Constants.OBJECT_HANDLES_GUMP_WIDTH + 4;
+                _showHpBar = entity is Mobile && ProfileManager.CurrentProfile.NameOverheadShowHpBar;
+                int hpBarExtra = _showHpBar ? Constants.OBJECT_HANDLES_HP_BAR_HEIGHT + 1 : 0;
+                Height = _background.Height = Constants.OBJECT_HANDLES_GUMP_HEIGHT + 4 + hpBarExtra;
 
                 WantUpdateSize = false;
 
@@ -493,7 +497,7 @@ namespace ClassicUO.Game.UI.Gumps
                 _lockedPosition.Y = (int)(
                     m.RealScreenPosition.Y
                     + (m.Offset.Y - m.Offset.Z)
-                    - (height + centerY + 8)
+                    - (height + centerY + 8 + 10)
                     + (
                         m.IsGargoyle && m.IsFlying
                             ? -22
@@ -592,7 +596,7 @@ namespace ClassicUO.Game.UI.Gumps
                     y = (int)(
                         m.RealScreenPosition.Y
                         + (m.Offset.Y - m.Offset.Z)
-                        - (height + centerY + 8)
+                        - (height + centerY + 8 + 10)
                         + (
                             m.IsGargoyle && m.IsFlying
                                 ? -22
@@ -673,6 +677,31 @@ namespace ClassicUO.Game.UI.Gumps
                     );
                 }
             );
+
+            if (_showHpBar && World.Get(LocalSerial) is Mobile mob)
+            {
+                int barX = x;
+                int barY = y + Height - Constants.OBJECT_HANDLES_HP_BAR_HEIGHT;
+                int barWidth = Width;
+                int barHeight = Constants.OBJECT_HANDLES_HP_BAR_HEIGHT;
+                int filledWidth = barWidth * mob.HitsPercentage / 100;
+                Color hpColor = mob.HitsPercentage >= 80 ? Color.Green
+                              : mob.HitsPercentage >= 50 ? Color.YellowGreen
+                              : mob.HitsPercentage >= 30 ? Color.Yellow
+                              : Color.Red;
+                float barDepth = layerDepth + CHILD_LAYER_INCREMENT * 3;
+
+                renderLists.AddGumpNoAtlas(batcher =>
+                {
+                    batcher.Draw(SolidColorTextureCache.GetTexture(Color.Black),
+                        new Rectangle(barX, barY, barWidth, barHeight), hueVector, barDepth);
+                    if (filledWidth > 0)
+                        batcher.Draw(SolidColorTextureCache.GetTexture(hpColor),
+                            new Rectangle(barX, barY, filledWidth, barHeight), hueVector, barDepth + CHILD_LAYER_INCREMENT);
+                    return true;
+                });
+            }
+
             return true;
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -37,6 +37,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         //experimental
         private Checkbox _autoOpenDoors, _autoOpenCorpse, _skipEmptyCorpse, _disableTabBtn, _disableCtrlQWBtn, _disableDefaultHotkeys, _disableArrowBtn, _disableAutoMove, _overrideContainerLocation, _smoothDoors, _showTargetRangeIndicator, _customBars, _customBarsBBG, _saveHealthbars;
+        private Checkbox _nameOverheadAlwaysOn, _nameOverheadShowHpBar;
         private HSliderBar _cellSize;
         private Checkbox _containerScaleItems, _containerDoubleClickToLoot, _relativeDragAnDropItems, _useLargeContianersGumps, _highlightContainersWhenMouseIsOver;
 
@@ -1202,6 +1203,30 @@ namespace ClassicUO.Game.UI.Gumps
                     null,
                     ResGumps.ShowTarRangeIndic,
                     _currentProfile.ShowTargetRangeIndicator,
+                    startX,
+                    startY
+                )
+            );
+
+            section4.Add
+            (
+                _nameOverheadAlwaysOn = AddCheckBox
+                (
+                    null,
+                    "Always show name overheads",
+                    _currentProfile.NameOverheadToggled,
+                    startX,
+                    startY
+                )
+            );
+
+            section4.Add
+            (
+                _nameOverheadShowHpBar = AddCheckBox
+                (
+                    null,
+                    "Show HP bar on name overheads",
+                    _currentProfile.NameOverheadShowHpBar,
                     startX,
                     startY
                 )
@@ -3606,6 +3631,8 @@ namespace ClassicUO.Game.UI.Gumps
                     _dragSelectHumanoidsOnly.IsChecked = false;
                     _dragSelectHostileOnly.IsChecked = false;
                     _showTargetRangeIndicator.IsChecked = false;
+                    _nameOverheadAlwaysOn.IsChecked = false;
+                    _nameOverheadShowHpBar.IsChecked = true;
                     _customBars.IsChecked = false;
                     _customBarsBBG.IsChecked = false;
                     _autoOpenCorpse.IsChecked = false;
@@ -4250,6 +4277,8 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.OverrideContainerLocationSetting = _overrideContainerLocationSetting.SelectedIndex;
 
             _currentProfile.ShowTargetRangeIndicator = _showTargetRangeIndicator.IsChecked;
+            _currentProfile.NameOverheadToggled = _nameOverheadAlwaysOn.IsChecked;
+            _currentProfile.NameOverheadShowHpBar = _nameOverheadShowHpBar.IsChecked;
 
 
             bool updateHealthBars = _currentProfile.CustomBarsToggled != _customBars.IsChecked;


### PR DESCRIPTION
- Add color-coded HP bar overlay on name overheads for mobiles
- Rework object handle filters from radio buttons to multi-select checkboxes with per-notoriety granularity (Innocent, Ally, Gray, Criminal, Enemy, Murderer, Invulnerable, Items, Corpses)
- Add "Always show name overheads" and "Show HP bar on name overheads" options in settings
- Hide handler gump menu when stay-active is on, show on Ctrl+Shift
- Fix object handle width to consistent OBJECT_HANDLES_GUMP_WIDTH
- Adjust Y-offsets in HealthLinesManager and Mobile for HP bar height