### PR TITLE
Fix FastList<T>.Length overflow in FontsLoader wrap path

### DIFF
--- a/src/ClassicUO.Assets/FontsLoader.cs
+++ b/src/ClassicUO.Assets/FontsLoader.cs
@@ -876,7 +876,7 @@ namespace ClassicUO.Assets
                             ptr.MaxHeight = 14;
                         }
 
-                        ptr.Data.Length = ptr.CharCount - newlineval;
+                        ptr.Data.Resize(ptr.CharCount - newlineval);
 
                         MultilinesFontInfo newptr = new MultilinesFontInfo();
                         newptr.Reset();
@@ -979,7 +979,7 @@ namespace ClassicUO.Assets
 
                         //ptr.CharCount = charCount;
                         charCount = 0;
-                        ptr.Data.Length = ptr.CharCount;
+                        ptr.Data.Resize(ptr.CharCount);
 
                         if (isFixed || isCropped)
                         {
@@ -1445,7 +1445,7 @@ namespace ClassicUO.Assets
                             ptr.MaxHeight = 14 + extraheight;
                         }
 
-                        ptr.Data.Length = ptr.CharCount - newlineval;
+                        ptr.Data.Resize(ptr.CharCount - newlineval);
                         MultilinesFontInfo newptr = new MultilinesFontInfo();
                         newptr.Reset();
                         ptr.Next = newptr;
@@ -1553,7 +1553,7 @@ namespace ClassicUO.Assets
                         //ptr.CharCount = charCount;
 
                         charCount = 0;
-                        ptr.Data.Length = ptr.CharCount;
+                        ptr.Data.Resize(ptr.CharCount);
 
                         if (isFixed || isCropped)
                         {
@@ -2366,7 +2366,7 @@ namespace ClassicUO.Assets
                         }
 
                         ptr.MaxHeight = MAX_HTML_TEXT_HEIGHT;
-                        ptr.Data.Length = ptr.CharCount;
+                        ptr.Data.Resize(ptr.CharCount);
                         MultilinesFontInfo newptr = new MultilinesFontInfo();
                         newptr.Reset();
                         ptr.Next = newptr;
@@ -2464,7 +2464,7 @@ namespace ClassicUO.Assets
                         }
 
                         ptr.MaxHeight = MAX_HTML_TEXT_HEIGHT;
-                        ptr.Data.Length = ptr.CharCount;
+                        ptr.Data.Resize(ptr.CharCount);
                         charCount = 0;
 
                         if (isFixed || isCropped)

--- a/src/ClassicUO.Utility/Collections/FastList.cs
+++ b/src/ClassicUO.Utility/Collections/FastList.cs
@@ -63,6 +63,22 @@ namespace ClassicUO.Utility.Collections
 
 
         /// <summary>
+        /// Sets <see cref="Length"/> to <paramref name="newLength"/>, growing <see cref="Buffer"/> if needed
+        /// to preserve the invariant <c>Length &lt;= Buffer.Length</c>. Use this instead of writing to
+        /// <see cref="Length"/> directly when the new length may exceed the current buffer size.
+        /// </summary>
+        public void Resize(int newLength)
+        {
+            if (newLength > Buffer.Length)
+            {
+                Array.Resize(ref Buffer, Math.Max(Buffer.Length << 1, newLength));
+            }
+
+            Length = newLength;
+        }
+
+
+        /// <summary>
         /// adds the item to the list
         /// </summary>
         public void Add(T item)

--- a/tests/ClassicUO.UnitTests/Utility/Collections/FastListTests.cs
+++ b/tests/ClassicUO.UnitTests/Utility/Collections/FastListTests.cs
@@ -1,0 +1,194 @@
+using ClassicUO.Utility.Collections;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Utility.Collections
+{
+    public class FastListTests
+    {
+        [Fact]
+        public void DefaultCapacity_IsFive()
+        {
+            var list = new FastList<int>();
+
+            list.Length.Should().Be(0);
+            list.Buffer.Length.Should().Be(5);
+        }
+
+        [Fact]
+        public void Add_GrowsBufferWhenAtCapacity()
+        {
+            var list = new FastList<int>();
+            for (int i = 0; i < 5; i++)
+            {
+                list.Add(i);
+            }
+
+            // After exactly capacity items: Length == Buffer.Length, no growth yet.
+            list.Length.Should().Be(5);
+            list.Buffer.Length.Should().Be(5);
+
+            list.Add(5);
+
+            // Add #6 trips the resize.
+            list.Length.Should().Be(6);
+            list.Buffer.Length.Should().Be(10);
+            list.Buffer[5].Should().Be(5);
+        }
+
+        [Fact]
+        public void Resize_BelowCapacity_DoesNotGrowBuffer()
+        {
+            var list = new FastList<int>();
+            list.Add(1);
+            list.Add(2);
+            list.Add(3);
+
+            list.Resize(2);
+
+            list.Length.Should().Be(2);
+            list.Buffer.Length.Should().Be(5);
+            list.Buffer[0].Should().Be(1);
+            list.Buffer[1].Should().Be(2);
+        }
+
+        [Fact]
+        public void Resize_EqualToBufferLength_DoesNotGrowBuffer()
+        {
+            var list = new FastList<int>();
+
+            list.Resize(5);
+
+            list.Length.Should().Be(5);
+            list.Buffer.Length.Should().Be(5);
+        }
+
+        [Fact]
+        public void Resize_OnePastBufferLength_GrowsBuffer()
+        {
+            // Regression for FontsLoader bug: GetInfoASCII would set
+            // Data.Length = CharCount where CharCount could land one past
+            // the current Buffer.Length boundary (5, 10, 20, ...) when a
+            // long token wrapped and `countspaces` bumped CharCount past
+            // the natural Add-grown buffer size. Direct field assignment
+            // would leave Length > Buffer.Length and the rendering loop
+            // would IndexOutOfRange.
+            var list = new FastList<int>();
+            for (int i = 0; i < 5; i++)
+            {
+                list.Add(i);
+            }
+
+            list.Length.Should().Be(5);
+            list.Buffer.Length.Should().Be(5);
+
+            list.Resize(6);
+
+            list.Length.Should().Be(6);
+            list.Buffer.Length.Should().BeGreaterThanOrEqualTo(6);
+            list.Length.Should().BeLessThanOrEqualTo(list.Buffer.Length);
+        }
+
+        [Fact]
+        public void Resize_GrowsByDoubling()
+        {
+            var list = new FastList<int>();
+            for (int i = 0; i < 5; i++)
+            {
+                list.Add(i);
+            }
+
+            list.Resize(6);
+
+            // Math.Max(Buffer.Length << 1, newLength) = Math.Max(10, 6) = 10
+            list.Buffer.Length.Should().Be(10);
+        }
+
+        [Fact]
+        public void Resize_GrowsToNewLengthWhenLargerThanDoubled()
+        {
+            var list = new FastList<int>();
+
+            list.Resize(64);
+
+            // Math.Max(5 << 1, 64) = Math.Max(10, 64) = 64
+            list.Length.Should().Be(64);
+            list.Buffer.Length.Should().BeGreaterThanOrEqualTo(64);
+        }
+
+        [Fact]
+        public void Resize_PreservesExistingItemsBelowNewLength()
+        {
+            var list = new FastList<int>();
+            for (int i = 0; i < 5; i++)
+            {
+                list.Add(100 + i);
+            }
+
+            list.Resize(8);
+
+            list.Buffer[0].Should().Be(100);
+            list.Buffer[1].Should().Be(101);
+            list.Buffer[2].Should().Be(102);
+            list.Buffer[3].Should().Be(103);
+            list.Buffer[4].Should().Be(104);
+        }
+
+        [Fact]
+        public void Resize_GrownSlotsAreDefault()
+        {
+            var list = new FastList<int>();
+            list.Add(42);
+
+            list.Resize(8);
+
+            for (int i = 1; i < list.Length; i++)
+            {
+                list.Buffer[i].Should().Be(0);
+            }
+        }
+
+        [Fact]
+        public void Resize_AcrossMultipleBufferBoundaries_AlwaysHoldsInvariant()
+        {
+            // Walks the buffer-doubling boundaries (5 → 10 → 20 → 40 → 80 → 160)
+            // and verifies that Resize crossing each boundary keeps the
+            // FastList invariant: Length <= Buffer.Length.
+            var list = new FastList<int>();
+            int[] boundaries = { 5, 10, 20, 40, 80, 160, 320 };
+
+            foreach (int boundary in boundaries)
+            {
+                while (list.Length < boundary)
+                {
+                    list.Add(list.Length);
+                }
+
+                list.Resize(boundary + 1);
+
+                list.Length.Should().Be(boundary + 1);
+                list.Length.Should().BeLessThanOrEqualTo(
+                    list.Buffer.Length,
+                    "Resize across boundary {0} must keep Length <= Buffer.Length",
+                    boundary
+                );
+            }
+        }
+
+        [Fact]
+        public void Resize_ToZero_ClearsLengthOnly()
+        {
+            var list = new FastList<int>();
+            list.Add(1);
+            list.Add(2);
+            list.Add(3);
+
+            list.Resize(0);
+
+            list.Length.Should().Be(0);
+            list.Buffer.Length.Should().Be(5);
+            // Buffer contents are not zeroed by Resize-down (matches Reset semantics).
+            list.Buffer[0].Should().Be(1);
+        }
+    }
+}


### PR DESCRIPTION
FastList<T>.Length is a public mutable field; assigning to it does not grow Buffer. FontsLoader.GetInfoASCII / GetInfoUnicode / GetInfoHTML write `ptr.Data.Length = ptr.CharCount` after a `countspaces` synthetic increment in the long-token-then-space wrap path. When CharCount lands on the buffer's current capacity boundary (5, 10, 20, 40, ...), this sets Length one past Buffer.Length. Downstream consumers that iterate `for (i; i < Data.Length; i++) Data.Buffer[i]` would IndexOutOfRange.

Add FastList<T>.Resize(int) that grows Buffer (using the same doubling rule as Add/EnsureCapacity) before setting Length, and route the six unsafe assignments in FontsLoader through it (newline + Path B branches across ASCII/Unicode/HTML).

Repro: GetInfoASCII(font, new string('a', 80) + " tail", ..., width: 50, countret: false, countspaces: true) violates the FastList invariant without the fix.

Tests: Adds FastListTests covering Resize semantics, including a boundary regression that walks 5 → 10 → 20 → 40 → 80 → 160 and verifies Length <= Buffer.Length is preserved across each grow.