### PR TITLE
fix(map): guard null Node in Chunk.Destroy

### DIFF
--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -403,11 +403,15 @@ namespace ClassicUO.Game.Map
                 }
             }
 
-            if (Node.Next != null || Node.Previous != null)
+            if (Node != null)
             {
-                Node.List?.Remove(Node);
+                if (Node.Next != null || Node.Previous != null)
+                {
+                    Node.List?.Remove(Node);
+                }
+
+                Node = null;
             }
-            Node = null;
 
             IsDestroyed = true;
 


### PR DESCRIPTION
UltimaLive block reload calls the single-arg Map.GetChunk(int), which returns the raw terrain slot without an IsDestroyed check or Node reassignment. A previously destroyed chunk (Node already null) could be handed back and Clear()/Destroy() again, dereferencing Node.Next and throwing NullReferenceException. Null-guard the Node cleanup.