### PR TITLE
Add Z coordinate support to GET_COORDS in UoAssist.cs

### DIFF
--- a/src/ClassicUO.Client/Game/UoAssist.cs
+++ b/src/ClassicUO.Client/Game/UoAssist.cs
@@ -262,6 +262,11 @@ namespace ClassicUO.Utility.Platforms
 
                         if (_world.Player != null)
                         {
+                            if (wParam == 1)
+                            {
+                                return _world.Player.Z;
+                            }
+
                             return (_world.Player.X & 0xFFFF) | ((_world.Player.Y & 0xFFFF) << 16);
                         }
 


### PR DESCRIPTION
Add Z coordinate support to GET_COORDS in UoAssist.cs, allowing third-party tools to get player's current Z coordinate (as seen by client) by passing wParam = 1 along with the request. Returns packed X/Y coords as before when wParam is passed with default value of 0.