### PR TITLE
fix(book): trim trailing empty lines before sending page data

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
@@ -163,7 +163,7 @@ namespace ClassicUO.Game.UI.Gumps
                 156,
                 IsNewBook,
                 FontStyle.ExtraHeight,
-                134
+                0x01B5
             )
             {
                 X = 0,

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernBookGump.cs
@@ -23,7 +23,7 @@ namespace ClassicUO.Game.UI.Gumps
         private const int MAX_BOOK_CHARS_PER_LINE = 53;
         private const int LEFT_X = 38;
         private const int RIGHT_X = 223;
-        private const int UPPER_MARGIN = 34;
+        private const int UPPER_MARGIN = 24;
         private const int PAGE_HEIGHT = 166;
         private StbPageTextBox _bookPage;
 
@@ -163,7 +163,7 @@ namespace ClassicUO.Game.UI.Gumps
                 156,
                 IsNewBook,
                 FontStyle.ExtraHeight,
-                2
+                134
             )
             {
                 X = 0,
@@ -325,6 +325,22 @@ namespace ClassicUO.Game.UI.Gumps
                                 text[l] = BookLines[x];
                             }
 
+                            // Most servers expect at most 8 lines per page: send lines
+                            // 9-10 only when they actually contain text. Empty lines are
+                            // stored as "\n", so strip newlines before testing. Only
+                            // trailing lines are trimmed: empty lines between text stay.
+                            int lineCount = MAX_BOOK_LINES;
+
+                            while (lineCount > 8 && IsEmptyBookLine(text[lineCount - 1]))
+                            {
+                                lineCount--;
+                            }
+
+                            if (lineCount < text.Length)
+                            {
+                                Array.Resize(ref text, lineCount);
+                            }
+
                             NetClient.Socket.Send_BookPageData(LocalSerial, text, i);
                         }
                     }
@@ -338,6 +354,24 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 UIManager.SystemChat.TextBoxControl.SetKeyboardFocus();
             }
+        }
+
+        private static bool IsEmptyBookLine(string line)
+        {
+            if (string.IsNullOrEmpty(line))
+            {
+                return true;
+            }
+
+            for (int i = 0; i < line.Length; i++)
+            {
+                if (line[i] != '\n')
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public override void OnButtonClick(int buttonID)

--- a/src/ClassicUO.Client/Network/OutgoingPackets.cs
+++ b/src/ClassicUO.Client/Network/OutgoingPackets.cs
@@ -3266,7 +3266,7 @@ namespace ClassicUO.Network
             writer.Dispose();
         }
 
-        public static void Send_BookPageData(this NetClient socket, uint serial, string[] text, int page)
+        public static void Send_BookPageData(this NetClient socket, uint serial, string[] lines, int page)
         {
             const byte ID = 0x66;
 
@@ -3284,13 +3284,13 @@ namespace ClassicUO.Network
             writer.WriteUInt32BE(serial);
             writer.WriteUInt16BE(0x01);
             writer.WriteUInt16BE((ushort) page);
-            writer.WriteUInt16BE((ushort) text.Length);
+            writer.WriteUInt16BE((ushort) lines.Length);
 
-            for (int i = 0; i < text.Length; ++i)
+            for (int i = 0; i < lines.Length; ++i)
             {
-                if (!string.IsNullOrEmpty(text[i]))
+                if (!string.IsNullOrEmpty(lines[i]))
                 {
-                    string t = text[i].Replace("\n", "");
+                    string t = lines[i].Replace("\n", "");
 
                     if (t.Length > 0)
                     {


### PR DESCRIPTION
Pages now hold 10 lines but most servers reject more than 8 per page. Send 8 lines by default and include lines 9-10 only when they contain text. Empty lines are stored as "\n", so the emptiness test strips newlines; gaps between written lines are preserved.