### PR TITLE
✨ Quality: Regex pattern with incorrect escape sequence handling

### DIFF
--- a/src/ClassicUO.Client/Configuration/ConfigurationResolver.cs
+++ b/src/ClassicUO.Client/Configuration/ConfigurationResolver.cs
@@ -22,15 +22,9 @@ namespace ClassicUO.Configuration
 
             var text = File.ReadAllText(file);
 
-            text = Regex.Replace
-            (
-                text,
-                @"(?<!\\)  # lookbehind: Check that previous character isn't a \
-                                                \\         # match a \
-                                                (?!\\)     # lookahead: Check that the following character isn't a \",
-                @"\\",
-                RegexOptions.IgnorePatternWhitespace
-            );
+            // Remove the problematic regex replacement that could corrupt JSON data
+            // The original pattern was attempting to fix escape sequences but had logic flaws
+            // Better to let JsonSerializer handle validation and report errors
 
             return JsonSerializer.Deserialize(text, ctx);
         }


### PR DESCRIPTION
## Problem

The Regex.Replace pattern attempts to match escaped backslashes but has multiple issues:
1. The pattern uses `(?<!\\)` (negative lookbehind) which checks for a single backslash, but the comment says it should check for "previous character isn't a \"
2. The pattern then tries to match `\\` (two backslashes) which would match literal "\\" in the text
3. The lookahead `(?!\\)` checks that the following character isn't a backslash
4. The replacement is `@"\\"` which would insert two backslashes, potentially doubling them

This appears to be trying to fix JSON escaping issues but will likely corrupt the JSON data or not work as intended.
The pattern uses RegexOptions.IgnorePatternWhitespace which allows comments, but the pattern logic is flawed.


**Severity**: `medium`
**File**: `src/ClassicUO.Client/Configuration/ConfigurationResolver.cs`

## Solution

If the goal is to fix malformed JSON escape sequences, consider using a more robust approach:


## Changes

- `src/ClassicUO.Client/Configuration/ConfigurationResolver.cs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
