### PR TITLE
Remove PlatformTarget from project file

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>cuo</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
     <PublishAot>true</PublishAot>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
Removing x64 from the client unlocks osx/linux arm64 support. This works in conjunction with two other changes, removing net40 from MP3Sharp, and building an additional Bootsrap application that supports native .NET 10+