### PR TITLE
Add 3-pixel forgiveness to backpack ItemGump pixel-pick

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/ItemGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ItemGump.cs
@@ -210,7 +210,10 @@ namespace ClassicUO.Game.UI.Controls
             }
             else
             {
-                if (Client.Game.UO.Arts.PixelCheck(Graphic, x, y))
+                // 3-pixel forgiveness radius so items with sparse opaque pixels (robes, hats,
+                // small icons) are still clickable when the click lands a couple of pixels
+                // off the visible content.
+                if (Client.Game.UO.Arts.PixelCheck(Graphic, x, y, extraRange: 3))
                 {
                     return true;
                 }
@@ -219,7 +222,7 @@ namespace ClassicUO.Game.UI.Controls
 
                 if (item != null && !item.IsCoin && item.Amount > 1 && item.ItemData.IsStackable)
                 {
-                    if (Client.Game.UO.Arts.PixelCheck(Graphic, x - 5, y - 5))
+                    if (Client.Game.UO.Arts.PixelCheck(Graphic, x - 5, y - 5, extraRange: 3))
                     {
                         return true;
                     }

--- a/src/ClassicUO.Renderer/Arts/Art.cs
+++ b/src/ClassicUO.Renderer/Arts/Art.cs
@@ -216,6 +216,6 @@ namespace ClassicUO.Renderer.Arts
                 ? Rectangle.Empty
                 : _realArtBounds[idx];
 
-        public bool PixelCheck(uint idx, int x, int y) => _picker.Get(idx, x, y);
+        public bool PixelCheck(uint idx, int x, int y, int extraRange = 0) => _picker.Get(idx, x, y, extraRange);
     }
 }


### PR DESCRIPTION
some items, like gm robes, dupre/lord british etc items, are currently not pickable when on the ground/in the backpack. this should address that.