### PR TITLE
Alternate Journal Hue and Transparency customization

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -322,6 +322,9 @@ namespace ClassicUO.Configuration
 
         //Alternate Journal
         public bool UseAlternateJournal { get; set; }
+        public ushort AlternateJournalHue { get; set; }
+        public int AlternateJournalTransparency { get; set; }
+        public bool AlternateJournalTransparencyToggle { get; set; }
         public Dictionary<string, MessageType[]> JournalTabs { get; } = new Dictionary<string, MessageType[]>()
         {
             { "All", new MessageType[] {

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -128,6 +128,9 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _showInfoBar;
         private Checkbox _ignoreAllianceMessages;
         private Checkbox _ignoreGuildMessages, _useAlternateJournal, _partyMessagesOverhead;
+        private ClickableColorBox _AlternateJournalHue;
+        private Checkbox _AlternateJournalTransparencyToggle;
+        private HSliderBar _AlternateJournalTransparency;
 
         // general
         private HSliderBar _sliderFPS, _circleOfTranspRadius;
@@ -2487,7 +2490,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             startY += _saveJournalCheckBox.Height + 2;
 
-            if (!_currentProfile.SaveJournalToFile)
+                        if (!_currentProfile.SaveJournalToFile)
             {
                 World.Journal.CloseWriter();
             }
@@ -2543,6 +2546,46 @@ namespace ClassicUO.Game.UI.Gumps
                 startX,
                 startY
             );
+
+            startX = 5;
+            startY += _journalFileWithSerial.Height + 10;
+
+            _AlternateJournalHue = AddColorBox
+            (
+                rightArea,
+                startX,
+                startY,
+                _currentProfile.AlternateJournalHue,
+                ResGumps.AlternateJournalHue
+            );
+
+            startY += _AlternateJournalHue.Height + 2;
+
+            _AlternateJournalTransparencyToggle = AddCheckBox
+            (
+                rightArea,
+                ResGumps.AlternateJournalTransparency,
+                _currentProfile.AlternateJournalTransparencyToggle,
+                startX,
+                startY
+            );
+
+            startX += _AlternateJournalTransparencyToggle.Width + 5;
+
+            _AlternateJournalTransparency = AddHSlider
+            (
+                rightArea,
+                1,
+                10,
+                _currentProfile.AlternateJournalTransparency,
+                startX,
+                startY,
+                180
+            );
+
+            startY += _AlternateJournalHue.Height + 15;
+
+
 
             startX = 5;
             startY += _journalFileWithSerial.Height + 2 + 5;
@@ -3743,6 +3786,9 @@ namespace ClassicUO.Game.UI.Gumps
                     _ignoreGuildMessages.IsChecked = false;
                     _ignoreAllianceMessages.IsChecked = false;
                     _useAlternateJournal.IsChecked = false;
+                    _AlternateJournalHue.Hue = 0x0000;
+                    _AlternateJournalTransparency.Value = 7;
+                    _AlternateJournalTransparencyToggle.IsChecked = true;
                     _partyMessagesOverhead.IsChecked = false;
 
                     break;
@@ -4146,6 +4192,9 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.IgnoreGuildMessages = _ignoreGuildMessages.IsChecked;
             _currentProfile.IgnoreAllianceMessages = _ignoreAllianceMessages.IsChecked;
             _currentProfile.UseAlternateJournal = _useAlternateJournal.IsChecked;
+            _currentProfile.AlternateJournalHue = _AlternateJournalHue.Hue;
+            _currentProfile.AlternateJournalTransparencyToggle = _AlternateJournalTransparencyToggle.IsChecked; 
+            _currentProfile.AlternateJournalTransparency = _AlternateJournalTransparency.Value;
 
             // fonts
             _currentProfile.ForceUnicodeJournal = _forceUnicodeJournal.IsChecked;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
@@ -61,8 +61,11 @@ namespace ClassicUO.Game.UI.Gumps
 
 
             #region Background
-            _background = new AlphaBlendControl(0.7f);
-            _background.Hue = 0x0000;
+            if(ProfileManager.CurrentProfile.AlternateJournalTransparencyToggle)    
+                _background = new AlphaBlendControl((float)ProfileManager.CurrentProfile.AlternateJournalTransparency/10);
+            else
+                _background = new AlphaBlendControl(1.0f);
+            _background.Hue = ProfileManager.CurrentProfile.AlternateJournalHue;
             _background.Width = Width - (BORDER_WIDTH * 2);
             _background.Height = Height - (BORDER_WIDTH * 2);
             _background.X = BORDER_WIDTH;

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -230,6 +230,24 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("AltCloseGumps", resourceCulture);
             }
         }
+                
+        /// <summary>
+        ///   Looks up a localized string similar to Alternative Journal Hue.
+        /// </summary>
+        public static string AlternateJournalHue {
+            get {
+                return ResourceManager.GetString("AlternateJournalHue", resourceCulture);
+            }
+        }
+                
+        /// <summary>
+        ///   Looks up a localized string similar to Alternative journal Transparency.
+        /// </summary>
+        public static string AlternateJournalTransparency {
+            get {
+                return ResourceManager.GetString("AlternateJournalTransparency", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Alternative lights.

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1667,4 +1667,10 @@ start your first counter</value>
   <data name="JournalFileWithSerial" xml:space="preserve">
     <value>Add speaker serial to journal entries</value>
   </data>
+  <data name="AlternateJournalHue" xml:space="preserve">
+    <value>Alternative Journal Hue</value>
+  </data>
+  <data name="AlternateJournalTransparency" xml:space="preserve">
+    <value>Alternative journal Transparency</value>
+  </data>
 </root>


### PR DESCRIPTION
Added Hue selection and transparency slider for the alternative journal to the Speech option section
<img width="1176" height="273" alt="image" src="https://github.com/user-attachments/assets/7ceb47bc-83e8-4d99-8052-eba1a6ba687e" />
