### PR TITLE
Fix native plugin loading on Linux systems without libdl

### DIFF
--- a/src/ClassicUO.Utility/Platforms/Native.cs
+++ b/src/ClassicUO.Utility/Platforms/Native.cs
@@ -76,35 +76,30 @@ namespace ClassicUO.Utility.Platforms
 
         private class UnixNativeLoader : NativeLoader
         {
-            private const string LibName = "libdl";
-
-            public const int RTLD_NOW = 0x002;
-
-            [DllImport(LibName)]
-            private static extern IntPtr dlopen(string fileName, int flags);
-
-            [DllImport(LibName)]
-            private static extern IntPtr dlsym(IntPtr handle, string name);
-
-            [DllImport(LibName)]
-            private static extern int dlclose(IntPtr handle);
-
-            [DllImport(LibName)]
-            private static extern string dlerror();
-
             public override IntPtr LoadLibrary(string name)
             {
-                return dlopen(name, RTLD_NOW);
+                if (NativeLibrary.TryLoad(name, out IntPtr handle))
+                {
+                    return handle;
+                }
+
+                return IntPtr.Zero;
             }
 
             public override IntPtr GetProcessAddress(IntPtr module, string name)
             {
-                return dlsym(module, name);
+                if (NativeLibrary.TryGetExport(module, name, out IntPtr address))
+                {
+                    return address;
+                }
+
+                return IntPtr.Zero;
             }
 
             public override int FreeLibrary(IntPtr module)
             {
-                return dlclose(module);
+                NativeLibrary.Free(module);
+                return 0;
             }
         }
     }


### PR DESCRIPTION
UnixNativeLoader resolved dlopen/dlsym/dlclose through [DllImport("libdl")]. glibc 2.34 (Aug 2021) merged libdl into libc, so distributions built against it keep only the versioned libdl.so.2 stub for pre-existing binaries and no longer ship an unversioned libdl.so. The runtime probes libdl.so and liblibdl.so for that DllImport but never the versioned name, so there is nothing for it to find. Installing libc6-dev does not help: on Ubuntu 24.04 (glibc 2.39) with libc6-dev present, the only files are libdl.so.2 and an empty libdl.a.

DllImport("libdl") therefore throws DllNotFoundException on first use, so Native.LoadLibrary could never load a plugin and the native "Install" entry point was unreachable. Plugin.Load catches everything and falls back to the managed load path, so this surfaced not as an error but as native plugins silently never being used.

Use System.Runtime.InteropServices.NativeLibrary instead. It is in-box from .NET Core 3.0, wraps the OS loader directly (dlopen/dlsym on Unix, including macOS, where the old libdl import did still resolve) and never names libdl, so there is nothing left to be missing.

The single-argument TryLoad overload is used deliberately. The (name, assembly, searchPath) overload searches paths based on the calling assembly's DllImportSearchPath attributes and invokes AssemblyLoadContext's LoadUnmanagedDll and ResolvingUnmanagedDll hooks, none of which the dlopen call it replaces ever did; the single-argument one wraps the OS loader with default flags, so the string reaches it exactly as it reached dlopen. That matters for the relative "./cuo.so" ClassicUO.Bootstrap passes, where the probing overload is most likely to resolve differently than a plain dlopen.

Behaviour is otherwise unchanged: a failed load or missing export still returns IntPtr.Zero, which is what both call sites already test for. FreeLibrary returns 0 because NativeLibrary.Free is void and does not fail; its one caller ignores the result.