### PR TITLE
Fixes regression in books from previous gump fix.

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
@@ -157,6 +157,16 @@ namespace ClassicUO.Game
                             }
                         }
 
+                        // countret/countspaces MUST be true so that CharCount in each
+                        // MultilinesFontInfo node includes '\n' and ' '. Stb's hit-testing
+                        // (LocateCoord) walks rows by `i += r.num_chars` and bails out by
+                        // returning text length when it sees num_chars == 0. With
+                        // countret=false an empty line ("\n") produces CharCount=0, which
+                        // forces every click on an empty editable area (book body, etc.)
+                        // to put the caret at the end of the buffer — observed in
+                        // ModernBookGump as "click goes to the last page". The draw path
+                        // (DrawGlyphs) explicitly skips '\n'/'\r' glyphs so counting them
+                        // here costs nothing visually.
                         if (IsUnicode)
                         {
                             _info = Client.Game.UO.FileManager.Fonts.GetInfoUnicode(
@@ -166,8 +176,8 @@ namespace ClassicUO.Game
                                 Align,
                                 (ushort)FontStyle,
                                 layoutWidth,
-                                countret: false,
-                                countspaces: false
+                                countret: true,
+                                countspaces: true
                             );
                         }
                         else
@@ -179,8 +189,8 @@ namespace ClassicUO.Game
                                 Align,
                                 (ushort)FontStyle,
                                 layoutWidth,
-                                countret: false,
-                                countspaces: false
+                                countret: true,
+                                countspaces: true
                             );
                         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
@@ -10,6 +10,7 @@ using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
+using SDL3;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -355,150 +356,96 @@ namespace ClassicUO.Game.UI.Gumps
             base.AddToRenderLists(renderLists, x, y, ref layerDepthRef);
             float layerDepth = layerDepthRef;
 
+            // Render path is intentionally PURE — no state mutation, no SetActivePage,
+            // no _caretPage/_focusPage writes. Caret/page realignment runs from input
+            // handlers via _bookPage.RealignCaretAndActivePage(), so a single mismatch
+            // between _caretScreenPosition and _pageCoords cannot spin SetActivePage
+            // every frame.
             renderLists.AddGumpNoAtlas
             (
                 batcher =>
                 {
-                    if (batcher.ClipBegin(x, y, Width, Height))
+                    if (!batcher.ClipBegin(x, y, Width, Height))
                     {
-                        RenderedText t = _bookPage.renderedText;
-                        int startpage = (ActivePage - 1) * 2;
-
-                        if (startpage < BookPageCount)
-                        {
-                            int poy = _bookPage._pageCoords[startpage, 0], phy = _bookPage._pageCoords[startpage, 1];
-
-                            _bookPage.DrawSelection
-                            (
-                                batcher,
-                                x + RIGHT_X,
-                                y + UPPER_MARGIN,
-                                poy,
-                                poy + phy,
-                                layerDepth
-                            );
-
-                            t.Draw
-                            (
-                                batcher,
-                                x + RIGHT_X,
-                                y + UPPER_MARGIN,
-                                0,
-                                poy,
-                                t.Width,
-                                phy,
-                                layerDepth
-                            );
-
-                            if (startpage == _bookPage._caretPage)
-                            {
-                                if (_bookPage._caretPos.Y < poy + phy)
-                                {
-                                    if (_bookPage._caretPos.Y >= poy)
-                                    {
-                                        if (_bookPage.HasKeyboardFocus)
-                                        {
-                                            _bookPage.renderedCaret.Draw
-                                            (
-                                                batcher,
-                                                _bookPage._caretPos.X + x + RIGHT_X,
-                                                _bookPage._caretPos.Y + y + UPPER_MARGIN - poy,
-                                                0,
-                                                0,
-                                                _bookPage.renderedCaret.Width,
-                                                _bookPage.renderedCaret.Height,
-                                                layerDepth
-                                            );
-                                        }
-                                    }
-                                    else
-                                    {
-                                        _bookPage._caretPage = _bookPage.GetCaretPage();
-                                    }
-                                }
-                                else if (_bookPage._caretPos.Y <= _bookPage.Height)
-                                {
-                                    if (_bookPage._caretPage + 2 < _bookPage._pagesChanged.Length)
-                                    {
-                                        _bookPage._focusPage = _bookPage._caretPage++;
-                                        SetActivePage(_bookPage._caretPage / 2 + 2);
-                                    }
-                                }
-                            }
-                        }
-
-                        startpage--;
-
-                        if (startpage > 0)
-                        {
-                            int poy = _bookPage._pageCoords[startpage, 0], phy = _bookPage._pageCoords[startpage, 1];
-
-                            _bookPage.DrawSelection
-                            (
-                                batcher,
-                                x + LEFT_X,
-                                y + UPPER_MARGIN,
-                                poy,
-                                poy + phy,
-                                layerDepth
-                            );
-
-                            t.Draw
-                            (
-                                batcher,
-                                x + LEFT_X,
-                                y + UPPER_MARGIN,
-                                0,
-                                poy,
-                                t.Width,
-                                phy,
-                                layerDepth
-                            );
-
-                            if (startpage == _bookPage._caretPage)
-                            {
-                                if (_bookPage._caretPos.Y < poy + phy)
-                                {
-                                    if (_bookPage._caretPos.Y >= poy)
-                                    {
-                                        if (_bookPage.HasKeyboardFocus)
-                                        {
-                                            _bookPage.renderedCaret.Draw
-                                            (
-                                                batcher,
-                                                _bookPage._caretPos.X + x + LEFT_X,
-                                                _bookPage._caretPos.Y + y + UPPER_MARGIN - poy,
-                                                0,
-                                                0,
-                                                _bookPage.renderedCaret.Width,
-                                                _bookPage.renderedCaret.Height,
-                                                layerDepth
-                                            );
-                                        }
-                                    }
-                                    else if (_bookPage._caretPage > 0)
-                                    {
-                                        _bookPage._focusPage = _bookPage._caretPage--;
-                                        SetActivePage(_bookPage._caretPage / 2 + 1);
-                                    }
-                                }
-                                else if (_bookPage._caretPos.Y <= _bookPage.Height)
-                                {
-                                    if (_bookPage._caretPage + 2 < _bookPage._pagesChanged.Length)
-                                    {
-                                        _bookPage._caretPage++;
-                                    }
-                                }
-                            }
-                        }
-
-                        batcher.ClipEnd();
+                        return true;
                     }
+
+                    DrawBookPage(batcher, x, y, layerDepth, (ActivePage - 1) * 2, RIGHT_X);
+                    DrawBookPage(batcher, x, y, layerDepth, (ActivePage - 1) * 2 - 1, LEFT_X);
+
+                    batcher.ClipEnd();
                     return true;
                 }
             );
 
             return true;
+        }
+
+        private void DrawBookPage(UltimaBatcher2D batcher, int x, int y, float layerDepth, int pageIndex, int pageX)
+        {
+            if (pageIndex < 0 || pageIndex >= BookPageCount)
+            {
+                return;
+            }
+
+            int poy = _bookPage._pageCoords[pageIndex, 0];
+            int phy = _bookPage._pageCoords[pageIndex, 1];
+            RenderedText t = _bookPage.renderedText;
+
+            _bookPage.DrawSelection(batcher, x + pageX, y + UPPER_MARGIN, poy, poy + phy, layerDepth);
+            t.Draw(batcher, x + pageX, y + UPPER_MARGIN, 0, poy, t.Width, phy, layerDepth);
+
+            if (pageIndex == _bookPage._caretPage
+                && _bookPage.HasKeyboardFocus
+                && _bookPage._caretPos.Y >= poy
+                && _bookPage._caretPos.Y < poy + phy)
+            {
+                _bookPage.renderedCaret.Draw(
+                    batcher,
+                    _bookPage._caretPos.X + x + pageX,
+                    _bookPage._caretPos.Y + y + UPPER_MARGIN - poy,
+                    0, 0,
+                    _bookPage.renderedCaret.Width,
+                    _bookPage.renderedCaret.Height,
+                    layerDepth
+                );
+            }
+        }
+
+        // Re-snap ActivePage to whichever page the caret is actually on. Called from
+        // _bookPage's input handlers (mouse click, key, text change) — never from the
+        // render path. If the caret didn't move into a different page, this is a no-op.
+        internal void RealignCaretAndActivePage()
+        {
+            if (_bookPage == null || IsDisposed)
+            {
+                return;
+            }
+
+            int newCaretPage = _bookPage.GetCaretPage();
+
+            if (newCaretPage != _bookPage._caretPage)
+            {
+                _bookPage._focusPage = _bookPage._caretPage;
+                _bookPage._caretPage = newCaretPage;
+            }
+
+            // Page-to-ActivePage mapping: page 0 is the right page of AP 1, then
+            // each subsequent ActivePage shows {left=odd, right=even} pairs.
+            //   page 0           → ActivePage 1
+            //   pages 1,2        → ActivePage 2
+            //   pages 3,4        → ActivePage 3
+            //   pages 2k-1, 2k   → ActivePage k+1
+            // So target = (page + 1) / 2 + 1 with integer division.
+            int targetActivePage = (newCaretPage + 1) / 2 + 1;
+            int maxActivePage = MaxPage;
+
+            if (targetActivePage != ActivePage
+                && targetActivePage >= 1
+                && targetActivePage <= maxActivePage)
+            {
+                SetActivePage(targetActivePage);
+            }
         }
 
         public override void Dispose()
@@ -619,8 +566,14 @@ namespace ClassicUO.Game.UI.Gumps
 
                     Stb.Click(x, y);
                     UpdateCaretScreenPosition();
-                    _caretPage = GetCaretPage();
+                    _gump.RealignCaretAndActivePage();
                 }
+            }
+
+            protected override void OnKeyDown(SDL.SDL_Keycode key, SDL.SDL_Keymod mod)
+            {
+                base.OnKeyDown(key, mod);
+                _gump.RealignCaretAndActivePage();
             }
 
             protected override void OnMouseOver(int x, int y)
@@ -855,6 +808,11 @@ namespace ClassicUO.Game.UI.Gumps
 
                 base.OnTextChanged(previousText);
                 _is_writing = false;
+
+                if (!_ServerUpdate)
+                {
+                    _gump.RealignCaretAndActivePage();
+                }
             }
 
             protected override void CloseWithRightClick()


### PR DESCRIPTION
## Summary

Three independent bugs in `ModernBookGump` text editing made editable books effectively unusable on `main`. All three are addressed here. Touches only `RenderedText.cs` and `ModernBookGump.cs`.

## Symptoms

- Clicking the body of any page jumped to the last 2-page spread of the book (e.g. page 19 of a 20-page book).
- Typing produced no visible character — the gump scrolled away from the caret before the next paint.
- Pressing Tab (or any key) while the book had keyboard focus also jumped to the last spread.
- After the click-to-last-page bug was fixed, clicking on a left-side page (1, 3, 5…) flipped one ActivePage backwards instead of staying put.

## Root causes

### 1. `RenderedText` layout-info uses `countret: false, countspaces: false`

The glyph-atlas refactor (`119108d37`) flipped these flags from `true, true` (as they had been forever pre-atlas) to `false, false` when the `Text` setter calls `Fonts.GetInfoUnicode/ASCII`. With `countret: false`, a `MultilinesFontInfo` node for a line that contains only `\n` reports `CharCount = 0`.

That breaks `Stb`'s hit-testing in `TextEdit.LocateCoord`:

```csharp
while (i < n) {
    r = Handler.LayoutRow(i);
    if (r.num_chars <= 0) return n;   // gives up — returns text length
    ...
}
```

Editable books pad their body to `BookPageCount × MAX_BOOK_LINES` newlines so the per-page coord math works. Every line is `\n`-only, so every line reports `CharCount = 0`, so `LocateCoord` returns `text.Length` for any click — which puts the caret on the last book page, and `RealignCaretAndActivePage` dutifully flips to `MaxPage`.

The atlas draw path (`DrawGlyphs`) explicitly skips `\n`/`\r` glyphs (`RenderedText.cs:580`), so re-including them in `CharCount` is free at draw time. **Fix: restore both flags to `true`.**

### 2. Render closure had destructive side effects

The `AddGumpNoAtlas` closure in `ModernBookGump.AddToRenderLists` mutated UI state every frame:

```csharp
_bookPage._caretPage = _bookPage.GetCaretPage();    // line 416
_bookPage._focusPage = _bookPage._caretPage++;       // line 423
SetActivePage(_bookPage._caretPage / 2 + 2);         // line 424
```

With the pre-atlas per-string-texture renderer, `_caretScreenPosition` and `_pageCoords` came from compatible code paths and rarely diverged, so the "caret past page bottom" branch self-corrected in one frame. After the atlas refactor, `Fonts.GetCaretPos*` and the line metrics walked by `UpdatePageCoords` can disagree by a pixel or two — enough to keep the spin condition true frame after frame, advancing `ActivePage` every paint until it hit `MaxPage`.

**Fix: make the render path pure.** All caret/page realignment moves into a new `RealignCaretAndActivePage()` helper, called only from input handlers (`OnMouseDown`, `OnKeyDown`, `OnTextChanged`). A transient pixel mismatch can no longer spin `SetActivePage` — if the caret really did cross a page boundary, exactly one realignment fires from the responsible input event.

The duplicated left/right page draw blocks were also extracted into `DrawBookPage(...)` for readability.

### 3. Off-by-one in page → ActivePage mapping

The realign was using `caretPage / 2 + 1`, which is correct only for even (right-side) book pages. For odd (left-side) pages it returned the previous spread:

| Caret on book page | Should land on ActivePage | `caretPage / 2 + 1` |
|---|---|---|
| 0 | 1 | 1 ✓ |
| 1 | 2 | 1 ✗ |
| 2 | 2 | 2 ✓ |
| 3 | 3 | 2 ✗ |
| 4 | 3 | 3 ✓ |

**Fix: `(caretPage + 1) / 2 + 1`** — gives the spread that actually contains each page.

## Why this didn't show up sooner

(1) requires an editable book whose body is mostly empty — a fresh book or one with sparse pages. (2) was latent since `dcd8d3fa8` (Oct 2025) when gump rendering moved to `RenderLists`, but pre-atlas the spin condition self-corrected in one frame so the symptom was invisible. (3) only surfaced once (1) was fixed enough that `GetCaretPage` started returning real page indices instead of always-19.

## Test plan

- [ ] Open a fresh editable book, 20 pages
- [ ] Click body of page 1 → caret lands at click, ActivePage stays at 1
- [ ] Type "hello" → characters appear at the caret
- [ ] Click body of page 3 (left page of ActivePage 2) → caret lands at click, ActivePage stays at 2
- [ ] Press Tab while focused on book body → no page change (Tab is a no-op since `_bookPage.Parent == null`)
- [ ] Type past the bottom of the right page → flips forward exactly one ActivePage
- [ ] Backspace past the top of the left page → flips backward exactly one ActivePage
- [ ] Sanity check: PropsGump cropped labels still render (`[props self`) — the cropping branch in `RenderedText.Text` runs before the `GetInfoUnicode` call this PR touches, so the text it hands to GetInfo is already truncated; behavior should be identical to PR #1888.

## Files

- `src/ClassicUO.Client/Game/GameObjects/RenderedText.cs` — restore `countret: true, countspaces: true` (the actual bug)
- `src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs` — pure render path, `RealignCaretAndActivePage()` helper called from input handlers, correct page → ActivePage formula

172/172 unit tests pass.
