### PR TITLE
Add server-driven dynamic map definitions

### DIFF
--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -22,6 +22,8 @@ namespace ClassicUO.Assets
         // cannot be a const, due to UOLive implementation
         public static int MAPS_COUNT = 6;
 
+        public static (int width, int height)[] ServerMapDefinitions { get; private set; }
+
         public MapLoader(UOFileManager fileManager) : base(fileManager)
         {
         }
@@ -253,6 +255,93 @@ namespace ClassicUO.Assets
             _filesMap.CopyTo(_currentMapFiles, 0);
             _filesIdxStatics.CopyTo(_currentIdxStaticsFiles, 0);
             _filesStatics.CopyTo(_currentStaticsFiles, 0);
+        }
+
+        protected static int GetMapCount((int index, int width, int height)[] defs)
+        {
+            int maxIndex = -1;
+
+            foreach (var d in defs)
+            {
+                if (d.index > maxIndex)
+                {
+                    maxIndex = d.index;
+                }
+            }
+
+            return maxIndex + 1;
+        }
+
+        protected static void StoreServerMapDefinitions((int index, int width, int height)[] defs, int count)
+        {
+            var store = new (int width, int height)[count];
+
+            foreach ((int index, int width, int height) in defs)
+            {
+                if (index < 0 || index >= count || width <= 0 || height <= 0)
+                {
+                    continue;
+                }
+
+                store[index] = (width, height);
+            }
+
+            ServerMapDefinitions = store;
+        }
+
+        public virtual void ApplyServerMapDefinitions((int index, int width, int height)[] defs)
+        {
+            if (defs == null)
+            {
+                return;
+            }
+
+            int count = GetMapCount(defs);
+
+            if (count <= 0)
+            {
+                return;
+            }
+
+            count = Math.Max(count, MAPS_COUNT);
+
+            StoreServerMapDefinitions(defs, count);
+
+            int[] widths = new int[count];
+            int[] heights = new int[count];
+
+            int existing = MapsDefaultSize.GetLength(0);
+
+            for (int i = 0; i < count; i++)
+            {
+                int src = i < existing ? i : 0;
+                widths[i] = MapsDefaultSize[src, 0];
+                heights[i] = MapsDefaultSize[src, 1];
+            }
+
+            foreach ((int index, int width, int height) in defs)
+            {
+                if (index < 0 || index >= count || width <= 0 || height <= 0)
+                {
+                    continue;
+                }
+
+                widths[index] = width;
+                heights[index] = height;
+            }
+
+            string[] parts = new string[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                parts[i] = $"{widths[i]},{heights[i]}";
+            }
+
+            MapsLayouts = string.Join(";", parts);
+
+            Log.Trace($"Applying server map definitions [count: {count}] -> {MapsLayouts}");
+
+            Load();
         }
 
         public unsafe void LoadMap(int i, bool useXFiles = false)

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -314,6 +314,37 @@ namespace ClassicUO.Game
                     break;
                 }
 
+                case 0x10: //dynamic map definitions
+                {
+                    if (p.Length < 15)
+                    {
+                        return;
+                    }
+
+                    p.Seek(14);
+                    byte mapCount = p.ReadUInt8();
+
+                    var defs = new (int index, int width, int height)[mapCount];
+
+                    for (int i = 0; i < mapCount; i++)
+                    {
+                        int index = p.ReadUInt8();
+                        int width = p.ReadUInt16BE();
+                        int height = p.ReadUInt16BE();
+
+                        defs[i] = (index, width, height);
+                    }
+
+                    Client.Game.UO.FileManager.Maps.ApplyServerMapDefinitions(defs);
+
+                    if (world != null && world.InGame)
+                    {
+                        world.ReloadCurrentMap();
+                    }
+
+                    break;
+                }
+
                 case 0x01: //map definition update
                 {
                     if (_UL == null)
@@ -697,13 +728,37 @@ namespace ClassicUO.Game
                 _feedCancel = new CancellationTokenSource();
                 NumMaps = maps;
                 var old = _UL.MapSizeWrapSize;
+
+                int[,] previous = fileManager.Maps?.MapsDefaultSize;
+                int previousLen = previous?.GetLength(0) ?? 0;
+                var serverDefs = ServerMapDefinitions;
+                int serverLen = serverDefs?.Length ?? 0;
+
                 MapsDefaultSize = new int[NumMaps, 2];
 
                 for (int i = 0; i < NumMaps; i++)
                 {
                     for (int x = 0; x < 2; x++)
                     {
-                        MapsDefaultSize[i, x] = i < old.GetLength(0) ? old[i, x] : old[0, x];
+                        int ulSize = i < old.GetLength(0) ? old[i, x] : 0;
+                        int serverSize = i < serverLen ? (x == 0 ? serverDefs[i].width : serverDefs[i].height) : 0;
+
+                        if (ulSize > 0)
+                        {
+                            MapsDefaultSize[i, x] = ulSize;
+                        }
+                        else if (serverSize > 0)
+                        {
+                            MapsDefaultSize[i, x] = serverSize;
+                        }
+                        else if (i < previousLen && previous[i, x] > 0)
+                        {
+                            MapsDefaultSize[i, x] = previous[i, x];
+                        }
+                        else
+                        {
+                            MapsDefaultSize[i, x] = old.GetLength(0) > 0 ? old[0, x] : 0;
+                        }
                     }
 
                     MapBlocksSize[i, 0] = MapsDefaultSize[i, 0] >> 3;
@@ -807,6 +862,16 @@ namespace ClassicUO.Game
                     throw new FileNotFoundException($"No maps, staidx or statics found on {_UL.ShardName}.");
                 }
 
+                for (int i = 0; i < NumMaps; i++)
+                {
+                    if (_filesMap[i] != null || _UL._ValidMaps.Contains(i))
+                    {
+                        continue;
+                    }
+
+                    LoadVanillaMapFiles(i);
+                }
+
                 _filesMap.CopyTo(_currentMapFiles, 0);
                 _filesIdxStatics.CopyTo(_currentIdxStaticsFiles, 0);
                 _filesStatics.CopyTo(_currentStaticsFiles, 0);
@@ -818,6 +883,89 @@ namespace ClassicUO.Game
                     MapBlocksSize[i, 1] = MapsDefaultSize[i, 1] >> 3;
                     //on ultimalive map always preload
                     LoadMap(i);
+                }
+            }
+
+            public override void ApplyServerMapDefinitions((int index, int width, int height)[] defs)
+            {
+                if (defs == null)
+                {
+                    return;
+                }
+
+                int count = GetMapCount(defs);
+
+                if (count <= 0)
+                {
+                    return;
+                }
+
+                count = Math.Max(count, (int)NumMaps);
+
+                StoreServerMapDefinitions(defs, count);
+
+                foreach ((int index, int width, int height) in defs)
+                {
+                    if (index < 0 || index >= MapsDefaultSize.GetLength(0) || width <= 0 || height <= 0)
+                    {
+                        continue;
+                    }
+
+                    if (_UL._ValidMaps.Contains(index))
+                    {
+                        continue;
+                    }
+
+                    MapsDefaultSize[index, 0] = width;
+                    MapsDefaultSize[index, 1] = height;
+                    MapBlocksSize[index, 0] = width >> 3;
+                    MapBlocksSize[index, 1] = height >> 3;
+
+                    if (_filesMap[index] == null)
+                    {
+                        LoadVanillaMapFiles(index);
+                    }
+
+                    _currentMapFiles[index] = _filesMap[index];
+                    _currentStaticsFiles[index] = _filesStatics[index];
+                    _currentIdxStaticsFiles[index] = _filesIdxStatics[index];
+
+                    BlockData[index] = null;
+                }
+            }
+
+            private void LoadVanillaMapFiles(int i)
+            {
+                string path = FileManager.GetUOFilePath($"map{i}LegacyMUL.uop");
+
+                if (FileManager.IsUOPInstallation && File.Exists(path))
+                {
+                    var uop = new UOFileUop(path, $"build/map{i}legacymul/{{0:D8}}.dat");
+                    uop.FillEntries();
+                    _filesMap[i] = uop;
+                }
+                else
+                {
+                    path = FileManager.GetUOFilePath($"map{i}.mul");
+
+                    if (File.Exists(path))
+                    {
+                        _filesMap[i] = new UOFileMul(path);
+                    }
+                }
+
+                path = FileManager.GetUOFilePath($"statics{i}.mul");
+
+                if (File.Exists(path))
+                {
+                    _filesStatics[i] = new UOFileMul(path);
+                }
+
+                path = FileManager.GetUOFilePath($"staidx{i}.mul");
+
+                if (File.Exists(path))
+                {
+                    _filesIdxStatics[i] = new UOFileMul(path);
                 }
             }
 

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -180,6 +180,37 @@ namespace ClassicUO.Game
 
         public bool InGame => Player != null && Map != null;
 
+        public void ReloadCurrentMap()
+        {
+            if (Map == null)
+                return;
+
+            int index = Map.Index;
+
+            InternalMapChangeClear(true);
+
+            ushort x = Player.X;
+            ushort y = Player.Y;
+            sbyte z = Player.Z;
+
+            Map.Destroy();
+            Map = null;
+
+            if (index < 0 || index >= MapLoader.MAPS_COUNT)
+                index = 0;
+
+            Client.Game.UO.FileManager.Maps.LoadMap(index, ClientFeatures.Flags.HasFlag(CharacterListFlags.CLF_UNLOCK_FELUCCA_AREAS));
+            Map = new Map.Map(this, index);
+
+            Player.SetInWorldTile(x, y, z);
+            Player.ClearSteps();
+
+            if (Client.Game.UO.GameCursor != null)
+            {
+                Client.Game.UO.GameCursor.Graphic = 0xFFFF;
+            }
+        }
+
         public IsometricLight Light { get; } = new IsometricLight
         {
             Overall = 0,


### PR DESCRIPTION
Adds a lightweight map-definitions command (0x10) on the UltimaLive 0x3F packet so a server can advertise its map count and per-facet dimensions on login, letting clients load additional or non-standard maps at the correct size. The packet is frame-safe and server-initiated, so no client configuration or handshake is required.

Dimensions are applied via MapLoader.ApplyServerMapDefinitions and persisted in MapLoader.ServerMapDefinitions; World.ReloadCurrentMap rebuilds the active facet if it changes in-game. ULMapLoader honors these definitions and loads the player's normal files for facets it does not manage, so UltimaLive keeps working when additional maps are present.

-----

**Testing/Implemtnation**
1. Add a map6.mul with accompanying statics6/staidx6 to the client and server folders.
2. Add the DynamicMapDefinitions.cs to your server (shown below).
3. Register your map in MapDefinitions.cs
    - RegisterMap( 7, 6, 6, 2560, 2048, 1, "YourLand",		MapRules.Trammel | MapRules.FreeMovement); 
4. Load into server and [set map 6 - or whatever number your map is to ensure it's working.

-----

**_DynamicMapDefinitions.cs_**
```using System.Collections.Generic;
using Server;
using Server.Network;

namespace Server.Network
{
    public class DynamicMapDefinitions
    {
        public static void Initialize()
        {
            EventSink.Login += OnLogin;
        }

        private static void OnLogin(LoginEventArgs e)
        {
            if (e == null || e.Mobile == null)
                return;

            NetState ns = e.Mobile.NetState;

            if (ns == null)
                return;

            ns.Send(new MapDefinitionsPacket());
        }
    }

    public sealed class MapDefinitionsPacket : Packet
    {
        public MapDefinitionsPacket() : base(0x3F)
        {
            List<Map> maps = new List<Map>();

            foreach (Map m in Map.AllMaps)
            {
                if (m == null || m == Map.Internal)
                    continue;

                if (m.MapID < 0 || m.MapID > 0x7E)
                    continue;

                if (m.Width <= 0 || m.Height <= 0)
                    continue;

                maps.Add(m);
            }

            EnsureCapacity(3 + 10 + 1 + 1 + (maps.Count * 5));

            for (int i = 0; i < 10; i++)
                m_Stream.Write((byte)0);

            m_Stream.Write((byte)0x10);
            m_Stream.Write((byte)maps.Count);

            foreach (Map m in maps)
            {
                m_Stream.Write((byte)m.MapID);
                m_Stream.Write((ushort)m.Width);
                m_Stream.Write((ushort)m.Height);
            }
        }
    }
}
```