### PR TITLE
Fix audit findings and add cross-platform patch report

### DIFF
--- a/security_patch_report.md
+++ b/security_patch_report.md
@@ -1,0 +1,184 @@
+# ClassicUO Security Patch Report
+
+Date: 2026-03-15
+Source findings: `security_best_practices_report.md`
+
+## CRIT-001 - UltimaLive path traversal
+
+Problem
+- Server-provided shard names were converted into filesystem paths with insufficient validation.
+
+Patch
+- Added strict shard-name validation (`A-Z`, `a-z`, `0-9`, `.`, `_`, `-`, max 64 chars).
+- Rejected rooted paths and `.` / `..` path segments.
+- Moved storage under fixed base: `<Local/CommonApplicationData>/ClassicUO/UltimaLive/<shard>`.
+- Enforced canonical `StartsWith(basePath)` boundary check.
+
+Files
+- `src/ClassicUO.Client/Game/UltimaLive.cs`
+
+Why this fixes it
+- Untrusted shard names can no longer escape the storage root or traverse to arbitrary locations.
+
+## HIGH-002 - Plugin/DLL loading hardening gaps
+
+Problem
+- Global `PATH` mutation and permissive load behavior increased side-loading risk.
+
+Patch
+- Removed process-wide `PATH` plugin-folder mutation.
+- Added plugin root canonicalization and traversal rejection in plugin creation.
+- Hardened Windows loader to use restricted DLL search flags (`LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`) with compatibility fallback.
+
+Files
+- `src/ClassicUO.Client/Main.cs`
+- `src/ClassicUO.Client/Network/Plugin.cs`
+- `src/ClassicUO.Utility/Platforms/Native.cs`
+
+Why this fixes it
+- Plugin binaries are constrained to the intended plugin directory and native dependency resolution uses safer search rules.
+
+## HIGH-003 - Weak reversible password storage
+
+Problem
+- Password persistence used reversible XOR obfuscation.
+
+Patch
+- Reworked `Crypter`:
+  - Windows: DPAPI (`ProtectedData`) with `dpapi:` prefix.
+  - Non-Windows: volatile in-memory encoding (`volatile:`) and no persisted secret.
+  - Legacy decrypt compatibility retained for existing stored values.
+- Added save-time password sanitation to avoid persisting non-secure values.
+
+Files
+- `src/ClassicUO.Utility/Crypter.cs`
+- `src/ClassicUO.Client/Configuration/Settings.cs`
+- `src/ClassicUO.Utility/ClassicUO.Utility.csproj` (added `System.Security.Cryptography.ProtectedData`)
+
+Why this fixes it
+- Stored secrets are OS-protected on Windows; insecure reversible-at-rest values are no longer written when secure storage is unavailable.
+
+## MED-004 - WebSocket resource leak
+
+Problem
+- WebSocket wrapper owned disposable resources but did not dispose them.
+
+Patch
+- Implemented idempotent cleanup in `Disconnect`/`Dispose`:
+  - cancel token
+  - close/abort websocket as needed
+  - await/settle receive task
+  - dispose websocket, raw socket, token source
+- Added null guards and receive-task tracking.
+
+Files
+- `src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs`
+
+Why this fixes it
+- Reconnect and teardown paths now release network and cancellation resources reliably.
+
+## MED-005 - Connect crash on malformed IP input
+
+Problem
+- `Substring(0, 2)` on short IP strings could throw.
+
+Patch
+- Replaced substring check with safe prefix check: `StartsWith("ws", StringComparison.OrdinalIgnoreCase)`.
+
+Files
+- `src/ClassicUO.Client/Network/NetClient.cs`
+
+Why this fixes it
+- Empty/short/malformed input no longer causes substring exceptions.
+
+## MED-006 - Marker parsing crashers
+
+Problem
+- Marker loaders used direct indexing and `int.Parse` without strict field validation.
+
+Patch
+- Added defensive parsing with `TryParse` and schema checks.
+- Hardened XML/UOAM/CSV loaders to skip malformed rows instead of throwing.
+- Added robust `TryParseMarker` helper used by CSV/user marker loading.
+- Fixed empty-line behavior in CSV loader (`continue` instead of early `return`).
+
+Files
+- `src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs`
+
+Why this fixes it
+- Malformed files are now tolerated and ignored safely, preventing parser-driven crashes.
+
+## LOW-007 - Plugin packet length trust
+
+Problem
+- Plugin callbacks could return invalid packet lengths used directly for copy/slice operations.
+
+Patch
+- Added centralized packet-length clamping/validation after each plugin callback.
+- Added null-buffer handling and safe copy bounds for recv/send pipelines.
+
+Files
+- `src/ClassicUO.Client/Network/Plugin.cs`
+
+Why this fixes it
+- Invalid lengths no longer trigger out-of-range operations or unstable packet flow.
+
+## LOW-008 - Unmanaged allocation leak in plugin host init
+
+Problem
+- `NativeMemory.AllocZeroed` allocation in plugin host init was not freed.
+
+Patch
+- Wrapped host init buffer usage in `try/finally` and released with `NativeMemory.Free`.
+
+Files
+- `src/ClassicUO.Client/PluginHost.cs`
+
+Why this fixes it
+- Native memory allocated for binding bootstrap is now released deterministically.
+
+## Validation
+
+Command
+- `E:\dotnet 10\dotnet.exe test ClassicUO/ClassicUO.sln -c Release --nologo`
+
+Result
+- Passed: 162
+- Failed: 0
+- Skipped: 0
+
+## End Result
+
+- All report findings (CRIT-001 through LOW-008) have code-level remediation patches in this branch.
+- Patch set compiles and test suite passes.
+
+## Compatibility Validation Update (Latest Repo Snapshot)
+
+Date checked: 2026-03-15
+
+Scope requested:
+- Browser
+- Windows x64
+- Linux x64
+- macOS x64
+
+What was run:
+- `E:\dotnet 10\dotnet.exe build ClassicUO/ClassicUO.sln -c Release --nologo`
+- `E:\dotnet 10\dotnet.exe test ClassicUO/ClassicUO.sln -c Release --nologo`
+- `E:\dotnet 10\dotnet.exe publish src/ClassicUO.Client/ClassicUO.Client.csproj -c Release -r win-x64   -o dist-check/win-x64   /p:IS_DEV_BUILD=true /p:NativeLib=Shared /p:OutputType=Library /p:PublishAot=false`
+- `E:\dotnet 10\dotnet.exe publish src/ClassicUO.Client/ClassicUO.Client.csproj -c Release -r linux-x64 -o dist-check/linux-x64 /p:IS_DEV_BUILD=true /p:NativeLib=Shared /p:OutputType=Library /p:PublishAot=false`
+- `E:\dotnet 10\dotnet.exe publish src/ClassicUO.Client/ClassicUO.Client.csproj -c Release -r osx-x64   -o dist-check/osx-x64   /p:IS_DEV_BUILD=true /p:NativeLib=Shared /p:OutputType=Library /p:PublishAot=false`
+- `E:\dotnet 10\dotnet.exe publish src/ClassicUO.Client/ClassicUO.Client.csproj -c Release -r browser-wasm -o dist-check/browser-wasm /p:IS_DEV_BUILD=true /p:NativeLib=Shared /p:OutputType=Library /p:PublishAot=false`
+
+Results:
+- `Build`: PASS
+- `Tests`: PASS (`162/162`)
+- `Windows x64 publish`: PASS
+- `Linux x64 publish`: PASS
+- `macOS x64 publish`: PASS
+- `Browser (browser-wasm) publish`: FAIL on environment prerequisite (`NETSDK1147`, missing workloads `wasm-tools` and `wasm-tools-net8`)
+
+Notes:
+- Upstream CI/release workflows in this repo currently target `win-x64`, `linux-x64`, and `osx-x64` (not Browser) via `.github/workflows/deploy.yml`.
+- Based on this check, the patch set does not require code changes for Windows/Linux/macOS x64 builds.
+- Browser build requires workload/tooling setup before it can be validated further.

--- a/src/ClassicUO.Client/Configuration/Settings.cs
+++ b/src/ClassicUO.Client/Configuration/Settings.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using ClassicUO.Configuration.Json;
+using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Configuration
@@ -120,6 +121,10 @@ namespace ClassicUO.Configuration
             {
                 settingsToSave.Username = string.Empty;
                 settingsToSave.Password = string.Empty;
+            }
+            else
+            {
+                settingsToSave.Password = Crypter.SanitizeForStorage(settingsToSave.Password);
             }
 
             settingsToSave.ProfilesPath = string.Empty;

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -21,6 +21,7 @@ using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -1613,21 +1614,32 @@ namespace ClassicUO.Game.UI.Gumps
                                     {
                                         if (reader.Name.Equals("Marker"))
                                         {
+                                            if
+                                            (
+                                                !TryParseInt(reader.GetAttribute("X"), out int markerX)
+                                                || !TryParseInt(reader.GetAttribute("Y"), out int markerY)
+                                                || !TryParseInt(reader.GetAttribute("Facet"), out int markerFacet)
+                                            )
+                                            {
+                                                continue;
+                                            }
+
+                                            string iconName = reader.GetAttribute("Icon")?.ToLowerInvariant() ?? string.Empty;
+
                                             WMapMarker marker = new WMapMarker
                                             {
-                                                X = int.Parse(reader.GetAttribute("X")),
-                                                Y = int.Parse(reader.GetAttribute("Y")),
-                                                Name = reader.GetAttribute("Name"),
-                                                MapId = int.Parse(reader.GetAttribute("Facet")),
+                                                X = markerX,
+                                                Y = markerY,
+                                                Name = reader.GetAttribute("Name") ?? string.Empty,
+                                                MapId = markerFacet,
                                                 Color = Color.White,
                                                 ZoomIndex = 3
                                             };
 
-                                            if (_markerIcons.TryGetValue(reader.GetAttribute("Icon").ToLower(), out Texture2D value))
+                                            if (!string.IsNullOrWhiteSpace(iconName) && _markerIcons.TryGetValue(iconName, out Texture2D value))
                                             {
                                                 marker.MarkerIcon = value;
-
-                                                marker.MarkerIconName = reader.GetAttribute("Icon").ToLower();
+                                                marker.MarkerIconName = iconName;
                                             }
 
                                             markerFile.Markers.Add(marker);
@@ -1651,34 +1663,45 @@ namespace ClassicUO.Game.UI.Gumps
                                         }
 
                                         // Check for UOAM file
-                                        if (line.Substring(0, 1).Equals("+") || line.Substring(0, 1).Equals("-"))
+                                        if (line.Length > 1 && (line[0] == '+' || line[0] == '-'))
                                         {
-                                            string icon = line.Substring(1, line.IndexOf(':') - 1);
+                                            int iconSeparatorIndex = line.IndexOf(':');
 
-                                            line = line.Substring(line.IndexOf(':') + 2);
-
-                                            string[] splits = line.Split(' ');
-
-                                            if (splits.Length <= 1)
+                                            if (iconSeparatorIndex <= 1 || iconSeparatorIndex + 2 > line.Length)
                                             {
                                                 continue;
                                             }
 
+                                            string icon = line.Substring(1, iconSeparatorIndex - 1);
+                                            line = line.Substring(iconSeparatorIndex + 2);
+
+                                            string[] splits = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+                                            if
+                                            (
+                                                splits.Length < 4
+                                                || !TryParseInt(splits[0], out int markerX)
+                                                || !TryParseInt(splits[1], out int markerY)
+                                                || !TryParseInt(splits[2], out int markerMapId)
+                                            )
+                                            {
+                                                continue;
+                                            }
+
+                                            string markerIconName = icon.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.ToLowerInvariant() ?? string.Empty;
+
                                             WMapMarker marker = new WMapMarker
                                             {
-                                                X = int.Parse(splits[0]),
-                                                Y = int.Parse(splits[1]),
-                                                MapId = int.Parse(splits[2]),
+                                                X = markerX,
+                                                Y = markerY,
+                                                MapId = markerMapId,
                                                 Name = string.Join(" ", splits, 3, splits.Length - 3),
+                                                MarkerIconName = markerIconName,
                                                 Color = Color.White,
                                                 ZoomIndex = 3
                                             };
 
-                                            string[] iconSplits = icon.Split(' ');
-
-                                            marker.MarkerIconName = iconSplits[0].ToLower();
-
-                                            if (_markerIcons.TryGetValue(iconSplits[0].ToLower(), out Texture2D value))
+                                            if (!string.IsNullOrWhiteSpace(markerIconName) && _markerIcons.TryGetValue(markerIconName, out Texture2D value))
                                             {
                                                 marker.MarkerIcon = value;
                                             }
@@ -1703,30 +1726,14 @@ namespace ClassicUO.Game.UI.Gumps
 
                                         if (string.IsNullOrEmpty(line))
                                         {
-                                            return;
+                                            continue;
                                         }
 
                                         string[] splits = line.Split(',');
 
-                                        if (splits.Length <= 1)
+                                        if (!TryParseMarker(splits, out WMapMarker marker))
                                         {
                                             continue;
-                                        }
-
-                                        WMapMarker marker = new WMapMarker
-                                        {
-                                            X = int.Parse(splits[0]),
-                                            Y = int.Parse(splits[1]),
-                                            MapId = int.Parse(splits[2]),
-                                            Name = splits[3],
-                                            MarkerIconName = splits[4].ToLower(),
-                                            Color = GetColor(splits[5]),
-                                            ZoomIndex = splits.Length == 7 ? int.Parse(splits[6]) : 3
-                                        };
-
-                                        if (_markerIcons.TryGetValue(splits[4].ToLower(), out Texture2D value))
-                                        {
-                                            marker.MarkerIcon = value;
                                         }
 
                                         markerFile.Markers.Add(marker);
@@ -1862,7 +1869,11 @@ namespace ClassicUO.Game.UI.Gumps
                     {
                         continue;
                     }
-                    tempList.Add(ParseMarker(splits));
+
+                    if (TryParseMarker(splits, out WMapMarker marker))
+                    {
+                        tempList.Add(marker);
+                    }
                 }
             }
 
@@ -3237,24 +3248,55 @@ namespace ClassicUO.Game.UI.Gumps
         /// <returns>Marker</returns>
         internal static WMapMarker ParseMarker(string[] splits)
         {
-            WMapMarker marker = new WMapMarker
+            return TryParseMarker(splits, out WMapMarker marker) ? marker : null;
+        }
+
+        internal static bool TryParseMarker(string[] splits, out WMapMarker marker)
+        {
+            marker = null;
+
+            if (splits == null || splits.Length < 6)
             {
-                X = int.Parse(Truncate(splits[0], 4)),
-                Y = int.Parse(Truncate(splits[1], 4)),
-                MapId = int.Parse(splits[2]),
-                Name = Truncate(splits[3], 25),
-                MarkerIconName = splits[4].ToLower(),
-                Color = GetColor(Truncate(splits[5], 10)),
-                ColorName = Truncate(splits[5], 10),
-                ZoomIndex = splits.Length == 7 ? int.Parse(splits[6]) : 3
+                return false;
+            }
+
+            string markerIconName = splits[4]?.Trim().ToLowerInvariant() ?? string.Empty;
+            string colorName = Truncate((splits[5] ?? string.Empty).Trim().ToLowerInvariant(), 10);
+            int zoomIndex = 3;
+
+            if (splits.Length >= 7 && !string.IsNullOrWhiteSpace(splits[6]) && !TryParseInt(splits[6], out zoomIndex))
+            {
+                return false;
+            }
+
+            if
+            (
+                !TryParseInt(Truncate((splits[0] ?? string.Empty).Trim(), 4), out int markerX)
+                || !TryParseInt(Truncate((splits[1] ?? string.Empty).Trim(), 4), out int markerY)
+                || !TryParseInt((splits[2] ?? string.Empty).Trim(), out int markerMapId)
+            )
+            {
+                return false;
+            }
+
+            marker = new WMapMarker
+            {
+                X = markerX,
+                Y = markerY,
+                MapId = markerMapId,
+                Name = Truncate((splits[3] ?? string.Empty).Trim(), 25),
+                MarkerIconName = markerIconName,
+                Color = GetColor(colorName),
+                ColorName = colorName,
+                ZoomIndex = zoomIndex
             };
 
-            if (_markerIcons.TryGetValue(splits[4].ToLower(), out Texture2D value))
+            if (!string.IsNullOrWhiteSpace(markerIconName) && _markerIcons.TryGetValue(markerIconName, out Texture2D value))
             {
                 marker.MarkerIcon = value;
             }
 
-            return marker;
+            return true;
         }
 
         /// <summary>
@@ -3291,6 +3333,11 @@ namespace ClassicUO.Game.UI.Gumps
         public static Color GetColor(string name)
         {
             return _colorMap.TryGetValue(name, out var color) ? color : Color.White;
+        }
+
+        private static bool TryParseInt(string value, out int parsedValue)
+        {
+            return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsedValue);
         }
     }
 

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -23,10 +23,12 @@ namespace ClassicUO.Game
         private const int STATICS_MEMORY_SIZE = 200000000;
         private const int CRC_LENGTH = 25;
         private const int LAND_BLOCK_LENGTH = 192;
+        private const int MAX_SHARD_NAME_LENGTH = 64;
 
         private static UltimaLive _UL;
 
         private static readonly char[] _pathSeparatorChars = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        private static readonly char[] _allowedShardNamePunctuation = { '.', '_', '-' };
         private uint[] _EOF;
         private ULFileMul[] _filesIdxStatics;
         private ULFileMul[] _filesMap;
@@ -425,12 +427,10 @@ namespace ClassicUO.Game
                         return;
                     }
 
-                    string[] split = name.Split(_pathSeparatorChars, StringSplitOptions.RemoveEmptyEntries);
-
                     _UL = new UltimaLive
                     {
                         ShardName = name,
-                        RealShardName = split[split.Length - 1]
+                        RealShardName = Path.GetFileName(name)
                     };
 
                     //TODO: create shard directory, copy map and statics to that directory, use that files instead of the original ones
@@ -609,14 +609,13 @@ namespace ClassicUO.Game
         {
             try
             {
-                //we cannot allow directory separator inside our name
-                if (!string.IsNullOrEmpty(shardName) && shardName.IndexOfAny(_pathSeparatorChars) == -1)
+                if (IsValidShardName(shardName))
                 {
-                    string folderPath = Environment.GetFolderPath(CUOEnviroment.IsUnix ? Environment.SpecialFolder.LocalApplicationData : Environment.SpecialFolder.CommonApplicationData);
+                    string basePath = GetStorageRootPath();
+                    string normalizedBasePath = Path.GetFullPath(basePath);
+                    string fullPath = Path.GetFullPath(Path.Combine(normalizedBasePath, shardName));
 
-                    string fullPath = Path.GetFullPath(Path.Combine(folderPath, shardName));
-
-                    if (!string.IsNullOrEmpty(fullPath))
+                    if (!string.IsNullOrEmpty(fullPath) && IsPathUnderRoot(fullPath, normalizedBasePath))
                     {
                         return fullPath;
                     }
@@ -629,6 +628,57 @@ namespace ClassicUO.Game
             //if invalid 'path', we get an exception, if uncorrectly formatted, we'll be here also, maybe wrong characters are sent?
             //since we are using only ascii (8bit) charset, send only normal letters! in this case we return null and invalidate ultimalive request
             return null;
+        }
+
+        private static bool IsValidShardName(string shardName)
+        {
+            if (string.IsNullOrWhiteSpace(shardName) || shardName.Length > MAX_SHARD_NAME_LENGTH)
+            {
+                return false;
+            }
+
+            if (shardName == "." || shardName == "..")
+            {
+                return false;
+            }
+
+            if (Path.IsPathRooted(shardName) || shardName.IndexOfAny(_pathSeparatorChars) != -1)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < shardName.Length; i++)
+            {
+                char c = shardName[i];
+
+                if (char.IsLetterOrDigit(c) || Array.IndexOf(_allowedShardNamePunctuation, c) >= 0)
+                {
+                    continue;
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        private static string GetStorageRootPath()
+        {
+            string baseFolder = Environment.GetFolderPath
+            (
+                CUOEnviroment.IsUnix ? Environment.SpecialFolder.LocalApplicationData : Environment.SpecialFolder.CommonApplicationData
+            );
+
+            return Path.Combine(baseFolder, "ClassicUO", "UltimaLive");
+        }
+
+        private static bool IsPathUnderRoot(string fullPath, string rootPath)
+        {
+            string normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(rootPath));
+            string normalizedPath = Path.GetFullPath(fullPath);
+            StringComparison comparison = CUOEnviroment.IsUnix ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+            return normalizedPath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, comparison);
         }
 
         private class ULFileMul : FileReader

--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -103,7 +103,6 @@ namespace ClassicUO
             Environment.SetEnvironmentVariable("FNA3D_BACKBUFFER_SCALE_NEAREST", "1");
             Environment.SetEnvironmentVariable("FNA3D_OPENGL_FORCE_COMPATIBILITY_PROFILE", "1");
             Environment.SetEnvironmentVariable(SDL.SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
-            Environment.SetEnvironmentVariable("PATH", Environment.GetEnvironmentVariable("PATH") + ";" + Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Plugins"));
 
             string globalSettingsPath = Settings.GetSettingsFilepath();
 

--- a/src/ClassicUO.Client/Network/NetClient.cs
+++ b/src/ClassicUO.Client/Network/NetClient.cs
@@ -126,7 +126,7 @@ namespace ClassicUO.Network
             if (string.IsNullOrEmpty(ip))
                 throw new ArgumentNullException(nameof(ip));
 
-            var isWebsocketAddress = ip.ToLowerInvariant().Substring(0, 2) is "ws" or "wss";
+            var isWebsocketAddress = ip.StartsWith("ws", StringComparison.OrdinalIgnoreCase);
             var addr = $"{(isWebsocketAddress ? "" : "tcp://")}{ip}:{port}";
 
             if (!Uri.TryCreate(addr, UriKind.RelativeOrAbsolute, out var uri))

--- a/src/ClassicUO.Client/Network/Plugin.cs
+++ b/src/ClassicUO.Client/Network/Plugin.cs
@@ -123,9 +123,14 @@ namespace ClassicUO.Network
 
         public static Plugin Create(string path)
         {
-            path = Path.GetFullPath(
-                Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Plugins", path)
-            );
+            string configuredPath = path;
+
+            if (!TryGetSafePluginPath(configuredPath, out path))
+            {
+                Log.Error($"Plugin '{configuredPath}' is outside the allowed plugin directory.");
+
+                return null;
+            }
 
             if (!File.Exists(path))
             {
@@ -150,6 +155,37 @@ namespace ClassicUO.Network
             Plugins.Add(p);
 
             return p;
+        }
+
+        private static bool TryGetSafePluginPath(string configuredPath, out string safePath)
+        {
+            safePath = null;
+
+            if (string.IsNullOrWhiteSpace(configuredPath))
+            {
+                return false;
+            }
+
+            string pluginRoot = Path.GetFullPath(Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Plugins"));
+            string candidatePath = Path.GetFullPath(Path.Combine(pluginRoot, configuredPath));
+
+            if (!IsPathUnderRoot(candidatePath, pluginRoot))
+            {
+                return false;
+            }
+
+            safePath = candidatePath;
+
+            return true;
+        }
+
+        private static bool IsPathUnderRoot(string path, string rootPath)
+        {
+            string normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(rootPath));
+            string normalizedPath = Path.GetFullPath(path);
+            StringComparison comparison = CUOEnviroment.IsUnix ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+            return normalizedPath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, comparison);
         }
 
         public void Load()
@@ -511,6 +547,7 @@ namespace ClassicUO.Network
 
         internal static bool ProcessRecvPacket(byte[] data, ref int length)
         {
+            length = ClampPacketLength(length, data?.Length ?? 0, "plugin host", "recv");
             bool result = Client.Game.PluginHost?.PacketIn(new ArraySegment<byte>(data, 0, length)) ?? true;
 
             foreach (Plugin plugin in Plugins)
@@ -519,24 +556,53 @@ namespace ClassicUO.Network
                 {
                     byte[] tmp = new byte[length];
                     Array.Copy(data, tmp, length);
+                    int pluginLength = length;
 
-                    if (!plugin._onRecv_new(tmp, ref length))
+                    if (!plugin._onRecv_new(tmp, ref pluginLength))
                     {
                         result = false;
                     }
 
+                    pluginLength = ClampPacketLength
+                    (
+                        pluginLength,
+                        Math.Min(tmp.Length, data.Length),
+                        plugin.PluginPath,
+                        "recv"
+                    );
+
+                    length = pluginLength;
                     Array.Copy(tmp, data, length);
                 }
                 else if (plugin._onRecv != null)
                 {
                     byte[] tmp = new byte[length];
                     Array.Copy(data, tmp, length);
+                    int pluginLength = length;
 
-                    if (!plugin._onRecv(ref tmp, ref length))
+                    if (!plugin._onRecv(ref tmp, ref pluginLength))
                     {
                         result = false;
                     }
 
+                    if (tmp == null)
+                    {
+                        Log.Warn($"Plugin '{plugin.PluginPath}' returned null recv buffer. Dropping packet.");
+                        length = 0;
+                        result = false;
+
+                        continue;
+                    }
+
+                    pluginLength = ClampPacketLength
+                    (
+                        pluginLength,
+                        Math.Min(tmp.Length, data.Length),
+                        plugin.PluginPath,
+                        "recv"
+                    );
+
+                    length = pluginLength;
                     Array.Copy(tmp, data, length);
                 }
             }
@@ -553,32 +619,60 @@ namespace ClassicUO.Network
                 if (plugin._onSend_new != null)
                 {
                     var tmp = message.ToArray();
-                    var length = tmp.Length;
+                    int length = tmp.Length;
 
                     if (!plugin._onSend_new(tmp, ref length))
                     {
                         result = false;
                     }
 
+                    length = ClampPacketLength(length, Math.Min(tmp.Length, message.Length), plugin.PluginPath, "send");
                     message = message.Slice(0, length);
                     tmp.AsSpan(0, length).CopyTo(message);
                 }
                 else if (plugin._onSend != null)
                 {
                     var tmp = message.ToArray();
-                    var length = tmp.Length;
+                    int length = tmp.Length;
 
                     if (!plugin._onSend(ref tmp, ref length))
                     {
                         result = false;
                     }
 
+                    if (tmp == null)
+                    {
+                        Log.Warn($"Plugin '{plugin.PluginPath}' returned null send buffer. Dropping packet.");
+                        message = message[..0];
+                        result = false;
+
+                        continue;
+                    }
+
+                    length = ClampPacketLength(length, Math.Min(tmp.Length, message.Length), plugin.PluginPath, "send");
                     message = message.Slice(0, length);
                     tmp.AsSpan(0, length).CopyTo(message);
                 }
             }
 
             return result;
+        }
+
+        private static int ClampPacketLength(int length, int maxLength, string pluginPath, string direction)
+        {
+            if ((uint) length <= (uint) maxLength)
+            {
+                return length;
+            }
+
+            int clamped = Math.Clamp(length, 0, maxLength);
+
+            Log.Warn
+            (
+                $"Invalid {direction} packet length {length} from '{pluginPath}'. Clamped to {clamped} (max {maxLength})."
+            );
+
+            return clamped;
         }
 
         internal static void OnClosing()

--- a/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
+++ b/src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs
@@ -22,15 +22,18 @@ sealed class WebSocketWrapper : SocketWrapper
 
     private ClientWebSocket _webSocket;
     private TcpSocket _rawSocket;
+    private Task _receiveTask;
+    private readonly object _disposeLock = new();
+    private bool _disposed;
 
     public override bool IsConnected => _webSocket?.State is WebSocketState.Connecting or WebSocketState.Open;
     public override EndPoint LocalEndPoint => _rawSocket?.LocalEndPoint;
-    public bool IsCanceled => _tokenSource.IsCancellationRequested;
+    public bool IsCanceled => _tokenSource?.IsCancellationRequested ?? true;
 
     private CancellationTokenSource _tokenSource = new();
     private CircularBuffer _receiveStream;
 
-    public override void Connect(Uri uri) => ConnectAsync(uri, _tokenSource).Wait();
+    public override void Connect(Uri uri) => ConnectAsync(uri).Wait();
 
     public override void Send(byte[] buffer, int offset, int count)
     {
@@ -53,6 +56,9 @@ sealed class WebSocketWrapper : SocketWrapper
 
     public override int Read(byte[] buffer)
     {
+        if (_receiveStream == null)
+            return 0;
+
         lock (_receiveStream)
         {
             return _receiveStream.Dequeue(buffer, 0, buffer.Length);
@@ -64,7 +70,17 @@ sealed class WebSocketWrapper : SocketWrapper
         if (IsConnected)
             return;
 
-        _tokenSource = tokenSource ?? new CancellationTokenSource();
+        if (tokenSource == null)
+        {
+            _tokenSource?.Dispose();
+            _tokenSource = new CancellationTokenSource();
+        }
+        else if (!ReferenceEquals(tokenSource, _tokenSource))
+        {
+            _tokenSource?.Dispose();
+            _tokenSource = tokenSource;
+        }
+
         _receiveStream = new CircularBuffer();
 
         try
@@ -137,7 +153,7 @@ sealed class WebSocketWrapper : SocketWrapper
         Log.Trace($"Connected WebSocket: {uri}");
 
         // Kicks off the async receiving loop 
-        StartReceiveAsync().ConfigureAwait(false);
+        _receiveTask = StartReceiveAsync();
     }
 
     private async Task StartReceiveAsync()
@@ -163,6 +179,11 @@ sealed class WebSocketWrapper : SocketWrapper
                 if (!receiveResult.EndOfMessage)
                     continue;
 
+                if (_receiveStream == null)
+                {
+                    break;
+                }
+
                 lock (_receiveStream)
                 {
                     _receiveStream.Enqueue(buffer, 0, position);
@@ -185,7 +206,7 @@ sealed class WebSocketWrapper : SocketWrapper
             Shared.Return(buffer);
         }
 
-        if (!IsCanceled)
+        if (!IsCanceled && !_disposed)
             InvokeOnError(SocketError.ConnectionReset);
     }
 
@@ -193,6 +214,9 @@ sealed class WebSocketWrapper : SocketWrapper
     // We peek the raw tcp socket available bytes, grow if the frame is bigger, we're naively assuming no compression.
     private void GrowReceiveBufferIfNeeded(ref byte[] buffer, ref Memory<byte> memory)
     {
+        if (_rawSocket == null)
+            return;
+
         if (_rawSocket.Available <= buffer.Length)
             return;
 
@@ -208,21 +232,81 @@ sealed class WebSocketWrapper : SocketWrapper
 
     public override void Disconnect()
     {
-        if (!IsConnected)
-            return;
-
-        try
-        {
-            _webSocket?.CloseAsync(WebSocketCloseStatus.NormalClosure, "Disconnect", CancellationToken.None)
-                .ContinueWith(_ => _tokenSource?.Cancel());
-        }
-        catch
-        {
-            _tokenSource?.Cancel();
-        }
+        DisposeCore();
     }
 
     public override void Dispose()
     {
+        DisposeCore();
+    }
+
+    private void DisposeCore()
+    {
+        lock (_disposeLock)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+        }
+
+        var webSocket = _webSocket;
+        _webSocket = null;
+
+        var rawSocket = _rawSocket;
+        _rawSocket = null;
+
+        var tokenSource = _tokenSource;
+        _tokenSource = null;
+
+        var receiveTask = _receiveTask;
+        _receiveTask = null;
+
+        try
+        {
+            tokenSource?.Cancel();
+        }
+        catch
+        {
+        }
+
+        if (webSocket != null)
+        {
+            try
+            {
+                if (webSocket.State is WebSocketState.Open or WebSocketState.CloseReceived)
+                {
+                    webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Disconnect", CancellationToken.None).GetAwaiter().GetResult();
+                }
+                else if (webSocket.State == WebSocketState.Connecting)
+                {
+                    webSocket.Abort();
+                }
+            }
+            catch
+            {
+            }
+            finally
+            {
+                webSocket.Dispose();
+            }
+        }
+
+        if (receiveTask != null)
+        {
+            try
+            {
+                receiveTask.GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch
+            {
+            }
+        }
+
+        rawSocket?.Dispose();
+        tokenSource?.Dispose();
     }
 }

--- a/src/ClassicUO.Client/PluginHost.cs
+++ b/src/ClassicUO.Client/PluginHost.cs
@@ -273,17 +273,25 @@ namespace ClassicUO
                 return;
 
             var mem = NativeMemory.AllocZeroed((nuint)sizeof(ClientBindings));
-            ref var cuoHost = ref Unsafe.AsRef<ClientBindings>(mem);
-            cuoHost.PacketLengthFn = Marshal.GetFunctionPointerForDelegate(_packetLength);
-            cuoHost.CastSpellFn = Marshal.GetFunctionPointerForDelegate(_castSpell);
-            cuoHost.SetWindowTitleFn = Marshal.GetFunctionPointerForDelegate(_setWindowTitle);
-            cuoHost.PluginRecvFn = Marshal.GetFunctionPointerForDelegate(_sendToClient);
-            cuoHost.PluginSendFn = Marshal.GetFunctionPointerForDelegate(_sendToServer);
-            cuoHost.RequestMoveFn = Marshal.GetFunctionPointerForDelegate(_requestMove);
-            cuoHost.GetPlayerPositionFn = Marshal.GetFunctionPointerForDelegate(_getPlayerPosition);
-            cuoHost.ReflectionCmdFn = Marshal.GetFunctionPointerForDelegate(_reflectionCmd);
 
-            _initialize((IntPtr)mem);
+            try
+            {
+                ref var cuoHost = ref Unsafe.AsRef<ClientBindings>(mem);
+                cuoHost.PacketLengthFn = Marshal.GetFunctionPointerForDelegate(_packetLength);
+                cuoHost.CastSpellFn = Marshal.GetFunctionPointerForDelegate(_castSpell);
+                cuoHost.SetWindowTitleFn = Marshal.GetFunctionPointerForDelegate(_setWindowTitle);
+                cuoHost.PluginRecvFn = Marshal.GetFunctionPointerForDelegate(_sendToClient);
+                cuoHost.PluginSendFn = Marshal.GetFunctionPointerForDelegate(_sendToServer);
+                cuoHost.RequestMoveFn = Marshal.GetFunctionPointerForDelegate(_requestMove);
+                cuoHost.GetPlayerPositionFn = Marshal.GetFunctionPointerForDelegate(_getPlayerPosition);
+                cuoHost.ReflectionCmdFn = Marshal.GetFunctionPointerForDelegate(_reflectionCmd);
+
+                _initialize((IntPtr)mem);
+            }
+            finally
+            {
+                NativeMemory.Free(mem);
+            }
         }
 
         public void LoadPlugin(string pluginPath)

--- a/src/ClassicUO.Utility/ClassicUO.Utility.csproj
+++ b/src/ClassicUO.Utility/ClassicUO.Utility.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\external\FNA\FNA.Core.csproj" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ClassicUO.Utility/Crypter.cs
+++ b/src/ClassicUO.Utility/Crypter.cs
@@ -1,13 +1,110 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using System;
+using System.Security.Cryptography;
 using System.Text;
+using System.Runtime.Versioning;
 
 namespace ClassicUO.Utility
 {
     public static class Crypter
     {
+        private const string LEGACY_VERSION_PREFIX = "1-";
+        private const string DPAPI_PREFIX = "dpapi:";
+        private const string VOLATILE_PREFIX = "volatile:";
+        private static readonly byte[] _entropy = Encoding.UTF8.GetBytes("ClassicUO.Password.v2");
+
+        public static bool SupportsPersistentSecrets => OperatingSystem.IsWindows();
+
         public static string Encrypt(string source)
+        {
+            if (string.IsNullOrEmpty(source))
+            {
+                return string.Empty;
+            }
+
+            if (!OperatingSystem.IsWindows())
+            {
+                return VOLATILE_PREFIX + Convert.ToBase64String(Encoding.UTF8.GetBytes(source));
+            }
+
+            try
+            {
+                return EncryptWindows(source);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        public static string SanitizeForStorage(string source)
+        {
+            if (string.IsNullOrEmpty(source))
+            {
+                return string.Empty;
+            }
+
+            if (!OperatingSystem.IsWindows())
+            {
+                return string.Empty;
+            }
+
+            if (source.StartsWith(DPAPI_PREFIX, StringComparison.OrdinalIgnoreCase))
+            {
+                return source;
+            }
+
+            string plaintext = Decrypt(source);
+
+            return string.IsNullOrEmpty(plaintext) ? string.Empty : Encrypt(plaintext);
+        }
+
+        public static string Decrypt(string source)
+        {
+            if (string.IsNullOrEmpty(source))
+            {
+                return string.Empty;
+            }
+
+            if (source.StartsWith(DPAPI_PREFIX, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!OperatingSystem.IsWindows())
+                {
+                    return string.Empty;
+                }
+
+                try
+                {
+                    return DecryptWindows(source[DPAPI_PREFIX.Length..]);
+                }
+                catch
+                {
+                    return string.Empty;
+                }
+            }
+
+            if (source.StartsWith(VOLATILE_PREFIX, StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    return Encoding.UTF8.GetString(Convert.FromBase64String(source[VOLATILE_PREFIX.Length..]));
+                }
+                catch
+                {
+                    return string.Empty;
+                }
+            }
+
+            if (!LooksLikeLegacySecret(source))
+            {
+                return source;
+            }
+
+            return DecryptLegacy(source);
+        }
+
+        private static string EncryptLegacy(string source)
         {
             if (string.IsNullOrEmpty(source))
             {
@@ -24,7 +121,7 @@ namespace ClassicUO.Utility
             }
 
             StringBuilder sb = new StringBuilder(source.Length * 2 + 2);
-            sb.Append("1-");
+            sb.Append(LEGACY_VERSION_PREFIX);
 
             for (int i = 0; i < buff.Length; i++)
             {
@@ -39,7 +136,7 @@ namespace ClassicUO.Utility
             return sb.ToString();
         }
 
-        public static string Decrypt(string source)
+        private static string DecryptLegacy(string source)
         {
             if (string.IsNullOrEmpty(source))
             {
@@ -106,9 +203,63 @@ namespace ClassicUO.Utility
             return Encoding.ASCII.GetString(buff);
         }
 
+        private static bool LooksLikeLegacySecret(string source)
+        {
+            if (source.Length > 2 && source[0] == '1' && (source[1] == '-' || source[1] == '+'))
+            {
+                if (((source.Length - 2) & 1) != 0)
+                {
+                    return false;
+                }
+
+                for (int i = 2; i < source.Length; i++)
+                {
+                    if (!Uri.IsHexDigit(source[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            if ((source.Length & 1) != 0)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < source.Length; i++)
+            {
+                if (!Uri.IsHexDigit(source[i]))
+                {
+                    return false;
+                }
+            }
+
+            return source.Length > 0;
+        }
+
         private static string CalculateKey()
         {
             return Environment.MachineName;
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static string EncryptWindows(string source)
+        {
+            byte[] data = Encoding.UTF8.GetBytes(source);
+            byte[] encrypted = ProtectedData.Protect(data, _entropy, DataProtectionScope.CurrentUser);
+
+            return DPAPI_PREFIX + Convert.ToBase64String(encrypted);
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static string DecryptWindows(string encodedSource)
+        {
+            byte[] encrypted = Convert.FromBase64String(encodedSource);
+            byte[] decrypted = ProtectedData.Unprotect(encrypted, _entropy, DataProtectionScope.CurrentUser);
+
+            return Encoding.UTF8.GetString(decrypted);
         }
     }
 }

--- a/src/ClassicUO.Utility/Platforms/Native.cs
+++ b/src/ClassicUO.Utility/Platforms/Native.cs
@@ -47,9 +47,18 @@ namespace ClassicUO.Utility.Platforms
         private class WinNativeLoader : NativeLoader
         {
             private const uint LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008;
+            private const uint LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100;
+            private const uint LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000;
+
+            private readonly bool _supportsDefaultDllDirectories;
+
             [DllImport("kernel32.dll", SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
             private static extern IntPtr LoadLibraryExW([MarshalAs(UnmanagedType.LPWStr)] string lpLibFileName, IntPtr hFile, uint dwFlags);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            private static extern bool SetDefaultDllDirectories(uint directoryFlags);
 
             [DllImport("kernel32", EntryPoint = "GetProcAddress", CharSet = CharSet.Ansi)]
             private static extern IntPtr GetProcAddress_WIN(IntPtr module, [MarshalAs(UnmanagedType.LPStr)] string procName);
@@ -57,10 +66,26 @@ namespace ClassicUO.Utility.Platforms
             [DllImport("kernel32", EntryPoint = "FreeLibrary")]
             private static extern int FreeLibrary_WIN(IntPtr module);
 
+            public WinNativeLoader()
+            {
+                _supportsDefaultDllDirectories = SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+            }
 
             public override IntPtr LoadLibrary(string name)
             {
-                return LoadLibraryExW(name, IntPtr.Zero, LOAD_WITH_ALTERED_SEARCH_PATH);
+                uint flags = _supportsDefaultDllDirectories
+                    ? LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR
+                    : LOAD_WITH_ALTERED_SEARCH_PATH;
+
+                IntPtr handle = LoadLibraryExW(name, IntPtr.Zero, flags);
+
+                if (handle == IntPtr.Zero && _supportsDefaultDllDirectories)
+                {
+                    // Fallback for environments where restricted search flags are unavailable.
+                    handle = LoadLibraryExW(name, IntPtr.Zero, LOAD_WITH_ALTERED_SEARCH_PATH);
+                }
+
+                return handle;
             }
 
             public override IntPtr GetProcessAddress(IntPtr module, string name)


### PR DESCRIPTION
## CRIT-001 - UltimaLive path traversal

Problem
- Server-provided shard names were converted into filesystem paths with insufficient validation.

Patch
- Added strict shard-name validation (`A-Z`, `a-z`, `0-9`, `.`, `_`, `-`, max 64 chars).
- Rejected rooted paths and `.` / `..` path segments.
- Moved storage under fixed base: `<Local/CommonApplicationData>/ClassicUO/UltimaLive/<shard>`.
- Enforced canonical `StartsWith(basePath)` boundary check.

Files
- `src/ClassicUO.Client/Game/UltimaLive.cs`

Why this fixes it
- Untrusted shard names can no longer escape the storage root or traverse to arbitrary locations.

## HIGH-002 - Plugin/DLL loading hardening gaps

Problem
- Global `PATH` mutation and permissive load behavior increased side-loading risk.

Patch
- Removed process-wide `PATH` plugin-folder mutation.
- Added plugin root canonicalization and traversal rejection in plugin creation.
- Hardened Windows loader to use restricted DLL search flags (`LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`) with compatibility fallback.

Files
- `src/ClassicUO.Client/Main.cs`
- `src/ClassicUO.Client/Network/Plugin.cs`
- `src/ClassicUO.Utility/Platforms/Native.cs`

Why this fixes it
- Plugin binaries are constrained to the intended plugin directory and native dependency resolution uses safer search rules.

## HIGH-003 - Weak reversible password storage

Problem
- Password persistence used reversible XOR obfuscation.

Patch
- Reworked `Crypter`:
  - Windows: DPAPI (`ProtectedData`) with `dpapi:` prefix.
  - Non-Windows: volatile in-memory encoding (`volatile:`) and no persisted secret.
  - Legacy decrypt compatibility retained for existing stored values.
- Added save-time password sanitation to avoid persisting non-secure values.

Files
- `src/ClassicUO.Utility/Crypter.cs`
- `src/ClassicUO.Client/Configuration/Settings.cs`
- `src/ClassicUO.Utility/ClassicUO.Utility.csproj` (added `System.Security.Cryptography.ProtectedData`)

Why this fixes it
- Stored secrets are OS-protected on Windows; insecure reversible-at-rest values are no longer written when secure storage is unavailable.

## MED-004 - WebSocket resource leak

Problem
- WebSocket wrapper owned disposable resources but did not dispose them.

Patch
- Implemented idempotent cleanup in `Disconnect`/`Dispose`:
  - cancel token
  - close/abort websocket as needed
  - await/settle receive task
  - dispose websocket, raw socket, token source
- Added null guards and receive-task tracking.

Files
- `src/ClassicUO.Client/Network/Socket/WebSocketWrapper.cs`

Why this fixes it
- Reconnect and teardown paths now release network and cancellation resources reliably.

## MED-005 - Connect crash on malformed IP input

Problem
- `Substring(0, 2)` on short IP strings could throw.

Patch
- Replaced substring check with safe prefix check: `StartsWith("ws", StringComparison.OrdinalIgnoreCase)`.

Files
- `src/ClassicUO.Client/Network/NetClient.cs`

Why this fixes it
- Empty/short/malformed input no longer causes substring exceptions.

## MED-006 - Marker parsing crashers

Problem
- Marker loaders used direct indexing and `int.Parse` without strict field validation.

Patch
- Added defensive parsing with `TryParse` and schema checks.
- Hardened XML/UOAM/CSV loaders to skip malformed rows instead of throwing.
- Added robust `TryParseMarker` helper used by CSV/user marker loading.
- Fixed empty-line behavior in CSV loader (`continue` instead of early `return`).

Files
- `src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs`

Why this fixes it
- Malformed files are now tolerated and ignored safely, preventing parser-driven crashes.

## LOW-007 - Plugin packet length trust

Problem
- Plugin callbacks could return invalid packet lengths used directly for copy/slice operations.

Patch
- Added centralized packet-length clamping/validation after each plugin callback.
- Added null-buffer handling and safe copy bounds for recv/send pipelines.

Files
- `src/ClassicUO.Client/Network/Plugin.cs`

Why this fixes it
- Invalid lengths no longer trigger out-of-range operations or unstable packet flow.

## LOW-008 - Unmanaged allocation leak in plugin host init

Problem
- `NativeMemory.AllocZeroed` allocation in plugin host init was not freed.

Patch
- Wrapped host init buffer usage in `try/finally` and released with `NativeMemory.Free`.

Files
- `src/ClassicUO.Client/PluginHost.cs`

Why this fixes it
- Native memory allocated for binding bootstrap is now released deterministically.

## Validation

Command
- `E:\dotnet 10\dotnet.exe test ClassicUO/ClassicUO.sln -c Release --nologo`

Result
- Passed: 162
- Failed: 0
- Skipped: 0

## End Result

- All report findings (CRIT-001 through LOW-008) have code-level remediation patches in this branch.
- Patch set compiles and test suite passes.

## Compatibility Validation Update (Latest Repo Snapshot)

Date checked: 2026-03-15

Scope requested:
- Browser
- Windows x64
- Linux x64
- macOS x64

What was run:
- `E:\dotnet 10\dotnet.exe build ClassicUO/ClassicUO.sln -c Release --nologo`
- `E:\dotnet 10\dotnet.exe test ClassicUO/ClassicUO.sln -c Release --nologo`
- `E:\dotnet 10\dotnet.exe publish src/ClassicUO.Client/ClassicUO.Client.csproj -c Release -r win-x64   -o dist-check/win-x64   /p:IS_DEV_BUILD=true /p:NativeLib=Shared /p:OutputType=Library /p:PublishAot=false`
- `E:\dotnet 10\dotnet.exe publish src/ClassicUO.Client/ClassicUO.Client.csproj -c Release -r linux-x64 -o dist-check/linux-x64 /p:IS_DEV_BUILD=true /p:NativeLib=Shared /p:OutputType=Library /p:PublishAot=false`
- `E:\dotnet 10\dotnet.exe publish src/ClassicUO.Client/ClassicUO.Client.csproj -c Release -r osx-x64   -o dist-check/osx-x64   /p:IS_DEV_BUILD=true /p:NativeLib=Shared /p:OutputType=Library /p:PublishAot=false`
- `E:\dotnet 10\dotnet.exe publish src/ClassicUO.Client/ClassicUO.Client.csproj -c Release -r browser-wasm -o dist-check/browser-wasm /p:IS_DEV_BUILD=true /p:NativeLib=Shared /p:OutputType=Library /p:PublishAot=false`

Results:
- `Build`: PASS
- `Tests`: PASS (`162/162`)
- `Windows x64 publish`: PASS
- `Linux x64 publish`: PASS
- `macOS x64 publish`: PASS
- `Browser (browser-wasm) publish`: FAIL on environment prerequisite (`NETSDK1147`, missing workloads `wasm-tools` and `wasm-tools-net8`)

Notes:
- Upstream CI/release workflows in this repo currently target `win-x64`, `linux-x64`, and `osx-x64` (not Browser) via `.github/workflows/deploy.yml`.
- Based on this check, the patch set does not require code changes for Windows/Linux/macOS x64 builds.
- Browser build requires workload/tooling setup before it can be validated further.