### PR TITLE
Revert "[statics] Fix same z rendering order"

### DIFF
--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -316,20 +316,6 @@ namespace ClassicUO.Game.Map
                     break;
                 }
 
-                // Co-planar same-Z statics: the classic client draws the one
-                // stored EARLIER in statics.mul on top (verified vs client.exe:
-                // 89% of same-Z carpet/floor pairs map-wide store the carpet
-                // before the floor, and carpets render above floors). Default
-                // insertion appends the later-loaded static tail-ward, which
-                // the head->tail draw paints last (on top) — the reverse of
-                // the classic client. Break here so a newly-added static is
-                // inserted BEFORE an equal-priority static, keeping the
-                // earlier-loaded one tail-ward = drawn on top.
-                if (testPriorityZ == priorityZ && obj is Static && o is Static)
-                {
-                    break;
-                }
-
                 found = o;
                 o = o.TNext;
             }


### PR DESCRIPTION
Reverts ClassicUO/ClassicUO#1908

From discord:
<img width="666" height="464" alt="image" src="https://github.com/user-attachments/assets/7df020bb-d9b9-443d-8dea-4befabb3be2b" />
<img width="256" height="201" alt="image" src="https://github.com/user-attachments/assets/855bc6cb-2da9-42cd-8795-476d95028985" />
<img width="391" height="375" alt="image" src="https://github.com/user-attachments/assets/64e8abc7-1366-40b2-9624-002ae29d2483" />
