### PR TITLE
Fix skills-changed checkbox initializing from the stats-changed setting

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -1318,7 +1318,7 @@ namespace ClassicUO.Game.UI.Gumps
                 (
                     null,
                     ResGumps.ShowSkillsChangedMessageBy,
-                    _currentProfile.ShowStatsChangedMessage,
+                    _currentProfile.ShowSkillsChangedMessage,
                     startX,
                     startY
                 )


### PR DESCRIPTION
Fixes #1921.

The "Inform when skills change by (in tenths)" checkbox in General > Miscellaneous read its initial state from `ShowStatsChangedMessage` instead of `ShowSkillsChangedMessage`. The save path writes the checkbox back to the correct field, so whenever the two settings differ, opening the options gump misdisplays the skills checkbox — and pressing Apply then silently overwrites the user's actual skills-message preference with a value they never chose.

One line: initialize from `_currentProfile.ShowSkillsChangedMessage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiLa71wAbTw9p4oFJMyF9W