### PR TITLE
Replace static layer tables with graphic-driven paperdoll order

### DIFF
--- a/src/ClassicUO.Client/Game/Data/PaperdollOrder.cs
+++ b/src/ClassicUO.Client/Game/Data/PaperdollOrder.cs
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// =============================================================================
+//  PaperdollOrder.cs
+//  Builds the paperdoll / in-world equipment layer draw-order used by the UO
+//  Classic Client.
+//
+//  No coverage masks / no "hide" pass. Pure painter's algorithm:
+//    1. Copy one of THREE base order tables (chosen by body/arms/torso graphic).
+//    2. Apply per-graphic reorder rules (swap / move-to / move-after) keyed on
+//       specific equipped item graphics.
+//    3. Draw each layer's gump in that order — later index = painted on top.
+//
+//  The tables drive both the paperdoll gump and the in-world views. Base table T2
+//  is the default order and matches the old paperdoll _layerOrder; the
+//  Cloak->after->Robe rule (graphic 0x380/0x5F3) matches the old
+//  _layerOrder_quiver_fix.
+// =============================================================================
+
+using System;
+using ClassicUO.Game.GameObjects;
+
+namespace ClassicUO.Game.Data
+{
+    internal static class PaperdollOrder
+    {
+        // --- base tables, 25 layers each (leading Invalid is a sentinel) ---------
+        // T1: arms drawn late
+        private static readonly Layer[] T1 =
+        {
+            Layer.Invalid, Layer.Cloak, Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs,
+            Layer.Torso, Layer.Tunic, Layer.Ring, Layer.Bracelet, Layer.Face, Layer.Arms,
+            Layer.Gloves, Layer.Skirt, Layer.Robe, Layer.Waist, Layer.Necklace, Layer.Hair,
+            Layer.Beard, Layer.Earrings, Layer.Helmet, Layer.OneHanded, Layer.TwoHanded,
+            Layer.Backpack, Layer.Talisman
+        };
+
+        // T2: DEFAULT — arms early (matches the old _layerOrder)
+        private static readonly Layer[] T2 =
+        {
+            Layer.Invalid, Layer.Cloak, Layer.Shirt, Layer.Pants, Layer.Shoes, Layer.Legs,
+            Layer.Arms, Layer.Torso, Layer.Tunic, Layer.Ring, Layer.Bracelet, Layer.Face,
+            Layer.Gloves, Layer.Skirt, Layer.Robe, Layer.Waist, Layer.Necklace, Layer.Hair,
+            Layer.Beard, Layer.Earrings, Layer.Helmet, Layer.OneHanded, Layer.TwoHanded,
+            Layer.Backpack, Layer.Talisman
+        };
+
+        // T3: torso pulled to front (female-style chest-under)
+        private static readonly Layer[] T3 =
+        {
+            Layer.Invalid, Layer.Cloak, Layer.Torso, Layer.Shirt, Layer.Pants, Layer.Shoes,
+            Layer.Legs, Layer.Tunic, Layer.Ring, Layer.Bracelet, Layer.Face, Layer.Arms,
+            Layer.Gloves, Layer.Skirt, Layer.Robe, Layer.Waist, Layer.Necklace, Layer.Hair,
+            Layer.Beard, Layer.Earrings, Layer.Helmet, Layer.OneHanded, Layer.TwoHanded,
+            Layer.Backpack, Layer.Talisman
+        };
+
+        public const int N = 0x19; // 25 layers scanned by the reorder helpers
+
+        /// <summary>
+        /// Build the layer draw-order into <paramref name="order"/> (must be >= N).
+        /// <paramref name="graphic"/> is indexed by layer (0x00..0x18); 0 = nothing
+        /// equipped on that layer. <paramref name="altTorsoTable"/> gates the
+        /// gargoyle/female torso variant. The result is back-to-front paint order —
+        /// later index = painted on top. No heap allocation.
+        /// </summary>
+        public static void Build(ReadOnlySpan<ushort> graphic, bool altTorsoTable, Span<Layer> order)
+        {
+            // 1) base table selection --------------------------------------------
+            Layer[] table = T2; // default
+
+            uint arms = graphic[(int)Layer.Arms];
+            if (arms < 0x3d0)
+            {
+                if (arms == 0x3cf || arms == 0x210 || arms == 0x3b3) table = T1;
+            }
+            else if (arms == 0x3dd)
+            {
+                table = T1;
+            }
+
+            uint torso = graphic[(int)Layer.Torso];
+            if (torso == 0x21a) table = T1;
+            else if (torso - 0x399 < 5 && altTorsoTable) table = T3;
+
+            table.AsSpan(0, N).CopyTo(order);
+            Span<Layer> o = order.Slice(0, N);
+
+            // 2) per-graphic reorder rules ---------------------------------------
+            // shirt present + pants gfx 0x398 -> move Pants to Shirt's slot
+            if (graphic[(int)Layer.Shirt] != 0 && graphic[(int)Layer.Pants] == 0x398)
+            {
+                MoveTo(o, Layer.Pants, Layer.Shirt);
+            }
+
+            uint pants = graphic[(int)Layer.Pants];
+            bool skipFinalPantsCheck = false;
+            if (pants < 0x201)
+            {
+                if (pants == 0x200 || pants == 0x1eb || pants == 0x1fa)
+                {
+                    // ensure Shoes before Pants: if Pants currently precedes Shoes, swap
+                    int iShoes = IndexOf(o, Layer.Shoes), iPants = IndexOf(o, Layer.Pants);
+                    if (iShoes >= 0 && iPants >= 0 && iPants < iShoes)
+                    {
+                        o[iShoes] = Layer.Pants;
+                        o[iPants] = Layer.Shoes;
+                    }
+                }
+            }
+            else if (pants - 0x513u < 2)
+            {
+                if (graphic[(int)Layer.Shoes] != 0) MoveTo(o, Layer.Pants, Layer.Shoes);
+                skipFinalPantsCheck = true; // skip the 0x3e4 check below
+            }
+
+            if (!skipFinalPantsCheck && graphic[(int)Layer.Shoes] != 0 && graphic[(int)Layer.Pants] == 0x3e4)
+            {
+                MoveTo(o, Layer.Pants, Layer.Shoes);
+            }
+
+            // tunic gfx 0x238 -> Tunic after Waist; +robe in set -> Robe after Neck
+            if (graphic[(int)Layer.Tunic] == 0x238)
+            {
+                MoveAfter(o, Layer.Tunic, Layer.Waist);
+                if (graphic[(int)Layer.Robe] != 0)
+                {
+                    uint r = graphic[(int)Layer.Robe];
+                    if (r == 0x4e8 || r == 0x4e9 || r == 0x4ea || r == 0x4eb ||
+                        r == 0x5e2 || r == 0x5e3 || r == 0x5e4 || r == 0x5e5)
+                    {
+                        MoveTo(o, Layer.Robe, Layer.Necklace);
+                    }
+                }
+            }
+
+            // cloak/quiver gfx 0x380/0x5F3 -> Cloak after Robe (the quiver fix)
+            uint cloak = graphic[(int)Layer.Cloak];
+            if (cloak == 0x380 || cloak == 0x5f3) MoveAfter(o, Layer.Cloak, Layer.Robe);
+
+            // helmet/neck interplay
+            uint helm = graphic[(int)Layer.Helmet];
+            if (helm < 0x202)
+            {
+                uint neck = graphic[(int)Layer.Necklace];
+                if ((helm == 0x201 || helm == 0x1a9) &&
+                    (neck == 0x1c8 || (neck > 0x1d6 && neck < 0x1d9)))
+                {
+                    MoveAfter(o, Layer.Necklace, Layer.Helmet);
+                    return; // done — helmet covers the neck item
+                }
+            }
+            else if (helm - 0x5e9u < 2 && graphic[(int)Layer.Robe] != 0 && (graphic[(int)Layer.Robe] - 0x5e2u) < 4)
+            {
+                MoveTo(o, Layer.Robe, Layer.Helmet);
+            }
+        }
+
+        /// <summary>
+        /// Fill <paramref name="gfx"/> (length >= N) with the entity's per-layer item
+        /// graphics (0x00..0x18); empty layers are left at 0.
+        /// </summary>
+        public static void GraphicsFromEntity(Entity entity, Span<ushort> gfx)
+        {
+            gfx.Slice(0, N).Clear();
+
+            for (int layer = (int)Layer.OneHanded; layer <= (int)Layer.Legs; layer++)
+            {
+                Item item = entity.FindItemByLayer((Layer)layer);
+                if (item != null)
+                {
+                    gfx[layer] = item.Graphic;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copy a raw N-entry order into <paramref name="dest"/>, dropping the sentinel
+        /// and Mount. Backpack is kept only when <paramref name="includeBackpack"/> is
+        /// set. Returns the entry count.
+        /// </summary>
+        public static int Filter(ReadOnlySpan<Layer> order, bool includeBackpack, Span<Layer> dest)
+        {
+            int c = 0;
+            foreach (Layer layer in order)
+            {
+                if (layer == Layer.Invalid || layer == Layer.Mount) continue;
+                if (layer == Layer.Backpack && !includeBackpack) continue;
+                dest[c++] = layer;
+            }
+
+            return c;
+        }
+
+        /// <summary>
+        /// One-shot helper for the in-world (animated) views: builds the order for an
+        /// entity into <paramref name="dest"/> (length >= N) and repositions the cloak
+        /// by facing direction. Returns the entry count. No heap allocation.
+        /// </summary>
+        public static int BuildInWorld(Entity entity, bool altTorsoTable, byte direction, Span<Layer> dest)
+        {
+            Span<ushort> gfx = stackalloc ushort[N];
+            GraphicsFromEntity(entity, gfx);
+
+            Span<Layer> order = stackalloc Layer[N];
+            Build(gfx, altTorsoTable, order);
+
+            int count = Filter(order, includeBackpack: false, dest);
+            return ApplyDirectionCloak(dest, count, direction);
+        }
+
+        /// <summary>
+        /// Reposition Cloak for the in-world views, which the official client keys on
+        /// facing direction rather than the paperdoll cloak rules: dir 0 (North/away)
+        /// draws the cloak on top, dir 3 (facing viewer) behind, every other dir places
+        /// it just below the helmet. Operates in place; returns the (unchanged) count.
+        /// </summary>
+        public static int ApplyDirectionCloak(Span<Layer> layers, int count, byte dir)
+        {
+            int idx = -1;
+            for (int i = 0; i < count; i++)
+            {
+                if (layers[i] == Layer.Cloak) { idx = i; break; }
+            }
+
+            if (idx < 0) return count;
+
+            // remove cloak
+            for (int i = idx; i < count - 1; i++) layers[i] = layers[i + 1];
+            count--;
+
+            int insert;
+            if (dir == 0)
+            {
+                insert = count; // painted last = on top
+            }
+            else if (dir == 3)
+            {
+                insert = 0; // painted first = behind
+            }
+            else
+            {
+                insert = count;
+                for (int i = 0; i < count; i++)
+                {
+                    if (layers[i] == Layer.Helmet) { insert = i; break; }
+                }
+            }
+
+            // open a slot at 'insert' and drop cloak in
+            for (int i = count; i > insert; i--) layers[i] = layers[i - 1];
+            layers[insert] = Layer.Cloak;
+            return count + 1;
+        }
+
+        // --- reorder primitives (exact memmove semantics) -----------------------
+        private static int IndexOf(ReadOnlySpan<Layer> a, Layer v)
+        {
+            for (int i = 0; i < N; i++)
+            {
+                if (a[i] == v) return i;
+            }
+
+            return -1;
+        }
+
+        /// Relocate value A so it lands on B's index.
+        private static void MoveTo(Span<Layer> a, Layer A, Layer B)
+        {
+            int i1 = IndexOf(a, A); if (i1 < 0) return;
+            int i2 = IndexOf(a, B); if (i2 < 0 || i2 == i1) return;
+            if (i2 < i1) { for (int k = i1; k > i2; k--) a[k] = a[k - 1]; a[i2] = A; }
+            else { for (int k = i1; k < i2; k++) a[k] = a[k + 1]; a[i2] = A; }
+        }
+
+        /// Relocate value A so it lands immediately AFTER B.
+        private static void MoveAfter(Span<Layer> a, Layer A, Layer B)
+        {
+            int i1 = IndexOf(a, A); if (i1 < 0) return;
+            int i2 = IndexOf(a, B); if (i2 < 0 || i2 == i1) return;
+            if (i2 < i1) { for (int k = i1; k > i2 + 1; k--) a[k] = a[k - 1]; a[i2 + 1] = A; }
+            else { for (int k = i1; k < i2; k++) a[k] = a[k + 1]; a[i2] = A; }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
@@ -214,9 +214,15 @@ namespace ClassicUO.Game.GameObjects
                 depth
             );
 
-            for (int i = 0; i < Constants.USED_LAYER_COUNT; i++)
+            // draw order built from the layer algorithm (PaperdollOrder), keyed on
+            // equipped item graphics; cloak repositioned by facing direction to match
+            // the in-world tables. Stack-allocated, no GC churn.
+            Span<Layer> layers = stackalloc Layer[PaperdollOrder.N];
+            int layerCount = PaperdollOrder.BuildInWorld(this, altTorsoTable: false, direction, layers);
+
+            for (int i = 0; i < layerCount; i++)
             {
-                Layer layer = LayerOrder.UsedLayers[direction, i];
+                Layer layer = layers[i];
 
                 DrawLayer(
                     batcher,
@@ -547,10 +553,13 @@ namespace ClassicUO.Game.GameObjects
                     || Amount == 0x02E8
                     || Amount == 0x02E9;
 
-                for (int i = -1; i < Constants.USED_LAYER_COUNT; i++)
+                Span<Layer> layers = stackalloc Layer[PaperdollOrder.N];
+                int layerCount = PaperdollOrder.BuildInWorld(this, altTorsoTable: false, direction, layers);
+
+                for (int i = -1; i < layerCount; i++)
                 {
-                    // yes im lazy
-                    Layer layer = i == -1 ? Layer.Invalid : LayerOrder.UsedLayers[direction, i];
+                    // i == -1 draws the base body first, then each equipped layer
+                    Layer layer = i == -1 ? Layer.Invalid : layers[i];
 
                     ushort graphic;
 

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -348,9 +348,15 @@ namespace ClassicUO.Game.GameObjects
 
             if (!IsEmpty)
             {
-                for (int i = 0; i < Constants.USED_LAYER_COUNT; i++)
+                // draw order built from the layer algorithm (PaperdollOrder), keyed on
+                // the equipped item graphics; cloak is then repositioned by facing
+                // direction to match the in-world tables. Stack-allocated, no GC churn.
+                Span<Layer> layers = stackalloc Layer[PaperdollOrder.N];
+                int layerCount = PaperdollOrder.BuildInWorld(this, IsFemale || isGargoyle, layerDir, layers);
+
+                for (int i = 0; i < layerCount; i++)
                 {
-                    Layer layer = LayerOrder.UsedLayers[layerDir, i];
+                    Layer layer = layers[i];
 
                     Item item = FindItemByLayer(layer);
 

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -1170,85 +1170,31 @@ namespace ClassicUO.Game.GameObjects
                 return false;
             }
 
+            // Most occlusion is handled purely by the paint order (the robe/legs/skirt
+            // layers are drawn on top of the body layers they cover, so the underlying
+            // gump is simply overpainted). Only the cases the order CANNOT express are
+            // kept here: layers that paint on TOP of their occluder and must be hidden
+            // explicitly — surcoat-style tunics over a robe, hair/helmet under a hood,
+            // and plate legs (pants 0x1411) over shoes.
             switch (layer)
             {
                 case Layer.Shoes:
+                    // plate/studded legs paint under shoes, so order can't hide them
                     Item pants = mobile.FindItemByLayer(Layer.Pants);
-                    Item robe;
 
-                    if (
-                        mobile.FindItemByLayer(Layer.Legs) != null
-                        || pants != null
-                            && (
-                                pants.Graphic == 0x1411 /*|| pants.Graphic == 0x141A*/
-                            )
-                    )
+                    if (pants != null && pants.Graphic == 0x1411)
                     {
                         return true;
-                    }
-                    else
-                    {
-                        robe = mobile.FindItemByLayer(Layer.Robe);
-
-                        if (
-                            pants != null && (pants.Graphic == 0x0513 || pants.Graphic == 0x0514)
-                            || robe != null && robe.Graphic == 0x0504
-                        )
-                        {
-                            return true;
-                        }
-                    }
-
-                    break;
-
-                case Layer.Pants:
-
-                    robe = mobile.FindItemByLayer(Layer.Robe);
-                    pants = mobile.FindItemByLayer(Layer.Pants);
-
-                    if (
-                        mobile.FindItemByLayer(Layer.Legs) != null
-                        || robe != null && robe.Graphic == 0x0504
-                    )
-                    {
-                        return true;
-                    }
-
-                    if (
-                        pants != null
-                        && (
-                            pants.Graphic == 0x01EB
-                            || pants.Graphic == 0x03E5
-                            || pants.Graphic == 0x03eB
-                        )
-                    )
-                    {
-                        Item skirt = mobile.FindItemByLayer(Layer.Skirt);
-
-                        if (skirt != null && skirt.Graphic != 0x01C7 && skirt.Graphic != 0x01E4)
-                        {
-                            return true;
-                        }
-
-                        if (
-                            robe != null
-                            && robe.Graphic != 0x0229
-                            && (robe.Graphic <= 0x04E7 || robe.Graphic > 0x04EB)
-                        )
-                        {
-                            return true;
-                        }
                     }
 
                     break;
 
                 case Layer.Tunic:
-                    robe = mobile.FindItemByLayer(Layer.Robe);
+                    Item robe = mobile.FindItemByLayer(Layer.Robe);
                     Item tunic = mobile.FindItemByLayer(Layer.Tunic);
 
-                    /*if (robe != null && robe.Graphic != 0)
-                        return true;
-                    else*/
+                    // tunic 0x238 is moved on top of the robe (surcoat); hide it when a
+                    // full robe is worn underneath.
                     if (tunic != null && tunic.Graphic == 0x0238)
                     {
                         return robe != null
@@ -1258,49 +1204,6 @@ namespace ClassicUO.Game.GameObjects
                     }
 
                     break;
-
-                case Layer.Torso:
-                    robe = mobile.FindItemByLayer(Layer.Robe);
-
-                    if (
-                        robe != null
-                        && robe.Graphic != 0
-                        && robe.Graphic != 0x9985
-                        && robe.Graphic != 0x9986
-                        && robe.Graphic != 0xA412
-                        && robe.Graphic != 0xA2CA
-                    )
-                    {
-                        return true;
-                    }
-                    else
-                    {
-                        tunic = mobile.FindItemByLayer(Layer.Tunic);
-
-                        if (tunic != null && tunic.Graphic != 0x1541 && tunic.Graphic != 0x1542)
-                        {
-                            Item torso = mobile.FindItemByLayer(Layer.Torso);
-
-                            if (
-                                torso != null
-                                && (torso.Graphic == 0x782A || torso.Graphic == 0x782B)
-                            )
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
-                    break;
-
-                case Layer.Arms:
-                    robe = mobile.FindItemByLayer(Layer.Robe);
-
-                    return robe != null
-                        && robe.Graphic != 0
-                        && robe.Graphic != 0x9985
-                        && robe.Graphic != 0x9986
-                        && robe.Graphic != 0xA412;
 
                 case Layer.Helmet:
                 case Layer.Hair:

--- a/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
@@ -1,5 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using System;
 using System.Collections.Generic;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
@@ -16,60 +17,6 @@ namespace ClassicUO.Game.UI.Controls
 {
     internal class PaperDollInteractable : Control
     {
-        private static readonly Layer[] _layerOrder =
-        {
-            Layer.Cloak,
-            Layer.Shirt,
-            Layer.Pants,
-            Layer.Shoes,
-            Layer.Legs,
-            Layer.Arms,
-            Layer.Torso,
-            Layer.Tunic,
-            Layer.Ring,
-            Layer.Bracelet,
-            Layer.Face,
-            Layer.Gloves,
-            Layer.Skirt,
-            Layer.Robe,
-            Layer.Waist,
-            Layer.Necklace,
-            Layer.Hair,
-            Layer.Beard,
-            Layer.Earrings,
-            Layer.Helmet,
-            Layer.OneHanded,
-            Layer.TwoHanded,
-            Layer.Talisman
-        };
-
-        private static readonly Layer[] _layerOrder_quiver_fix =
-        {
-            Layer.Shirt,
-            Layer.Pants,
-            Layer.Shoes,
-            Layer.Legs,
-            Layer.Arms,
-            Layer.Torso,
-            Layer.Tunic,
-            Layer.Ring,
-            Layer.Bracelet,
-            Layer.Face,
-            Layer.Gloves,
-            Layer.Skirt,
-            Layer.Robe,
-            Layer.Cloak,
-            Layer.Waist,
-            Layer.Necklace,
-            Layer.Hair,
-            Layer.Beard,
-            Layer.Earrings,
-            Layer.Helmet,
-            Layer.OneHanded,
-            Layer.TwoHanded,
-            Layer.Talisman
-        };
-
         private readonly PaperDollGump _paperDollGump;
 
         private bool _updateUI;
@@ -178,65 +125,41 @@ namespace ClassicUO.Game.UI.Controls
                 );
             }
 
-            // equipment
-            Item equipItem = mobile.FindItemByLayer(Layer.Cloak);
-            Item arms = mobile.FindItemByLayer(Layer.Arms);
+            // equipment — draw order built from the paperdoll layer algorithm
+            // (PaperdollOrder), keyed on the equipped item graphics. This subsumes the
+            // old _layerOrder / quiver-fix tables and the hardcoded arms<->torso swap.
+            // Stack-allocated, no GC churn.
+            Span<ushort> layerGraphics = stackalloc ushort[PaperdollOrder.N];
+            PaperdollOrder.GraphicsFromEntity(mobile, layerGraphics);
 
-            bool switch_arms_with_torso = false;
-
-            if (arms != null)
-            {
-                switch_arms_with_torso = arms.Graphic == 0x1410 || arms.Graphic == 0x1417;
-            }
-            else if (
+            // account for an item held over an empty slot so the preview order matches
+            if (
                 HasFakeItem
                 && Client.Game.UO.GameCursor.ItemHold.Enabled
                 && !Client.Game.UO.GameCursor.ItemHold.IsFixedPosition
-                && (byte)Layer.Arms == Client.Game.UO.GameCursor.ItemHold.ItemData.Layer
             )
             {
-                switch_arms_with_torso =
-                    Client.Game.UO.GameCursor.ItemHold.Graphic == 0x1410
-                    || Client.Game.UO.GameCursor.ItemHold.Graphic == 0x1417;
+                byte holdLayer = Client.Game.UO.GameCursor.ItemHold.ItemData.Layer;
+
+                if (holdLayer > 0 && holdLayer < layerGraphics.Length && layerGraphics[holdLayer] == 0)
+                {
+                    layerGraphics[holdLayer] = Client.Game.UO.GameCursor.ItemHold.Graphic;
+                }
             }
 
-            Layer[] layers;
+            bool altTorso = mobile.IsFemale || IsGargoyleBody(mobile.Graphic);
 
-            if (equipItem != null)
-            {
-                layers = equipItem.ItemData.IsContainer ? _layerOrder_quiver_fix : _layerOrder;
-            }
-            else if (
-                HasFakeItem
-                && Client.Game.UO.GameCursor.ItemHold.Enabled
-                && !Client.Game.UO.GameCursor.ItemHold.IsFixedPosition
-                && (byte)Layer.Cloak == Client.Game.UO.GameCursor.ItemHold.ItemData.Layer
-            )
-            {
-                layers = Client.Game.UO.GameCursor.ItemHold.ItemData.IsContainer
-                    ? _layerOrder_quiver_fix
-                    : _layerOrder;
-            }
-            else
-            {
-                layers = _layerOrder;
-            }
+            Span<Layer> order = stackalloc Layer[PaperdollOrder.N];
+            PaperdollOrder.Build(layerGraphics, altTorso, order);
 
-            for (int i = 0; i < layers.Length; i++)
+            Span<Layer> layers = stackalloc Layer[PaperdollOrder.N];
+            int layerCount = PaperdollOrder.Filter(order, includeBackpack: false, layers);
+
+            Item equipItem;
+
+            for (int i = 0; i < layerCount; i++)
             {
                 Layer layer = layers[i];
-
-                if (switch_arms_with_torso)
-                {
-                    if (layer == Layer.Arms)
-                    {
-                        layer = Layer.Torso;
-                    }
-                    else if (layer == Layer.Torso)
-                    {
-                        layer = Layer.Arms;
-                    }
-                }
 
                 equipItem = mobile.FindItemByLayer(layer);
 
@@ -383,6 +306,12 @@ namespace ClassicUO.Game.UI.Controls
         public void RequestUpdate()
         {
             _updateUI = true;
+        }
+
+        private static bool IsGargoyleBody(ushort graphic)
+        {
+            return graphic == 0x029A || graphic == 0x029B
+                || graphic == 0x02B6 || graphic == 0x02B7;
         }
 
         protected static ushort GetAnimID(ushort mobileGraphic, ushort itemGraphic, ushort animID, bool isfemale)


### PR DESCRIPTION
Add PaperdollOrder: builds the equipment layer draw-order from the equipped item graphics via three base tables plus per-graphic reorder rules (pants/shirt, shoes, surcoat, robe-over-armor, cloak/quiver, helmet/necklace), instead of the fixed _layerOrder / UsedLayers tables.

Wire it into the paperdoll gump and the in-world mobile/corpse views. In-world keeps facing-direction cloak placement on top of the dynamic rules. All buffers are stack-allocated spans keyed on the Layer enum, so there is no per-frame heap churn.