### PR TITLE
fix(map): stop UltimaLive block reload from pooling live chunks

### DIFF
--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -431,6 +431,46 @@ namespace ClassicUO.Game.Map
             Destroy();
         }
 
+        /// <summary>
+        /// Clears the chunk's tile objects for an in-place reload (UltimaLive block
+        /// update) and marks the mesh dirty so it rebuilds — WITHOUT destroying or
+        /// pooling the chunk itself. The chunk stays owned by the map: its
+        /// <see cref="_terrainChunks"/> slot and <see cref="Node"/> are left intact.
+        /// Using <see cref="Destroy"/>/<see cref="Clear"/> here would enqueue this
+        /// chunk to the shared pool while it is still referenced by the map, so it
+        /// would later be handed out by <see cref="Create"/> for a different block
+        /// (double ownership) — the original block then renders a stale/empty mesh
+        /// (black, world-locked, permanent).
+        /// </summary>
+        public void ClearForReload()
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    GameObject first = GetHeadObject(i, j);
+
+                    while (first != null)
+                    {
+                        GameObject next = first.TNext;
+
+                        if (!ReferenceEquals(first, _world.Player))
+                        {
+                            first.Destroy();
+                        }
+
+                        first.TPrevious = null;
+                        first.TNext = null;
+                        first = next;
+                    }
+
+                    Tiles[i, j] = null;
+                }
+            }
+
+            Mesh.SoftClear();
+        }
+
         public bool HasNoExternalData()
         {
             for (int i = 0; i < 8; i++)

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -290,7 +290,7 @@ namespace ClassicUO.Game
                                 }
                             }
 
-                            mapChunk.Clear();
+                            mapChunk.ClearForReload();
                             _UL._ULMap.ReloadBlock(mapId, block);
                             mapChunk.Load(mapId);
 
@@ -511,7 +511,7 @@ namespace ClassicUO.Game
                             }
                         }
 
-                        mapChunk.Clear();
+                        mapChunk.ClearForReload();
                         mapChunk.Load(mapId);
 
                         foreach (GameObject obj in gameObjects)


### PR DESCRIPTION
UltimaLive reloaded blocks via Chunk.Clear() -> Destroy(), which enqueues the chunk to the shared static pool and drops its _usedIndices node while the map still references it in _terrainChunks. Normal chunk loading later dequeues that same chunk for a different block, so two map slots share one Chunk; its X/Y/mesh get overwritten and the reloaded block renders a stale/empty mesh (black, world-locked, permanent until relog).

Add Chunk.ClearForReload(): clears tile objects and marks the mesh dirty for an in-place rebuild without pooling/destroying the chunk or touching its node. Use it at both UltimaLive reload sites instead of Clear().