### PR TITLE
[statics] Fix same z rendering order

### DIFF
--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -316,6 +316,20 @@ namespace ClassicUO.Game.Map
                     break;
                 }
 
+                // Co-planar same-Z statics: the classic client draws the one
+                // stored EARLIER in statics.mul on top (verified vs client.exe:
+                // 89% of same-Z carpet/floor pairs map-wide store the carpet
+                // before the floor, and carpets render above floors). Default
+                // insertion appends the later-loaded static tail-ward, which
+                // the head->tail draw paints last (on top) — the reverse of
+                // the classic client. Break here so a newly-added static is
+                // inserted BEFORE an equal-priority static, keeping the
+                // earlier-loaded one tail-ward = drawn on top.
+                if (testPriorityZ == priorityZ && obj is Static && o is Static)
+                {
+                    break;
+                }
+
                 found = o;
                 o = o.TNext;
             }


### PR DESCRIPTION
<img width="1506" height="937" alt="image" src="https://github.com/user-attachments/assets/23a61b03-8b85-4e92-924c-b05e4b972d2c" />
vs correct rendering below
<img width="1469" height="946" alt="image" src="https://github.com/user-attachments/assets/4f67b55d-8546-4993-b962-85557171a32a" />
