### PR TITLE
fix(spellbook): populate mastery book abilities page

### DIFF
--- a/src/ClassicUO.Client/Game/Data/SpellsMastery.cs
+++ b/src/ClassicUO.Client/Game/Data/SpellsMastery.cs
@@ -22,6 +22,32 @@ namespace ClassicUO.Game.Data
 
         public static readonly string SpellBookName = SpellBookType.Mastery.ToString();
 
+        // Property-list cliloc identifying the active mastery -> the abilities shown on the
+        // book's right "Abilities" page, in display order (passive first when present).
+        private static readonly Dictionary<int, int[]> _activeMasteryAbilities =
+            new Dictionary<int, int[]>
+            {
+                { 0x1193CA, new[] { 1, 2 } },
+                { 0x1193CB, new[] { 3, 4 } },
+                { 0x1193C9, new[] { 5, 6 } },
+                { 0x11A2BB, new[] { 15, 7, 8 } },
+                { 0x11A2BC, new[] { 15, 9, 10 } },
+                { 0x11A2BD, new[] { 15, 11, 12 } },
+                { 0x11A2BE, new[] { 15, 13, 14 } },
+                { 0x11A2BF, new[] { 18, 16, 17 } },
+                { 0x11A2C0, new[] { 18, 19, 20 } },
+                { 0x11A2C1, new[] { 18, 21, 22 } },
+                { 0x11A2C2, new[] { 33, 25, 26 } },
+                { 0x11A2C3, new[] { 33, 27, 28 } },
+                { 0x11A2C4, new[] { 33, 29, 30 } },
+                { 0x11A2C5, new[] { 33, 31, 32 } },
+                { 0x11A2C6, new[] { 36, 34, 35 } },
+                { 0x11A2C7, new[] { 39, 37, 38 } },
+                { 0x11A2C8, new[] { 42, 40, 41 } },
+                { 0x11A2C9, new[] { 45, 43, 44 } },
+                { 0x11A2CA, new[] { 33, 23, 24 } }
+            };
+
 
         static SpellsMastery()
         {
@@ -745,6 +771,22 @@ namespace ClassicUO.Game.Data
             }
 
             return "Discordance";
+        }
+
+        public static int[] GetActiveMasteryAbilities(int[] propertyClilocs)
+        {
+            if (propertyClilocs != null)
+            {
+                for (int i = 0; i < propertyClilocs.Length; i++)
+                {
+                    if (_activeMasteryAbilities.TryGetValue(propertyClilocs[i], out int[] ids))
+                    {
+                        return ids;
+                    }
+                }
+            }
+
+            return null;
         }
 
         public static SpellDefinition GetSpell(int spellIndex)

--- a/src/ClassicUO.Client/Game/Managers/ObjectPropertiesListManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ObjectPropertiesListManager.cs
@@ -1,5 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using System;
 using System.Collections.Generic;
 using ClassicUO.Network;
 
@@ -10,7 +11,7 @@ namespace ClassicUO.Game.Managers
         private readonly Dictionary<uint, ItemProperty> _itemsProperties = new Dictionary<uint, ItemProperty>();
 
 
-        public void Add(uint serial, uint revision, string name, string data, int namecliloc)
+        public void Add(uint serial, uint revision, string name, string data, int namecliloc, int[] clilocs = null)
         {
             if (!_itemsProperties.TryGetValue(serial, out ItemProperty prop))
             {
@@ -27,6 +28,7 @@ namespace ClassicUO.Game.Managers
             prop.Name = name;
             prop.Data = data;
             prop.NameCliloc = namecliloc;
+            prop.Clilocs = clilocs;
         }
 
 
@@ -95,6 +97,16 @@ namespace ClassicUO.Game.Managers
             return 0;
         }
 
+        public int[] GetClilocs(uint serial)
+        {
+            if (_itemsProperties.TryGetValue(serial, out ItemProperty p) && p.Clilocs != null)
+            {
+                return p.Clilocs;
+            }
+
+            return Array.Empty<int>();
+        }
+
         public void Remove(uint serial)
         {
             _itemsProperties.Remove(serial);
@@ -114,6 +126,7 @@ namespace ClassicUO.Game.Managers
         public uint Revision;
         public uint Serial;
         public int NameCliloc;
+        public int[] Clilocs;
 
         public string CreateData(bool extended)
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellbookGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellbookGump.cs
@@ -195,6 +195,10 @@ namespace ClassicUO.Game.UI.Gumps
                 return;
             }
 
+            // Ensure the book's property list is requested; it carries the active mastery,
+            // and its arrival triggers a rebuild that fills the right "Abilities" page.
+            World.OPL.Contains(LocalSerial);
+
             for (LinkedObject i = item.Items; i != null; i = i.Next)
             {
                 Item spell = (Item)i;
@@ -349,92 +353,41 @@ namespace ClassicUO.Game.UI.Gumps
 
                         _dataBox.Add(text, page);
 
-                        if (
-                            World.OPL.TryGetNameAndData(
-                                LocalSerial,
-                                out string name,
-                                out string data
-                            )
-                        )
+                        int[] activeAbilities = SpellsMastery.GetActiveMasteryAbilities(
+                            World.OPL.GetClilocs(LocalSerial)
+                        );
+
+                        if (activeAbilities != null)
                         {
-                            data = data.ToLower();
-                            string[] buff = data.Split(
-                                new[] { '\n' },
-                                StringSplitOptions.RemoveEmptyEntries
-                            );
-
-                            for (int i = 0; i < buff.Length; i++)
+                            for (int k = 0; k < activeAbilities.Length; k++)
                             {
-                                if (buff[i] != null)
+                                int id = activeAbilities[k];
+
+                                SpellDefinition spell = SpellsMastery.GetSpell(id);
+
+                                if (spell.ID == 0)
                                 {
-                                    int index = buff[i].IndexOf(
-                                        "mastery",
-                                        StringComparison.InvariantCulture
-                                    );
-
-                                    if (--index < 0)
-                                    {
-                                        continue;
-                                    }
-
-                                    string skillName = buff[i].Substring(0, index);
-
-                                    if (!string.IsNullOrEmpty(skillName))
-                                    {
-                                        List<int> activedSpells =
-                                            SpellsMastery.GetSpellListByGroupName(skillName);
-
-                                        for (int k = 0; k < activedSpells.Count; k++)
-                                        {
-                                            int id = activedSpells[k];
-
-                                            SpellDefinition spell = SpellsMastery.GetSpell(id);
-
-                                            if (spell != null)
-                                            {
-                                                ushort iconGraphic = (ushort)spell.GumpIconID;
-                                                int toolTipCliloc =
-                                                    id >= 0 && id < 6 ? 1115689 : 1155938 - 6;
-
-                                                int iconMY = 55 + 44 * k;
-
-                                                GumpPic icon = new GumpPic(
-                                                    225,
-                                                    iconMY,
-                                                    iconGraphic,
-                                                    0
-                                                )
-                                                {
-                                                    LocalSerial = (uint)(id - 1)
-                                                };
-
-                                                _dataBox.Add(icon, page);
-                                                icon.MouseDoubleClick += OnIconDoubleClick;
-                                                icon.DragBegin += OnIconDragBegin;
-
-                                                text = new Label(spell.Name, false, 0x0288, 80, 6)
-                                                {
-                                                    X = 225 + 44 + 4,
-                                                    Y = iconMY + 2
-                                                };
-
-                                                _dataBox.Add(text, page);
-
-                                                if (toolTipCliloc > 0)
-                                                {
-                                                    string tooltip =
-                                                        Client.Game.UO.FileManager.Clilocs.GetString(
-                                                            toolTipCliloc + id
-                                                        );
-
-                                                    icon.SetTooltip(tooltip, 250);
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    break;
+                                    continue;
                                 }
+
+                                int iconMY = 55 + 44 * k;
+
+                                GumpPic icon = new GumpPic(225, iconMY, (ushort)spell.GumpIconID, 0)
+                                {
+                                    LocalSerial = (uint)(id - 1)
+                                };
+
+                                _dataBox.Add(icon, page);
+                                icon.MouseDoubleClick += OnIconDoubleClick;
+                                icon.DragBegin += OnIconDragBegin;
+
+                                text = new Label(spell.Name, false, 0x0288, 80, 6)
+                                {
+                                    X = 225 + 44 + 4,
+                                    Y = iconMY + 2
+                                };
+
+                                _dataBox.Add(text, page);
                             }
                         }
 

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -5064,7 +5064,21 @@ namespace ClassicUO.Network
                 sb.Dispose();
             }
 
-            world.OPL.Add(serial, revision, name, data, namecliloc);
+            int[] clilocs = null;
+
+            if (list.Count != 0)
+            {
+                clilocs = new int[list.Count];
+
+                for (int i = 0; i < list.Count; i++)
+                {
+                    clilocs[i] = list[i].Item1;
+                }
+            }
+
+            world.OPL.Add(serial, revision, name, data, namecliloc, clilocs);
+
+            UIManager.GetGump<SpellbookGump>(serial)?.RequestUpdateContents();
 
             if (inBuyList && container != null && SerialHelper.IsValid(container.Serial))
             {


### PR DESCRIPTION
The masteries book's right "Abilities" panel never populated. The gump was built on the spellbook-content packet, before the item's property list arrived, and it matched the active mastery by scraping OPL text instead of the property clilocs.

- Keep the property-list clilocs per item and expose GetClilocs()
- Capture them in the MegaCliloc handler and rebuild an open spellbook when its property list updates
- Map the active-mastery cliloc to its ability ids and render the icons and names on the right page
- Request the book's property list when the gump is built

The right panel now shows the active mastery's abilities; the left index still lists the masteries contained in the book.