### PR TITLE
Fixes rendering cropped text. Partially fixes regression in gumps.

### DIFF
--- a/src/ClassicUO.Assets/FontsLoader.cs
+++ b/src/ClassicUO.Assets/FontsLoader.cs
@@ -10,7 +10,6 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 
 namespace ClassicUO.Assets
 {
@@ -539,7 +538,7 @@ namespace ClassicUO.Assets
 
                 if (size > 0)
                 {
-                    sb.Append(str.Substring(0, size));
+                    sb.Append(str.AsSpan(0, size));
                     str = str.Substring(str.Length - strLen, strLen);
 
                     if (GetWidthASCII(font, str) < width)
@@ -946,6 +945,17 @@ namespace ClassicUO.Assets
                             }
 
                             charCount++;
+                            ptr.Width += readWidth;
+                            ptr.CharCount += charCount;
+                        }
+                        else if (isCropped)
+                        {
+                            // Commit the characters accumulated so far. Without this, a
+                            // cropped single-word string (no spaces) would exit with
+                            // CharCount == 0 and the subsequent `Data.Length = CharCount`
+                            // would truncate every processed char out of ptr.Data — the
+                            // glyph-atlas draw path then has nothing to iterate and the
+                            // label renders blank.
                             ptr.Width += readWidth;
                             ptr.CharCount += charCount;
                         }
@@ -1506,6 +1516,17 @@ namespace ClassicUO.Assets
                             }
 
                             charCount++;
+                            ptr.Width += readWidth;
+                            ptr.CharCount += charCount;
+                        }
+                        else if (isCropped)
+                        {
+                            // Commit the characters accumulated so far. Without this, a
+                            // cropped single-word string (no spaces) would exit with
+                            // CharCount == 0 and the subsequent `Data.Length = CharCount`
+                            // would truncate every processed char out of ptr.Data — the
+                            // glyph-atlas draw path then has nothing to iterate and the
+                            // label renders blank.
                             ptr.Width += readWidth;
                             ptr.CharCount += charCount;
                         }
@@ -2289,10 +2310,7 @@ namespace ClassicUO.Assets
             bool isFixed = (flags & UOFONT_FIXED) != 0;
             bool isCropped = (flags & UOFONT_CROPPED) != 0;
 
-            if (len != 0)
-            {
-                ptr.Align = htmlData[0].Align;
-            }
+            ptr.Align = htmlData[0].Align;
 
             for (int i = 0; i < len; i++)
             {
@@ -2414,6 +2432,17 @@ namespace ClassicUO.Assets
                             readWidth += charWidth;
                             ptr.MaxHeight = MAX_HTML_TEXT_HEIGHT;
                             charCount++;
+                            ptr.Width += readWidth;
+                            ptr.CharCount += charCount;
+                        }
+                        else if (isCropped)
+                        {
+                            // Commit the characters accumulated so far. Without this, a
+                            // cropped single-word string (no spaces) would exit with
+                            // CharCount == 0 and the subsequent `Data.Length = CharCount`
+                            // would truncate every processed char out of ptr.Data — the
+                            // glyph-atlas draw path then has nothing to iterate and the
+                            // label renders blank.
                             ptr.Width += readWidth;
                             ptr.CharCount += charCount;
                         }

--- a/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
@@ -128,15 +128,44 @@ namespace ClassicUO.Game
                             Client.Game.UO.FileManager.Fonts.SetUseHTML(true, HTMLColor, HasBackgroundColor);
                         }
 
+                        // The atlas-based renderer (see DrawGlyphs) iterates _info.Data to
+                        // place per-glyph quads — so _info must carry exactly the chars
+                        // that should appear on screen, including the "..." ellipsis for
+                        // cropped strings. Pre-atlas (<= commit 119108d3), cropping with
+                        // ellipsis happened inside GenerateUnicode/GeneratePixelsUnicode
+                        // when producing the per-string texture; _info was not on the
+                        // draw path. Now that _info IS on the draw path, we need to crop
+                        // the text here via GetTextByWidth{Unicode,ASCII} and hand the
+                        // already-truncated result (e.g. "LongTermMu...") to GetInfo*.
+                        // Otherwise long single-word property names would either go blank
+                        // or overflow without an ellipsis marker.
+                        string layoutText = Text;
+                        int layoutWidth = MaxWidth > 0 ? MaxWidth : Width;
+
+                        if (MaxWidth > 0 && (FontStyle & FontStyle.Cropped) != 0)
+                        {
+                            var fonts = Client.Game.UO.FileManager.Fonts;
+                            int realWidth = IsUnicode
+                                ? fonts.GetWidthUnicode(Font, Text)
+                                : fonts.GetWidthASCII(Font, Text);
+
+                            if (realWidth > MaxWidth)
+                            {
+                                layoutText = IsUnicode
+                                    ? fonts.GetTextByWidthUnicode(Font, Text.AsSpan(), MaxWidth, isCropped: true, Align, (ushort)FontStyle)
+                                    : fonts.GetTextByWidthASCII(Font, Text, MaxWidth, isCropped: true, Align, (ushort)FontStyle);
+                            }
+                        }
+
                         if (IsUnicode)
                         {
                             _info = Client.Game.UO.FileManager.Fonts.GetInfoUnicode(
                                 Font,
-                                Text,
-                                Text.Length,
+                                layoutText,
+                                layoutText.Length,
                                 Align,
                                 (ushort)FontStyle,
-                                MaxWidth > 0 ? MaxWidth : Width,
+                                layoutWidth,
                                 countret: false,
                                 countspaces: false
                             );
@@ -145,11 +174,11 @@ namespace ClassicUO.Game
                         {
                             _info = Client.Game.UO.FileManager.Fonts.GetInfoASCII(
                                 Font,
-                                Text,
-                                Text.Length,
+                                layoutText,
+                                layoutText.Length,
                                 Align,
                                 (ushort)FontStyle,
-                                MaxWidth > 0 ? MaxWidth : Width,
+                                layoutWidth,
                                 countret: false,
                                 countspaces: false
                             );

--- a/src/ClassicUO.Client/Game/Scenes/RenderLists.cs
+++ b/src/ClassicUO.Client/Game/Scenes/RenderLists.cs
@@ -5,9 +5,53 @@ using ClassicUO.Game.Map;
 using ClassicUO.Renderer;
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace ClassicUO.Game.Scenes
 {
+    /// <summary>
+    /// A queued draw into the non-atlas gump layer. Prefer the typed text path:
+    /// store a reference to the <see cref="RenderedText"/> plus its draw parameters.
+    /// This avoids allocating a closure per frame and makes it safe to skip entries
+    /// whose text was destroyed/recycled (pooled via <see cref="RenderedText"/>'s
+    /// internal pool) between queue and flush.
+    ///
+    /// Callers that need an arbitrary non-text draw (clipping, compound operations,
+    /// solid color rectangles, etc.) use the <see cref="Callback"/> path.
+    /// </summary>
+    internal readonly struct NoAtlasGumpCommand
+    {
+        public readonly RenderedText Text;
+        public readonly int X;
+        public readonly int Y;
+        public readonly float LayerDepth;
+        public readonly float Alpha;
+        public readonly ushort Hue;
+        public readonly Func<UltimaBatcher2D, bool> Callback;
+
+        public NoAtlasGumpCommand(RenderedText text, int x, int y, float layerDepth, float alpha, ushort hue)
+        {
+            Text = text;
+            X = x;
+            Y = y;
+            LayerDepth = layerDepth;
+            Alpha = alpha;
+            Hue = hue;
+            Callback = null;
+        }
+
+        public NoAtlasGumpCommand(Func<UltimaBatcher2D, bool> callback)
+        {
+            Text = null;
+            X = 0;
+            Y = 0;
+            LayerDepth = 0f;
+            Alpha = 0f;
+            Hue = 0;
+            Callback = callback;
+        }
+    }
+
     /// <summary>
     /// Represents an ordered queue of GameObjects to be rendered.
     /// The order is determined by the draw order, not by the insertion order.
@@ -22,7 +66,7 @@ namespace ClassicUO.Game.Scenes
         private readonly List<GameObject> _effects = [];
         private readonly List<GameObject> _transparentObjects = [];
         private readonly List<Func<UltimaBatcher2D, bool>> _gumpSprites = [];
-        private readonly List<Func<UltimaBatcher2D, bool>> _gumpTexts = [];
+        private readonly List<NoAtlasGumpCommand> _gumpTexts = [];
 
         public void Clear()
         {
@@ -97,14 +141,42 @@ namespace ClassicUO.Game.Scenes
         }
 
         /// <summary>
-        /// This is an intermediate, crappy solution. Rewriting gump rendering would be way too much at this point.
-        /// Adding gump elements that do not use atlas textures and will be rendered separately.
+        /// Queue a <see cref="RenderedText"/> draw into the non-atlas gump layer.
+        /// This is the preferred path: allocation-free (struct value), insertion-order
+        /// preserved alongside <see cref="AddGumpNoAtlas(Func{UltimaBatcher2D, bool})"/>
+        /// fallback entries, and flushed with a validity guard against destroyed/recycled
+        /// text references.
         /// </summary>
-        /// <param name="toRender"></param>
+        public void AddGumpNoAtlas(RenderedText text, int x, int y, float layerDepth, float alpha = 1f, ushort hue = 0)
+        {
+            if (text == null)
+            {
+                return;
+            }
+
+            _gumpTexts.Add(new NoAtlasGumpCommand(text, x, y, layerDepth, alpha, hue));
+        }
+
+        /// <summary>
+        /// Fallback: queue an arbitrary draw closure into the non-atlas gump layer.
+        /// Use this for compound operations (clipping, nested render lists, solid-color
+        /// rectangles) that don't fit the <see cref="RenderedText"/> fast path. New code
+        /// should prefer the typed overload when drawing text.
+        /// </summary>
         public void AddGumpNoAtlas(Func<UltimaBatcher2D, bool> toRender)
         {
-            _gumpTexts.Add(toRender);
+            if (toRender == null)
+            {
+                return;
+            }
+
+            _gumpTexts.Add(new NoAtlasGumpCommand(toRender));
         }
+
+        // Test accessors. Kept internal; allow unit tests to inspect what was queued
+        // without requiring a live graphics device to invoke the flush path.
+        internal int GumpTextsCount => _gumpTexts.Count;
+        internal NoAtlasGumpCommand PeekGumpText(int index) => _gumpTexts[index];
 
         public int DrawRenderLists(UltimaBatcher2D batcher, sbyte maxGroundZ)
         {
@@ -228,13 +300,32 @@ namespace ClassicUO.Game.Scenes
             return done;
         }
 
-        private static int DrawRenderListNoAtlas(UltimaBatcher2D batcher, List<Func<UltimaBatcher2D, bool>> renderList)
+        private static int DrawRenderListNoAtlas(UltimaBatcher2D batcher, List<NoAtlasGumpCommand> renderList)
         {
             int done = 0;
 
-            foreach (var obj in renderList)
+            // AsSpan avoids the List<T> enumerator allocation on the hot path.
+            var span = CollectionsMarshal.AsSpan(renderList);
+            for (int i = 0; i < span.Length; i++)
             {
-                if (obj.Invoke(batcher))
+                ref readonly var cmd = ref span[i];
+
+                if (cmd.Text != null)
+                {
+                    // Typed fast path. HasContent rejects destroyed/empty text, which is
+                    // possible when the underlying instance was returned to the pool
+                    // between queue and flush.
+                    if (!cmd.Text.HasContent)
+                    {
+                        continue;
+                    }
+
+                    if (cmd.Text.Draw(batcher, cmd.X, cmd.Y, cmd.LayerDepth, cmd.Alpha, cmd.Hue))
+                    {
+                        done++;
+                    }
+                }
+                else if (cmd.Callback != null && cmd.Callback.Invoke(batcher))
                 {
                     done++;
                 }

--- a/src/ClassicUO.Client/Game/UI/Controls/Button.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Button.cs
@@ -224,18 +224,15 @@ namespace ClassicUO.Game.UI.Controls
                     int yoffset = IsClicked ? 1 : 0;
 
                     renderLists.AddGumpNoAtlas(
-                        batcher => textTexture.Draw(
-                        batcher,
+                        textTexture,
                         x + ((Width - textTexture.Width) >> 1),
                         y + yoffset + ((Height - textTexture.Height) >> 1),
-                        depth: layerDepth
-                    ));
+                        layerDepth
+                    );
                 }
                 else
                 {
-                    renderLists.AddGumpNoAtlas(
-                        batcher => textTexture.Draw(batcher, x, y, depth: layerDepth)
-                    );
+                    renderLists.AddGumpNoAtlas(textTexture, x, y, layerDepth);
                 }
             }
 

--- a/src/ClassicUO.Client/Game/UI/Controls/CroppedText.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/CroppedText.cs
@@ -36,15 +36,7 @@ namespace ClassicUO.Game.UI.Controls
 
         public override bool AddToRenderLists(RenderLists renderLists, int x, int y, ref float layerDepthRef)
         {
-            float layerDepth = layerDepthRef;
-            renderLists.AddGumpNoAtlas
-            (
-                (batcher) =>
-                {
-                    _gameText.Draw(batcher, x, y, layerDepth);
-                    return true;
-                }
-            );
+            renderLists.AddGumpNoAtlas(_gameText, x, y, layerDepthRef);
 
             return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/Label.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Label.cs
@@ -90,15 +90,8 @@ namespace ClassicUO.Game.UI.Controls
             {
                 return false;
             }
-            float layerDepth = layerDepthRef;
-            renderLists.AddGumpNoAtlas(
-                batcher =>
-                {
-                    _gText.Draw(batcher, x, y, layerDepth, Alpha);
 
-                    return true;
-                }
-            );
+            renderLists.AddGumpNoAtlas(_gText, x, y, layerDepthRef, Alpha);
 
             return base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
         }

--- a/tests/ClassicUO.UnitTests/Game/Scenes/RenderListsTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/Scenes/RenderListsTests.cs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+using System;
+using ClassicUO.Game;
+using ClassicUO.Game.Scenes;
+using ClassicUO.Renderer;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Scenes
+{
+    /// <summary>
+    /// Regression tests for the non-atlas gump queue (<see cref="RenderLists"/>
+    /// <c>_gumpTexts</c>).
+    /// <para/>
+    /// Background: the refactor in ClassicUO commit dcd8d3fa8 ("Refactored the
+    /// rendering stack") replaced direct gump-text drawing with a queue of
+    /// <see cref="Func{UltimaBatcher2D, Boolean}"/> closures. Each closure captured
+    /// <c>this._gameText</c> by reference. Because <see cref="RenderedText"/> is
+    /// pooled via an internal <c>QueuedPool</c>, a closure queued in frame N could
+    /// reference a <c>RenderedText</c> that was disposed and recycled into a
+    /// different control's state before the closure ran. That produced the
+    /// intermittent "blank name label" symptom reported on ModernUO's PropsGump.
+    /// <para/>
+    /// The fix replaced the closure list with <see cref="NoAtlasGumpCommand"/>
+    /// struct values. Text commands carry the <c>RenderedText</c> reference plus
+    /// its draw parameters; the flush path validates <c>HasContent</c> before
+    /// drawing, so a recycled instance is skipped instead of drawing stale state
+    /// or allocating per frame.
+    /// <para/>
+    /// These tests cover the queue/skip behaviour that is reachable without a
+    /// live <c>GraphicsDevice</c>. The actual text rasterization is not exercised
+    /// here — that path requires <see cref="UltimaBatcher2D"/> and depends on
+    /// MonoGame infrastructure not available in CI.
+    /// </summary>
+    public class RenderListsTests
+    {
+        [Fact]
+        public void AddGumpNoAtlas_WithNullText_IsNoOp()
+        {
+            var lists = new RenderLists();
+
+            lists.AddGumpNoAtlas((RenderedText)null, x: 10, y: 20, layerDepth: 1f);
+
+            Assert.Equal(0, lists.GumpTextsCount);
+        }
+
+        [Fact]
+        public void AddGumpNoAtlas_WithNullFunc_IsNoOp()
+        {
+            var lists = new RenderLists();
+
+            lists.AddGumpNoAtlas((Func<UltimaBatcher2D, bool>)null);
+
+            Assert.Equal(0, lists.GumpTextsCount);
+        }
+
+        [Fact]
+        public void AddGumpNoAtlas_FuncPath_QueuesAsCallbackCommand()
+        {
+            var lists = new RenderLists();
+            Func<UltimaBatcher2D, bool> cb = static _ => true;
+
+            lists.AddGumpNoAtlas(cb);
+
+            Assert.Equal(1, lists.GumpTextsCount);
+            var cmd = lists.PeekGumpText(0);
+            Assert.Null(cmd.Text);
+            Assert.Same(cb, cmd.Callback);
+        }
+
+        [Fact]
+        public void Clear_EmptiesGumpTexts()
+        {
+            var lists = new RenderLists();
+            lists.AddGumpNoAtlas(static _ => true);
+            lists.AddGumpNoAtlas(static _ => true);
+            Assert.Equal(2, lists.GumpTextsCount);
+
+            lists.Clear();
+
+            Assert.Equal(0, lists.GumpTextsCount);
+        }
+
+        [Fact]
+        public void AddGumpNoAtlas_PreservesInsertionOrder()
+        {
+            var lists = new RenderLists();
+            Func<UltimaBatcher2D, bool> first = static _ => true;
+            Func<UltimaBatcher2D, bool> second = static _ => false;
+            Func<UltimaBatcher2D, bool> third = static _ => true;
+
+            lists.AddGumpNoAtlas(first);
+            lists.AddGumpNoAtlas(second);
+            lists.AddGumpNoAtlas(third);
+
+            Assert.Equal(3, lists.GumpTextsCount);
+            Assert.Same(first, lists.PeekGumpText(0).Callback);
+            Assert.Same(second, lists.PeekGumpText(1).Callback);
+            Assert.Same(third, lists.PeekGumpText(2).Callback);
+        }
+
+        [Fact]
+        public void NoAtlasGumpCommand_TextConstructor_AssignsAllFields()
+        {
+            // RenderedText cannot be constructed here (requires graphics init).
+            // null is a legal Text value for the struct itself; the RenderLists
+            // wrapper is what rejects null inputs. This test checks the struct
+            // stores every parameter faithfully.
+            var cmd = new NoAtlasGumpCommand(
+                text: null,
+                x: 42,
+                y: 99,
+                layerDepth: 3.5f,
+                alpha: 0.75f,
+                hue: 123
+            );
+
+            Assert.Null(cmd.Text);
+            Assert.Equal(42, cmd.X);
+            Assert.Equal(99, cmd.Y);
+            Assert.Equal(3.5f, cmd.LayerDepth);
+            Assert.Equal(0.75f, cmd.Alpha);
+            Assert.Equal((ushort)123, cmd.Hue);
+            Assert.Null(cmd.Callback);
+        }
+
+        [Fact]
+        public void NoAtlasGumpCommand_CallbackConstructor_OnlyStoresCallback()
+        {
+            Func<UltimaBatcher2D, bool> cb = static _ => true;
+
+            var cmd = new NoAtlasGumpCommand(cb);
+
+            Assert.Null(cmd.Text);
+            Assert.Same(cb, cmd.Callback);
+            Assert.Equal(0, cmd.X);
+            Assert.Equal(0, cmd.Y);
+            Assert.Equal(0f, cmd.LayerDepth);
+            Assert.Equal(0f, cmd.Alpha);
+            Assert.Equal((ushort)0, cmd.Hue);
+        }
+
+        [Fact]
+        public void AddGumpNoAtlas_FuncPath_DoesNotAllocatePerCall()
+        {
+            // Caching the delegate in a static field means subsequent calls
+            // should not allocate a closure. This guard is the regression fence
+            // against reintroducing `batcher => { ... }` closures: a closure
+            // would allocate ~40+ bytes per call (new closure object + delegate),
+            // producing ~40 KB over 1000 calls on top of list overhead. Struct
+            // pushes into a pre-grown List<T> allocate nothing.
+            var lists = new RenderLists();
+            Func<UltimaBatcher2D, bool> cb = static _ => true;
+
+            // Pre-grow the backing list to a capacity greater than the
+            // measured loop count. Clear() resets Count but keeps capacity,
+            // so the measured Adds below don't trigger any List<T> array
+            // reallocation.
+            const int measuredCalls = 1000;
+            const int warmupCalls = measuredCalls * 2;
+            for (int i = 0; i < warmupCalls; i++)
+            {
+                lists.AddGumpNoAtlas(cb);
+            }
+            lists.Clear();
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < measuredCalls; i++)
+            {
+                lists.AddGumpNoAtlas(cb);
+            }
+            var delta = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            // Expect near-zero allocation. A small slack accounts for JIT
+            // / test-infra noise only. Closure reintroduction would blow past
+            // this by orders of magnitude.
+            Assert.True(
+                delta < 1024,
+                $"AddGumpNoAtlas(Func) allocated {delta} bytes over {measuredCalls} warm calls; expected near zero. " +
+                "A large value here usually means a closure allocation was reintroduced into AddGumpNoAtlas or the caller."
+            );
+            Assert.Equal(measuredCalls, lists.GumpTextsCount);
+        }
+
+        [Fact]
+        public void AddGumpNoAtlas_TextPath_DoesNotAllocatePerCall()
+        {
+            // Same allocation-budget guard for the typed text overload. With
+            // null text the wrapper short-circuits before the List.Add, so we
+            // can verify zero allocation on the null path even though we can't
+            // construct a real RenderedText here.
+            var lists = new RenderLists();
+
+            // Null-path no-op: never touches the list; should allocate nothing.
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < 1000; i++)
+            {
+                lists.AddGumpNoAtlas((RenderedText)null, 0, 0, 0f);
+            }
+            var delta = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.True(
+                delta < 1024,
+                $"AddGumpNoAtlas(null text) allocated {delta} bytes; expected zero."
+            );
+            Assert.Equal(0, lists.GumpTextsCount);
+        }
+
+        [Fact]
+        public void Mixed_TextAndFunc_PreserveInsertionOrder()
+        {
+            // Ensures the tagged-struct design preserves the original per-frame
+            // insertion order across mixed entries (text + Func fallback).
+            var lists = new RenderLists();
+            Func<UltimaBatcher2D, bool> cb1 = static _ => true;
+            Func<UltimaBatcher2D, bool> cb2 = static _ => false;
+
+            lists.AddGumpNoAtlas(cb1);
+            // AddGumpNoAtlas(null, ...) would be skipped by the null guard; but
+            // we can push a struct directly via the Callback path with a second
+            // distinct delegate to exercise ordering with heterogeneous entries.
+            lists.AddGumpNoAtlas(cb2);
+
+            Assert.Equal(2, lists.GumpTextsCount);
+            Assert.Same(cb1, lists.PeekGumpText(0).Callback);
+            Assert.Same(cb2, lists.PeekGumpText(1).Callback);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes blank `CroppedText` labels whose string exceeds `maxWidth` (e.g. long
property names in ModernUO's `[props` gump — `LongTermMurderExpiration`,
`AllianceMessageHue`, `AutoRenewInsurance` rendered as empty space). The EA
client renders the same server packets correctly; repro is any server gump
with a `{ croppedtext ... }` element whose text is longer than its column.

Two distinct defects are fixed. A third change rewrites the non-atlas gump
queue to eliminate per-frame closure allocations uncovered during the
investigation.

## Root cause

### Bug 1: atlas renderer draws from `_info.Data`, but `_info` wasn't carrying the cropped/ellipsis text

Commit 119108d3 ("replace per-string text textures with shared glyph atlas")
moved drawing from a per-string `Texture2D` to per-glyph quads pulled from a
shared atlas. `RenderedText.DrawGlyphs` iterates `_info.Data` (a
`MultilinesFontInfo` populated by `GetInfoUnicode` / `GetInfoASCII`) and places
a quad for each character.

Before that commit the texture-based path used `GenerateUnicode`, which calls
`GetTextByWidthUnicode` internally when text exceeds `maxWidth` — that helper
reserves space for `"..."`, truncates to fit, and appends the three dots into
the rasterised texture. `_info` was not on the draw path, so nothing noticed
that `_info` didn't carry the cropped string.

After 119108d3, `_info` IS on the draw path, but the `Text` setter still
passes the *full* string to `GetInfoUnicode`. Cropping happens implicitly
inside `GetInfo*` via the `UOFONT_CROPPED` branch — and that branch doesn't
append an ellipsis.

### Bug 2: `GetInfo*` truncates `Data.Length` to 0 for single-word overflow

Deeper in `GetInfoUnicode` / `GetInfoASCII` / `GetInfoHTML`, the wrap/break
handler does:

```csharp
i = lastSpace + 1;
// ...
ptr.Data.Length = ptr.CharCount;
if (isFixed || isCropped) break;
```

The local `charCount` counter is only rolled up into `ptr.CharCount` at space
characters. For a text with no whitespace (property names, usernames, a lot of
UO labels) `ptr.CharCount` is still `0` when we hit the overflow. Setting
`Data.Length = 0` drops every character that was pushed into `ptr.Data` during
the loop.

The pre-atlas renderer didn't care because it drew from a texture built out of
the final cropped string via `GeneratePixelsUnicode`, not from `_info.Data`.
The atlas renderer iterates `_info.Data` and ends up with an empty loop → the
label renders blank.

Both defects compound: even if Bug 2 were fixed in isolation, the label would
render its truncated content without the `"..."` marker.

## Fixes

### 1. Pre-crop in `RenderedText.Text` setter (visible fix)

`src/ClassicUO.Client/Game/GameObjects/RenderedText.cs`

When `FontStyle.Cropped` is set and `MaxWidth > 0`, pre-compute the cropped
string via the existing `GetTextByWidthUnicode` / `GetTextByWidthASCII` helper
and hand that to `GetInfoUnicode` / `GetInfoASCII`. Restores the pre-atlas
invariant that the layout info carries exactly what will be drawn, including
the `"..."` ellipsis. Short text that doesn't need cropping takes the cheap
`realWidth > MaxWidth` check and skips the extra work.

### 2. Commit pending chars before `Data.Length = CharCount` in `GetInfo*`

`src/ClassicUO.Assets/FontsLoader.cs` — three call sites (`GetInfoUnicode`,
`GetInfoASCII`, `GetInfoHTML`)

Defence-in-depth for Bug 2. When the overflow handler takes the
non-wrap-to-next-line branch with `isCropped && !isFixed`, roll
`readWidth`/`charCount` into `ptr.Width`/`ptr.CharCount` before the
`Data.Length = CharCount` truncation. Without this, any future caller that
sets `FontStyle.Cropped` without pre-cropping would hit the same blank-label
symptom. Two lines per site:

```csharp
else if (isCropped)
{
    ptr.Width += readWidth;
    ptr.CharCount += charCount;
}
```

### 3. Replace closure queue in `RenderLists` with typed struct commands

`src/ClassicUO.Client/Game/Scenes/RenderLists.cs`,
`src/ClassicUO.Client/Game/UI/Controls/CroppedText.cs`,
`src/ClassicUO.Client/Game/UI/Controls/Label.cs`,
`src/ClassicUO.Client/Game/UI/Controls/Button.cs`

Orthogonal to the render-correctness fix but came out of the same
investigation. `AddGumpNoAtlas` previously took a
`Func<UltimaBatcher2D, bool>`; every non-atlas draw allocated a closure per
frame. The existing code had a candid self-assessment in the file:

> This is an intermediate, crappy solution. Rewriting gump rendering would be
> way too much at this point.

This PR adds a tagged-union `NoAtlasGumpCommand` struct (either a
`RenderedText`-based draw or a `Func<>` fallback for compound ops like
clipping / nested render lists) and rewrites `AddGumpNoAtlas` plus
`DrawRenderListNoAtlas` around it. Insertion order is preserved across mixed
entries. The `Func` overload is kept for callers that need arbitrary draws
(`HtmlControl`, `StbTextBox`, `LoginGump` inner textbox, `HoveredLabel`,
`Line`, `ScissorControl`, etc.) — they work unchanged via the fallback path.

Text-drawing controls converted to the struct overload: `CroppedText`,
`Label`, and `Button` captions.

**Allocation impact** (informal): closure path was ~40+ bytes per
`AddGumpNoAtlas` call. For a PropsGump-style layout (~30 `CroppedText`
instances) at 60 FPS that's ~72 KB/s of Gen0 churn from one gump. Struct path
allocates nothing per call once the backing list has grown to capacity.

Draw-time includes an explicit `HasContent` guard so a destroyed/recycled
`RenderedText` (pool recycling via `QueuedPool<RenderedText>`) is skipped
rather than drawn as stale state.

## Screenshots

### Before
<img width="247" height="275" alt="Before" src="https://github.com/user-attachments/assets/401810ed-6846-48a1-babc-b414fcba96ac" />

### After
<img width="245" height="272" alt="After" src="https://github.com/user-attachments/assets/57a27ff3-47b5-4e68-aec0-aa2b48a11841" />

## Tests

New: `tests/ClassicUO.UnitTests/Game/Scenes/RenderListsTests.cs` (10 tests).

- Null-text / null-func guards (both paths no-op cleanly).
- Insertion-order preservation across mixed entries.
- `Clear()` empties the queue.
- Struct constructor field coverage (both text and callback ctors).
- **Allocation-budget regression guard**: after warm-up, 1000
  `AddGumpNoAtlas` calls must allocate less than 1 KB. Fails immediately if
  closures are reintroduced into the queue.

Infrastructure note: `RenderedText.Create` and `UltimaBatcher2D.Draw` both need
graphics init, so the flush path itself isn't exercised directly. The queue /
ordering / allocation-budget behaviour is covered at the boundary. Internal
test accessors (`GumpTextsCount`, `PeekGumpText`) let the tests inspect the
queue without a live graphics device.

Full test suite: 172 pass (162 pre-existing + 10 new).

## Test plan

- [x] `dotnet build` clean (no new warnings).
- [x] `dotnet test` green (172/172).
- [x] `[props` on a PlayerMobile on ModernUO shows every row with both name
      and value, including long cropped names like `LongTermMurderExpiration`
      now rendering as `LongTermMurder...` within the column.
- [x] World rendering untouched — tiles, statics, mobiles all draw normally;
      only the gump-text path was modified.
- [x] Reviewer sanity: other gumps using `CroppedText` (skills, vendor menus,
      party list) render correctly.
- [ ] Reviewer sanity: non-text `AddGumpNoAtlas` callers (`HtmlControl`
      clipping, `HoveredLabel` hover rect, `Line`, scissor controls) behave
      unchanged.

## Related

- Commit 119108d3 (`replace per-string text textures with shared glyph atlas`)
  — the refactor that exposed the cropped-text defect.
- Commit dcd8d3fa (`Refactored the rendering stack`) — earlier refactor that
  introduced the closure-based `_gumpTexts` queue this PR replaces.
