### PR TITLE
Replace _webLinks dict with per-parse URLs and visited LRU

### DIFF
--- a/src/ClassicUO.Assets/ClassicUO.Assets.csproj
+++ b/src/ClassicUO.Assets/ClassicUO.Assets.csproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="..\ClassicUO.Utility\ClassicUO.Utility.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ClassicUO.UnitTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/ClassicUO.Assets/FontsLoader.cs
+++ b/src/ClassicUO.Assets/FontsLoader.cs
@@ -74,7 +74,7 @@ namespace ClassicUO.Assets
         private FontCharacterDataUnicode[,] _fontDataUNICODE;
         private readonly UOFile[] _unicodeFontAddress = new UOFile[20];
         private readonly long[] _unicodeFontSize = new long[20];
-        private readonly Dictionary<ushort, WebLink> _webLinks = new Dictionary<ushort, WebLink>();
+        private readonly VisitedUrlCache _visitedUrls = new VisitedUrlCache(1024);
         private readonly int[] _offsetCharTable = { 2, 0, 2, 2, 0, 0, 2, 2, 0, 0 };
         private readonly int[] _offsetSymbolTable = { 1, 0, 1, 1, -1, 0, 1, 1, 0, 0 };
 
@@ -556,7 +556,7 @@ namespace ClassicUO.Assets
                 {
                     HTMLChar* chars = stackalloc HTMLChar[strLen];
 
-                    GetHTMLData(chars, font, str.AsSpan(), ref strLen, align, flags);
+                    GetHTMLData(chars, font, str.AsSpan(), ref strLen, align, flags, urls: null);
                 }
 
                 int size = str.Length - strLen;
@@ -1193,7 +1193,7 @@ namespace ClassicUO.Assets
                 {
                     HTMLChar* data = stackalloc HTMLChar[strLen];
 
-                    GetHTMLData(data, font, str, ref strLen, align, flags);
+                    GetHTMLData(data, font, str, ref strLen, align, flags, urls: null);
                 }
 
                 int size = str.Length - strLen;
@@ -1793,6 +1793,11 @@ namespace ClassicUO.Assets
                 int linesCount = 0;
                 using var links = new PooledList<WebLinkRect>(8);
 
+                // Captured before the walk because `info` is reassigned to
+                // each segment as we iterate. The head node carries the
+                // per-parse URL list; LinkID values index into it (1-based).
+                List<string> urls = info.WebLinks;
+
                 while (ptr != null)
                 {
                     info = ptr;
@@ -1878,7 +1883,7 @@ namespace ClassicUO.Assets
 
                             WebLinkRect wlr = new WebLinkRect
                             {
-                                LinkID = oldLink,
+                                Url = urls[oldLink - 1],
                                 Bounds = new Margin(linkStartX, linkStartY, w - ofsX, linkHeight)
                             };
 
@@ -2319,7 +2324,13 @@ namespace ClassicUO.Assets
 
             HTMLChar* htmlData = stackalloc HTMLChar[len];
 
-            GetHTMLData(htmlData, font, str.AsSpan(), ref len, align, flags);
+            // Per-parse URL accumulator. The 1-based index assigned to each
+            // <a href> becomes the MultilinesFontData.LinkID for chars under
+            // that tag. Attached to the head MultilinesFontInfo on return so
+            // the renderer can look up URLs when emitting WebLinkRect entries.
+            List<string> urls = new List<string>();
+
+            GetHTMLData(htmlData, font, str.AsSpan(), ref len, align, flags, urls);
 
             if (len <= 0)
             {
@@ -2329,6 +2340,7 @@ namespace ClassicUO.Assets
             MultilinesFontInfo info = new MultilinesFontInfo();
             info.Reset();
             info.Align = align;
+            info.WebLinks = urls;
             MultilinesFontInfo ptr = info;
             int indentionOffset = 0;
             ptr.IndentionOffset = indentionOffset;
@@ -2557,7 +2569,8 @@ namespace ClassicUO.Assets
             ReadOnlySpan<char> str,
             ref int len,
             TEXT_ALIGN_TYPE align,
-            ushort flags
+            ushort flags,
+            List<string> urls
         )
         {
             int newlen = 0;
@@ -2594,7 +2607,7 @@ namespace ClassicUO.Assets
                         Link = 0
                     };
 
-                    HTML_TAG_TYPE tag = ParseHTMLTag(str, len, ref i, ref endTag, ref newInfo);
+                    HTML_TAG_TYPE tag = ParseHTMLTag(str, len, ref i, ref endTag, ref newInfo, urls);
 
                     if (tag == HTML_TAG_TYPE.HTT_NONE)
                     {
@@ -2809,7 +2822,8 @@ namespace ClassicUO.Assets
             int len,
             ref int i,
             ref bool endTag,
-            ref HTMLDataInfo info
+            ref HTMLDataInfo info,
+            List<string> urls
         )
         {
             HTML_TAG_TYPE tag = HTML_TAG_TYPE.HTT_NONE;
@@ -3015,7 +3029,7 @@ namespace ClassicUO.Assets
 
                                 if (str.Length != 0 && cmdLen >= 0 && str.Length > j && str.Length >= cmdLen)
                                 {
-                                    GetHTMLInfoFromContent(ref info, str.Slice(j, cmdLen));
+                                    GetHTMLInfoFromContent(ref info, str.Slice(j, cmdLen), urls);
                                 }
 
                                 break;
@@ -3027,7 +3041,7 @@ namespace ClassicUO.Assets
             return tag;
         }
 
-        private void GetHTMLInfoFromContent(ref HTMLDataInfo info, ReadOnlySpan<char> content)
+        private void GetHTMLInfoFromContent(ref HTMLDataInfo info, ReadOnlySpan<char> content, List<string> urls)
         {
             if (content.IsEmpty)
                 return;
@@ -3113,38 +3127,38 @@ namespace ClassicUO.Assets
                     case HTML_TAG_TYPE.HTT_BODY:
                     case HTML_TAG_TYPE.HTT_BODYBGCOLOR:
 
-                        if (MemoryExtensions.Equals(command, "text", StringComparison.InvariantCultureIgnoreCase))
+                        if (command.Equals("text", StringComparison.InvariantCultureIgnoreCase))
                         {
                             ReadColorFromTextBuffer(value, ref info.Color);
                         }
-                        else if (MemoryExtensions.Equals(command, "bgcolor", StringComparison.InvariantCultureIgnoreCase))
+                        else if (command.Equals("bgcolor", StringComparison.InvariantCultureIgnoreCase))
                         {
                             if (_htmlStatus.IsHtmlBackgroundColored)
                             {
                                 ReadColorFromTextBuffer(value, ref _htmlStatus.BackgroundColor);
                             }
                         }
-                        else if (MemoryExtensions.Equals(command, "link", StringComparison.InvariantCultureIgnoreCase))
+                        else if (command.Equals("link", StringComparison.InvariantCultureIgnoreCase))
                         {
                             ReadColorFromTextBuffer(value, ref _htmlStatus.WebLinkColor);
                         }
-                        else if (MemoryExtensions.Equals(command, "vlink", StringComparison.InvariantCultureIgnoreCase))
+                        else if (command.Equals("vlink", StringComparison.InvariantCultureIgnoreCase))
                         {
                             ReadColorFromTextBuffer(value, ref _htmlStatus.VisitedWebLinkColor);
                         }
-                        else if (MemoryExtensions.Equals(command, "leftmargin", StringComparison.InvariantCultureIgnoreCase))
+                        else if (command.Equals("leftmargin", StringComparison.InvariantCultureIgnoreCase))
                         {
                             _htmlStatus.Margins.X = int.Parse(value);
                         }
-                        else if (MemoryExtensions.Equals(command, "topmargin", StringComparison.InvariantCultureIgnoreCase))
+                        else if (command.Equals("topmargin", StringComparison.InvariantCultureIgnoreCase))
                         {
                             _htmlStatus.Margins.Y = int.Parse(value);
                         }
-                        else if (MemoryExtensions.Equals(command, "rightmargin", StringComparison.InvariantCultureIgnoreCase))
+                        else if (command.Equals("rightmargin", StringComparison.InvariantCultureIgnoreCase))
                         {
                             _htmlStatus.Margins.Width = int.Parse(value);
                         }
-                        else if (MemoryExtensions.Equals(command, "bottommargin", StringComparison.InvariantCultureIgnoreCase))
+                        else if (command.Equals("bottommargin", StringComparison.InvariantCultureIgnoreCase))
                         {
                             _htmlStatus.Margins.Height = int.Parse(value);
                         }
@@ -3153,17 +3167,17 @@ namespace ClassicUO.Assets
 
                     case HTML_TAG_TYPE.HTT_BASEFONT:
 
-                        if (MemoryExtensions.Equals(command, "color", StringComparison.InvariantCultureIgnoreCase))
+                        if (command.Equals("color", StringComparison.InvariantCultureIgnoreCase))
                         {
                             ReadColorFromTextBuffer(value, ref info.Color);
                         }
-                        else if (MemoryExtensions.Equals(command, "size", StringComparison.InvariantCultureIgnoreCase))
+                        else if (command.Equals("size", StringComparison.InvariantCultureIgnoreCase))
                         {
                             if (!byte.TryParse(value, out var font))
                             {
-                                if (MemoryExtensions.Equals(value, "big", StringComparison.InvariantCultureIgnoreCase))
+                                if (value.Equals("big", StringComparison.InvariantCultureIgnoreCase))
                                     info.Font = 4;
-                                else if (MemoryExtensions.Equals(value, "small", StringComparison.InvariantCultureIgnoreCase))
+                                else if (value.Equals("small", StringComparison.InvariantCultureIgnoreCase))
                                     info.Font = 0;
                                 else
                                     info.Font = 1;
@@ -3192,11 +3206,11 @@ namespace ClassicUO.Assets
 
                     case HTML_TAG_TYPE.HTT_A:
 
-                        if (MemoryExtensions.Equals(command, "href", StringComparison.InvariantCultureIgnoreCase))
+                        if (command.Equals("href", StringComparison.InvariantCultureIgnoreCase))
                         {
                             info.Flags = UOFONT_UNDERLINE;
                             info.Color = _htmlStatus.WebLinkColor;
-                            info.Link = GetWebLinkID(value, ref info.Color);
+                            info.Link = RegisterParseUrl(urls, value, ref info.Color);
                         }
 
                         break;
@@ -3204,17 +3218,17 @@ namespace ClassicUO.Assets
                     case HTML_TAG_TYPE.HTT_P:
                     case HTML_TAG_TYPE.HTT_DIV:
 
-                        if (MemoryExtensions.Equals(command, "align", StringComparison.InvariantCultureIgnoreCase))
+                        if (command.Equals("align", StringComparison.InvariantCultureIgnoreCase))
                         {
-                            if (MemoryExtensions.Equals(value, "left", StringComparison.InvariantCultureIgnoreCase))
+                            if (value.Equals("left", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 info.Align = TEXT_ALIGN_TYPE.TS_LEFT;
                             }
-                            else if (MemoryExtensions.Equals(value, "center", StringComparison.InvariantCultureIgnoreCase))
+                            else if (value.Equals("center", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 info.Align = TEXT_ALIGN_TYPE.TS_CENTER;
                             }
-                            else if (MemoryExtensions.Equals(value, "right", StringComparison.InvariantCultureIgnoreCase))
+                            else if (value.Equals("right", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 info.Align = TEXT_ALIGN_TYPE.TS_RIGHT;
                             }
@@ -3228,45 +3242,47 @@ namespace ClassicUO.Assets
             }
         }
 
-        private ushort GetWebLinkID(ReadOnlySpan<char> link, ref uint color)
+        // Append `link` to the parse-scoped URL list and return its 1-based
+        // index (used as MultilinesFontData.LinkID). If the URL has been
+        // visited in a prior parse, swap `color` to the visited color. The
+        // urls list dies with the FontInfo it's attached to — no global state.
+        // urls == null means "throwaway parse" (cropping/measurement); skip
+        // accumulation entirely.
+        private ushort RegisterParseUrl(List<string> urls, ReadOnlySpan<char> link, ref uint color)
         {
-            foreach (KeyValuePair<ushort, WebLink> ll in _webLinks)
+            if (urls == null)
             {
-                if (link.SequenceEqual(ll.Value.Link))
-                {
-                    if (ll.Value.IsVisited)
-                    {
-                        color = _htmlStatus.VisitedWebLinkColor;
-                    }
-
-                    return ll.Key;
-                }
+                return 0;
             }
 
-            ushort linkID = (ushort)(_webLinks.Count + 1);
+            string url = link.ToString();
 
-            if (!_webLinks.TryGetValue(linkID, out WebLink webLink))
+            if (_visitedUrls.IsVisited(url))
             {
-                webLink = new WebLink();
-                webLink.IsVisited = false;
-                webLink.Link = link.ToString();
-
-                _webLinks[linkID] = webLink;
+                color = _htmlStatus.VisitedWebLinkColor;
             }
 
-            return linkID;
+            // ushort cap: refuse to register past 65 535 anchor tags in a single
+            // parse — return 0 ("no link"). The text still renders styled but
+            // is non-clickable. In practice no real HTML chunk hits this.
+            if (urls.Count >= ushort.MaxValue)
+            {
+                return 0;
+            }
+
+            urls.Add(url);
+            return (ushort)urls.Count;
         }
 
-        public bool GetWebLink(ushort link, out WebLink result)
+        // Called by click handlers to record that a URL has been opened, so
+        // subsequent renders draw it in the visited color. Bounded by the
+        // VisitedUrlCache's LRU capacity.
+        public void MarkVisited(string url)
         {
-            if (!_webLinks.TryGetValue(link, out result))
+            if (!string.IsNullOrEmpty(url))
             {
-                return false;
+                _visitedUrls.Mark(url);
             }
-
-            result.IsVisited = true;
-
-            return true;
         }
 
         private unsafe void ReadColorFromTextBuffer(ReadOnlySpan<char> buffer, ref uint color)
@@ -3300,76 +3316,76 @@ namespace ClassicUO.Assets
                 }
                 else
                 {
-                    if (MemoryExtensions.Equals(buffer, "red", StringComparison.InvariantCultureIgnoreCase))
+                    if (buffer.Equals("red", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x0000FFFF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "cyan", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("cyan", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0xFFFF00FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "blue", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("blue", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0xFF0000FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "darkblue", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("darkblue", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0xA00000FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "lightblue", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("lightblue", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0xE6D8ADFF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "purple", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("purple", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x800080FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "yellow", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("yellow", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x00FFFFFF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "lime", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("lime", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x00FF00FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "magenta", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("magenta", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0xFF00FFFF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "white", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("white", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0xFFFEFEFF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "silver", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("silver", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0xC0C0C0FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "grey", StringComparison.InvariantCultureIgnoreCase) ||
-                             MemoryExtensions.Equals(buffer, "gray", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("grey", StringComparison.InvariantCultureIgnoreCase) ||
+                             buffer.Equals("gray", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x808080FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "black", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("black", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x010101FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "orange", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("orange", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x00A5FFFF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "brown", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("brown", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x2A2AA5FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "maroon", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("maroon", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x000080FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "green", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("green", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x008000FF;
                     }
-                    else if (MemoryExtensions.Equals(buffer, "olive", StringComparison.InvariantCultureIgnoreCase))
+                    else if (buffer.Equals("olive", StringComparison.InvariantCultureIgnoreCase))
                     {
                         color = 0x008080FF;
                     }
@@ -4099,6 +4115,12 @@ namespace ClassicUO.Assets
         public MultilinesFontInfo Next;
         public int Width;
 
+        // Set on the head node only by GetInfoHTML — the per-parse list of
+        // URLs collected from <a href> tags. MultilinesFontData.LinkID is a
+        // 1-based index into this list (0 means "no link"). Lifetime: dies
+        // with the FontInfo it belongs to.
+        public List<string> WebLinks;
+
         public void Reset()
         {
             Width = 0;
@@ -4108,6 +4130,7 @@ namespace ClassicUO.Assets
             CharCount = 0;
             Align = TEXT_ALIGN_TYPE.TS_LEFT;
             Next = null;
+            WebLinks = null;
         }
     }
 
@@ -4132,14 +4155,8 @@ namespace ClassicUO.Assets
 
     public struct WebLinkRect
     {
-        public ushort LinkID;
+        public string Url;
         public FontsLoader.Margin Bounds;
-    }
-
-    public class WebLink
-    {
-        public bool IsVisited;
-        public string Link;
     }
 
     public struct HTMLChar

--- a/src/ClassicUO.Assets/VisitedUrlCache.cs
+++ b/src/ClassicUO.Assets/VisitedUrlCache.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+using System.Collections.Generic;
+
+namespace ClassicUO.Assets
+{
+    // Bounded LRU of visited URLs. Replaces the unbounded
+    // Dictionary<ushort, WebLink> that previously coupled compact-id encoding
+    // to visited-state tracking. Intrusive doubly-linked list — the Node *is*
+    // the entry, no LinkedListNode<T> wrapper.
+    internal sealed class VisitedUrlCache
+    {
+        private sealed class Node
+        {
+            public string Url;
+            public Node Prev;
+            public Node Next;
+        }
+
+        private readonly int _capacity;
+        private readonly Dictionary<string, Node> _map;
+        private Node _head; // most recent
+        private Node _tail; // least recent
+
+        public VisitedUrlCache(int capacity)
+        {
+            _capacity = capacity;
+            _map = new Dictionary<string, Node>(capacity);
+        }
+
+        // Exposed for tests and diagnostics.
+        public int Count => _map.Count;
+
+        public bool IsVisited(string url)
+        {
+            if (!_map.TryGetValue(url, out Node node))
+            {
+                return false;
+            }
+
+            MoveToFront(node);
+            return true;
+        }
+
+        public void Mark(string url)
+        {
+            if (_map.TryGetValue(url, out Node node))
+            {
+                MoveToFront(node);
+                return;
+            }
+
+            if (_map.Count >= _capacity)
+            {
+                Node evict = _tail;
+                _tail = evict.Prev;
+
+                if (_tail != null)
+                {
+                    _tail.Next = null;
+                }
+                else
+                {
+                    _head = null;
+                }
+
+                _map.Remove(evict.Url);
+            }
+
+            node = new Node { Url = url, Next = _head };
+
+            if (_head != null)
+            {
+                _head.Prev = node;
+            }
+
+            _head = node;
+            _tail ??= node;
+            _map[url] = node;
+        }
+
+        private void MoveToFront(Node node)
+        {
+            if (node == _head)
+            {
+                return;
+            }
+
+            // Detach: node.Prev is non-null since node != _head.
+            node.Prev.Next = node.Next;
+
+            if (node.Next != null)
+            {
+                node.Next.Prev = node.Prev;
+            }
+            else
+            {
+                _tail = node.Prev;
+            }
+
+            // Insert at head.
+            node.Prev = null;
+            node.Next = _head;
+            _head.Prev = node;
+            _head = node;
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/Controls/HtmlControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/HtmlControl.cs
@@ -272,11 +272,12 @@ namespace ClassicUO.Game.UI.Controls
 
                         bool inbounds = link.Bounds.Contains(x, (_scrollBar == null ? 0 : _scrollBar.Value) + y);
 
-                        if (inbounds && Client.Game.UO.FileManager.Fonts.GetWebLink(link.LinkID, out WebLink result))
+                        if (inbounds && !string.IsNullOrEmpty(link.Url))
                         {
-                            Log.Info("LINK CLICKED: " + result.Link);
+                            Log.Info("LINK CLICKED: " + link.Url);
 
-                            PlatformHelper.LaunchBrowser(result.Link);
+                            Client.Game.UO.FileManager.Fonts.MarkVisited(link.Url);
+                            PlatformHelper.LaunchBrowser(link.Url);
 
                             _gameText.CreateTexture();
 

--- a/tests/ClassicUO.UnitTests/Assets/VisitedUrlCacheTests.cs
+++ b/tests/ClassicUO.UnitTests/Assets/VisitedUrlCacheTests.cs
@@ -1,0 +1,240 @@
+using ClassicUO.Assets;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Assets
+{
+    public class VisitedUrlCacheTests
+    {
+        [Fact]
+        public void When_Empty_IsVisited_Returns_False()
+        {
+            var cache = new VisitedUrlCache(8);
+
+            cache.IsVisited("https://example.com").Should().BeFalse();
+            cache.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void When_Marked_IsVisited_Returns_True()
+        {
+            var cache = new VisitedUrlCache(8);
+
+            cache.Mark("https://example.com");
+
+            cache.IsVisited("https://example.com").Should().BeTrue();
+            cache.Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void When_Marked_Twice_Same_Url_No_Duplicate_Stored()
+        {
+            var cache = new VisitedUrlCache(8);
+
+            cache.Mark("https://example.com");
+            cache.Mark("https://example.com");
+
+            cache.Count.Should().Be(1);
+            cache.IsVisited("https://example.com").Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_Different_Urls_Marked_Both_Visible()
+        {
+            var cache = new VisitedUrlCache(8);
+
+            cache.Mark("https://a.com");
+            cache.Mark("https://b.com");
+
+            cache.IsVisited("https://a.com").Should().BeTrue();
+            cache.IsVisited("https://b.com").Should().BeTrue();
+            cache.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void When_Capacity_Exceeded_Oldest_Evicted()
+        {
+            // Capacity 3, mark 4 distinct URLs in order. The first one (oldest)
+            // should be evicted; the rest remain.
+            var cache = new VisitedUrlCache(3);
+
+            cache.Mark("a");
+            cache.Mark("b");
+            cache.Mark("c");
+            cache.Mark("d");
+
+            cache.Count.Should().Be(3);
+            cache.IsVisited("a").Should().BeFalse();
+            cache.IsVisited("b").Should().BeTrue();
+            cache.IsVisited("c").Should().BeTrue();
+            cache.IsVisited("d").Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_Marking_Existing_Url_Bumps_To_Front()
+        {
+            // After Mark a/b/c, "a" is the LRU. Re-marking "a" promotes it; the
+            // next eviction takes "b" instead.
+            var cache = new VisitedUrlCache(3);
+
+            cache.Mark("a");
+            cache.Mark("b");
+            cache.Mark("c");
+            cache.Mark("a"); // re-mark — should bump "a" to MRU
+            cache.Mark("d"); // evicts the new LRU, which is "b"
+
+            cache.IsVisited("a").Should().BeTrue();
+            cache.IsVisited("b").Should().BeFalse();
+            cache.IsVisited("c").Should().BeTrue();
+            cache.IsVisited("d").Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_IsVisited_Hits_Touches_Lru()
+        {
+            // IsVisited must promote the matched entry — otherwise frequently
+            // displayed visited URLs that are never re-clicked would silently
+            // age out and revert to the unvisited color.
+            var cache = new VisitedUrlCache(3);
+
+            cache.Mark("a");
+            cache.Mark("b");
+            cache.Mark("c");
+
+            // Touch "a" via IsVisited; this should make it MRU.
+            cache.IsVisited("a").Should().BeTrue();
+
+            // Adding a 4th URL evicts the LRU, which should now be "b".
+            cache.Mark("d");
+
+            cache.IsVisited("a").Should().BeTrue();
+            cache.IsVisited("b").Should().BeFalse();
+            cache.IsVisited("c").Should().BeTrue();
+            cache.IsVisited("d").Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_IsVisited_Misses_No_State_Mutation()
+        {
+            var cache = new VisitedUrlCache(3);
+
+            cache.Mark("a");
+            cache.Mark("b");
+            cache.Mark("c");
+
+            cache.IsVisited("nonexistent").Should().BeFalse();
+            cache.Count.Should().Be(3);
+
+            // The miss must not have promoted anything or evicted anything;
+            // adding a 4th URL still evicts "a" (the original LRU).
+            cache.Mark("d");
+
+            cache.IsVisited("a").Should().BeFalse();
+            cache.IsVisited("b").Should().BeTrue();
+            cache.IsVisited("c").Should().BeTrue();
+            cache.IsVisited("d").Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_Capacity_One_Single_Slot_Replaced()
+        {
+            var cache = new VisitedUrlCache(1);
+
+            cache.Mark("a");
+            cache.IsVisited("a").Should().BeTrue();
+
+            cache.Mark("b");
+            cache.Count.Should().Be(1);
+            cache.IsVisited("a").Should().BeFalse();
+            cache.IsVisited("b").Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_Many_Marks_Cap_Strictly_Respected()
+        {
+            const int capacity = 16;
+            var cache = new VisitedUrlCache(capacity);
+
+            for (int i = 0; i < 1000; i++)
+            {
+                cache.Mark("url-" + i);
+                cache.Count.Should().BeLessThanOrEqualTo(capacity);
+            }
+
+            cache.Count.Should().Be(capacity);
+
+            // The last `capacity` URLs should be the survivors.
+            for (int i = 0; i < 1000 - capacity; i++)
+            {
+                cache.IsVisited("url-" + i).Should().BeFalse();
+            }
+
+            for (int i = 1000 - capacity; i < 1000; i++)
+            {
+                cache.IsVisited("url-" + i).Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void When_Refilled_After_Eviction_Order_Preserved()
+        {
+            // Evict, refill — the LRU pointer must still be sane.
+            var cache = new VisitedUrlCache(2);
+
+            cache.Mark("a");
+            cache.Mark("b");
+            cache.Mark("c"); // evicts "a"; head=c, tail=b
+            cache.Mark("d"); // evicts "b"; head=d, tail=c
+
+            cache.IsVisited("a").Should().BeFalse();
+            cache.IsVisited("b").Should().BeFalse();
+            cache.IsVisited("c").Should().BeTrue();
+            cache.IsVisited("d").Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_Marking_Tail_Then_Adding_New_Tail_Updated()
+        {
+            // Regression guard for the tail-pointer rewiring path: marking the
+            // current tail must move it to head so that the *next* eviction
+            // takes the new tail (formerly second-to-tail), not the URL we
+            // just promoted.
+            var cache = new VisitedUrlCache(3);
+
+            cache.Mark("a"); // head=a, tail=a
+            cache.Mark("b"); // head=b, tail=a
+            cache.Mark("c"); // head=c, tail=a
+            cache.Mark("a"); // promote tail; head=a, tail=b
+
+            cache.Mark("d"); // evicts the new tail "b"
+
+            cache.IsVisited("a").Should().BeTrue();
+            cache.IsVisited("b").Should().BeFalse();
+            cache.IsVisited("c").Should().BeTrue();
+            cache.IsVisited("d").Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_Marking_Head_Mark_Is_Idempotent()
+        {
+            // Re-marking the current head must not corrupt links — head stays
+            // head, tail stays tail.
+            var cache = new VisitedUrlCache(3);
+
+            cache.Mark("a");
+            cache.Mark("b");
+            cache.Mark("c"); // head=c, tail=a
+
+            cache.Mark("c"); // head=c, tail=a (unchanged)
+
+            cache.Count.Should().Be(3);
+
+            cache.Mark("d"); // should evict tail "a"
+
+            cache.IsVisited("a").Should().BeFalse();
+            cache.IsVisited("b").Should().BeTrue();
+            cache.IsVisited("c").Should().BeTrue();
+            cache.IsVisited("d").Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
The Dictionary<ushort, WebLink> on FontsLoader conflated two responsibilities: encoding URLs as compact ushort tokens for the renderer, and storing visited-state across renders. Because FontsLoader lives the whole session and the dictionary was never trimmed, every distinct URL ever parsed accumulated forever — a slow but unbounded leak. Capping the dict by Clear() would have rotated existing LinkIDs onto new URLs and silently misrouted clicks in already-rendered HTML.

Split the responsibilities:

- The compact LinkID is now a per-parse identifier. GetInfoHTML allocates a List<string> and threads it through GetHTMLData → ParseHTMLTag → GetHTMLInfoFromContent; each <a href> appends to the list and uses its 1-based count as the LinkID. The list is attached to the head MultilinesFontInfo and dies with the FontInfo that consumes it. Callers performing throwaway parses (text cropping/measurement) pass null.

- WebLinkRect now carries the URL string directly, so HtmlControl reads link.Url at click time without a global lookup. The GetWebLinkID and GetWebLink methods are removed; the WebLink class is removed.

- Visited-state moves to a bounded LRU (VisitedUrlCache, capacity 1024) built on an intrusive doubly-linked list — Mark/IsVisited are O(1) and IsVisited promotes on hit so frequently-displayed visited URLs survive. Eviction loses only the visited color (cosmetic), never click routing. Exposed via Fonts.MarkVisited(string), called by HtmlControl.OnMouseUp.

VisitedUrlCache is in its own file as internal sealed; ClassicUO.Assets now exposes internals to ClassicUO.UnitTests so it can be unit-tested.

Adds VisitedUrlCacheTests covering: empty/round-trip, idempotent re-mark, LRU eviction order, IsVisited touches LRU, capacity-1 boundary, 1000 inserts at cap=16, head/tail re-mark pointer hygiene, miss-is-read-only. 13 new tests, 185 total passing.