### PR TITLE
Update GridLoot hueVector calculation for item rendering

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
@@ -544,7 +544,12 @@ namespace ClassicUO.Game.UI.Gumps
                     );
                 }
 
-                hueVector = ShaderHueTranslator.GetHueVector(0);
+                hueVector = ShaderHueTranslator.GetHueVector(
+                    item.Hue,
+                    item.ItemData.IsPartialHue,
+                    1f
+                );
+                
                 renderLists.AddGumpNoAtlas(
                     batcher =>
                     {
@@ -562,14 +567,15 @@ namespace ClassicUO.Game.UI.Gumps
                 );
                 if (_hit.MouseIsOver)
                 {
-                    hueVector.Z = 0.7f;
+                    Vector3 hoverHue = ShaderHueTranslator.GetHueVector(0);
+                    hoverHue.Z = 0.2f;
                     renderLists.AddGumpNoAtlas(
                         batcher =>
                         {
                             batcher.Draw(
                                 SolidColorTextureCache.GetTexture(Color.Yellow),
                                 new Rectangle(x + 1, y + 15, Width - 1, Height - 15),
-                                hueVector,
+                                hoverHue,
                                 layerDepth
                             );
                             return true;


### PR DESCRIPTION
The issue of items in GridLoot not displaying their colors and the mouse cursor completely painting the grid has been fixed.

before;
normal:
<img width="488" height="234" alt="image" src="https://github.com/user-attachments/assets/3423b012-a9e8-4391-b34f-70ce581dd1c5" />

hover:
<img width="547" height="237" alt="image" src="https://github.com/user-attachments/assets/cd45a0d3-d71f-43e6-972b-41ebde6d94f3" />

after;

normal;
<img width="556" height="227" alt="image" src="https://github.com/user-attachments/assets/e6ff523b-4056-49e4-bb94-e5bb8e900f8a" />

hover;
<img width="509" height="219" alt="image" src="https://github.com/user-attachments/assets/1bd80c55-618c-456c-8023-4c19e0a4c0f5" />
