### PR TITLE
feat(customhouse): show fake floor grid on floor 0

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/HouseCustomizationManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HouseCustomizationManager.cs
@@ -316,11 +316,11 @@ namespace ClassicUO.Game.Managers
             // that cannot be legally supported in its current position.
             ValidateDesignGrid(foundationItem, house);
 
-            z = foundationItem.Z + 7 + 20;
+            z = foundationItem.Z + 7;
 
             ushort color = 0x0051;
 
-            for (int i = 1; i < CurrentFloor; i++)
+            for (int i = 0; i < CurrentFloor; i++)
             {
                 for (int x = _bounds.X; x < EndPos.X; x++)
                 {


### PR DESCRIPTION
Fake transparent grid (0x0496) was generated only for floors 1+. Start the loop at floor 0 so the ground floor gets the same visual grid as upper floors during house customization.