### PR TITLE
Drain queued NPC steps at the server's cadence

### DIFF
--- a/src/ClassicUO.Client/Game/Data/MovementSpeed.cs
+++ b/src/ClassicUO.Client/Game/Data/MovementSpeed.cs
@@ -11,6 +11,12 @@ namespace ClassicUO.Game.Data
         public const int STEP_DELAY_RUN = 200;
         public const int STEP_DELAY_WALK = 400;
 
+        // Floor for a measured server cadence. Below this a step is a teleport, and a
+        // jitter burst (two packets a frame apart) must not collapse the steps it touches
+        // into one; above it every legitimate creature pace we know of fits (ModernUO
+        // floors creatures at 50 ms, UOX3 tunes to 80 ms, POL to 125 ms, Sphere to 100 ms).
+        public const int STEP_DELAY_MIN = 50;
+
         public static bool FastRotation;
         public static int TurnDelay => FastRotation ? Constants.TURN_DELAY_FAST : Constants.TURN_DELAY;
 

--- a/src/ClassicUO.Client/Game/Data/MovementSpeed.cs
+++ b/src/ClassicUO.Client/Game/Data/MovementSpeed.cs
@@ -11,10 +11,7 @@ namespace ClassicUO.Game.Data
         public const int STEP_DELAY_RUN = 200;
         public const int STEP_DELAY_WALK = 400;
 
-        // Floor for a measured server cadence. Below this a step is a teleport, and a
-        // jitter burst (two packets a frame apart) must not collapse the steps it touches
-        // into one; above it every legitimate creature pace we know of fits (ModernUO
-        // floors creatures at 50 ms, UOX3 tunes to 80 ms, POL to 125 ms, Sphere to 100 ms).
+        // Floor for a measured server cadence; below this a step reads as a teleport.
         public const int STEP_DELAY_MIN = 50;
 
         public static bool FastRotation;

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -299,7 +299,7 @@ namespace ClassicUO.Game.GameObjects
             }
 
             Direction moveDir = DirectionHelper.CalculateDirection(endX, endY, x, y);
-            Step step = new Step();
+            Step step = new Step { Arrival = Time.Ticks };
 
             if (Serial != World.Player)
             {
@@ -729,10 +729,11 @@ namespace ClassicUO.Game.GameObjects
             LastAnimationChangeTime = Time.Ticks + currentDelay;
         }
 
-        // True when at least two position-changing steps are queued, counted from the
-        // tile the mobile stands on: the in-flight step plus a real move behind it.
-        // Facing-turns share their predecessor's tile and occupy depth without one.
-        private bool HasMoveBacklog()
+        // Milliseconds the first real move queued behind the in-flight step has waited,
+        // or -1 when there is no movement backlog. Counted from the tile the mobile
+        // stands on: the in-flight step plus a real move behind it. Facing-turns share
+        // their predecessor's tile and occupy depth without one.
+        private int QueuedMoveWait()
         {
             int moves = 0;
             int prevX = X;
@@ -746,7 +747,7 @@ namespace ClassicUO.Game.GameObjects
                 {
                     if (++moves > 1)
                     {
-                        return true;
+                        return (int)(Time.Ticks - s.Arrival);
                     }
 
                     prevX = s.X;
@@ -754,7 +755,7 @@ namespace ClassicUO.Game.GameObjects
                 }
             }
 
-            return false;
+            return -1;
         }
 
         public void ProcessSteps(out byte dir, bool evalutate = false)
@@ -788,13 +789,15 @@ namespace ClassicUO.Game.GameObjects
                     bool mounted = actuallyMounted;
                     bool run = step.Run;
 
+                    int backlogWait = Serial != World.Player && Steps.Count > 1 ? QueuedMoveWait() : -1;
+
                     // Client auto movements sync.
                     // When server sends more than 1 packet in an amount of time less than 100ms if mounted (or 200ms if walking mount)
                     // we need to remove the "teleport" effect.
                     // When delay == 0 means that we received multiple movement packets in a single frame, so the patch becomes quite useless.
                     // Only a genuine movement backlog may compress; a queued facing-turn
                     // occupies depth without one.
-                    if (!mounted && Serial != World.Player && Steps.Count > 1 && delay > 0 && HasMoveBacklog())
+                    if (!mounted && delay > 0 && backlogWait >= 0)
                     {
                         mounted =
                             delay
@@ -819,7 +822,11 @@ namespace ClassicUO.Game.GameObjects
                         && StepInterval <= MovementSpeed.TimeToCompleteMovement(false, actuallyMounted)
                     )
                     {
-                        stepTime = Math.Max(StepInterval, MovementSpeed.STEP_DELAY_MIN);
+                        // A move waiting behind this step is a tile the server has that we have
+                        // not shown yet. Shorten the step by the wait so the queued move starts
+                        // on time: a packet a few ms early costs a few ms, a full packet of lag
+                        // runs the tail at double speed and halves the deficit every step.
+                        stepTime = Math.Max(StepInterval - Math.Max(backlogWait, 0), MovementSpeed.STEP_DELAY_MIN);
                     }
 
                     int maxDelay = Math.Max(stepTime - (int)Client.Game.FrameDelay[1], 1);
@@ -1165,6 +1172,7 @@ namespace ClassicUO.Game.GameObjects
             public sbyte Z;
             public byte Direction;
             public bool Run;
+            public uint Arrival;
         }
     }
 }

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSD-2-Clause
+﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using ClassicUO.Assets;
 using ClassicUO.Configuration;
@@ -126,6 +126,7 @@ namespace ClassicUO.Game.GameObjects
         // Lets queued steps drain at the server's cadence instead of the nominal step time.
         public int StepInterval { get; private set; }
         private uint _lastStepArrival;
+        private bool _turnSinceLastStep;
         public bool IsParalyzed => (Flags & Flags.Frozen) != 0;
         public bool IsYellowHits => (Flags & Flags.YellowBar) != 0;
         public bool IsPoisoned =>
@@ -300,20 +301,38 @@ namespace ClassicUO.Game.GameObjects
             Direction moveDir = DirectionHelper.CalculateDirection(endX, endY, x, y);
             Step step = new Step();
 
-            if (moveDir != Direction.NONE)
+            if (Serial != World.Player)
             {
-                // Only packets that move the mobile define its cadence; a turn packet
-                // followed by a step would otherwise read as a near-zero interval.
-                if (Serial != World.Player)
+                if (moveDir == Direction.NONE)
+                {
+                    // A facing-turn is not a step: it neither defines the cadence nor
+                    // resets the clock the next step is measured against.
+                    _turnSinceLastStep = true;
+                }
+                else
                 {
                     if (_lastStepArrival != 0)
                     {
-                        StepInterval = (int)(Time.Ticks - _lastStepArrival);
+                        int elapsed = (int)(Time.Ticks - _lastStepArrival);
+
+                        // Servers that emit turns as their own packet pace the step after a
+                        // turn by the turn latency, not the step period (the client itself
+                        // steps 80 ms after a turn; some emulators charge a full period), so a
+                        // pair that spans a turn keeps the last estimate while it is still
+                        // renderable. Beyond a walk, measure: the mobile actually paused.
+                        if (!_turnSinceLastStep || elapsed > MovementSpeed.STEP_DELAY_WALK)
+                        {
+                            StepInterval = elapsed;
+                        }
                     }
 
                     _lastStepArrival = Time.Ticks;
+                    _turnSinceLastStep = false;
                 }
+            }
 
+            if (moveDir != Direction.NONE)
+            {
                 if (moveDir != endDir)
                 {
                     step.X = endX;
@@ -710,22 +729,29 @@ namespace ClassicUO.Game.GameObjects
             LastAnimationChangeTime = Time.Ticks + currentDelay;
         }
 
-        // True when any entry queued behind the in-flight front step is an actual move.
+        // True when at least two position-changing steps are queued, counted from the
+        // tile the mobile stands on: the in-flight step plus a real move behind it.
         // Facing-turns share their predecessor's tile and occupy depth without one.
         private bool HasMoveBacklog()
         {
-            Step prev = Steps[0];
+            int moves = 0;
+            int prevX = X;
+            int prevY = Y;
 
-            for (int i = 1; i < Steps.Count; i++)
+            for (int i = 0; i < Steps.Count; i++)
             {
                 Step s = Steps[i];
 
-                if (s.X != prev.X || s.Y != prev.Y)
+                if (s.X != prevX || s.Y != prevY)
                 {
-                    return true;
-                }
+                    if (++moves > 1)
+                    {
+                        return true;
+                    }
 
-                prev = s;
+                    prevX = s.X;
+                    prevY = s.Y;
+                }
             }
 
             return false;
@@ -781,18 +807,19 @@ namespace ClassicUO.Game.GameObjects
 
                     int stepTime = MovementSpeed.TimeToCompleteMovement(run, mounted);
 
-                    // Animate at the server's cadence while it is renderable (a mounted run
-                    // up to a walk): faster than nominal backs the queue up until steps drop
-                    // and the mobile snaps; slower than nominal stalls between steps. Beyond
-                    // a walk, keep the usual step-then-stand look. Bounded by the real
-                    // mounted state so the measured cadence outranks the backlog heuristic.
+                    // Animate at the server's cadence while it is renderable (the fastest
+                    // tuned creatures up to a walk): faster than nominal backs the queue up
+                    // until steps drop and the mobile snaps; slower than nominal stalls
+                    // between steps. Beyond a walk, keep the usual step-then-stand look.
+                    // Bounded by the real mounted state so the measured cadence outranks
+                    // the backlog heuristic.
                     if (
                         Serial != World.Player
                         && StepInterval > 0
                         && StepInterval <= MovementSpeed.TimeToCompleteMovement(false, actuallyMounted)
                     )
                     {
-                        stepTime = Math.Max(StepInterval, MovementSpeed.STEP_DELAY_MOUNT_RUN);
+                        stepTime = Math.Max(StepInterval, MovementSpeed.STEP_DELAY_MIN);
                     }
 
                     int maxDelay = Math.Max(stepTime - (int)Client.Game.FrameDelay[1], 1);

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -121,6 +121,11 @@ namespace ClassicUO.Game.GameObjects
         public Mobile(World world) : base(world, 0) { }
 
         public Deque<Step> Steps { get; } = new Deque<Step>(Constants.MAX_STEP_COUNT);
+
+        // Interval between the last two step packets from the server (ms); 0 = unknown.
+        // Lets queued steps drain at the server's cadence instead of the nominal step time.
+        public int StepInterval { get; private set; }
+        private uint _lastStepArrival;
         public bool IsParalyzed => (Flags & Flags.Frozen) != 0;
         public bool IsYellowHits => (Flags & Flags.YellowBar) != 0;
         public bool IsPoisoned =>
@@ -297,6 +302,18 @@ namespace ClassicUO.Game.GameObjects
 
             if (moveDir != Direction.NONE)
             {
+                // Only packets that move the mobile define its cadence; a turn packet
+                // followed by a step would otherwise read as a near-zero interval.
+                if (Serial != World.Player)
+                {
+                    if (_lastStepArrival != 0)
+                    {
+                        StepInterval = (int)(Time.Ticks - _lastStepArrival);
+                    }
+
+                    _lastStepArrival = Time.Ticks;
+                }
+
                 if (moveDir != endDir)
                 {
                     step.X = endX;
@@ -693,6 +710,27 @@ namespace ClassicUO.Game.GameObjects
             LastAnimationChangeTime = Time.Ticks + currentDelay;
         }
 
+        // True when any entry queued behind the in-flight front step is an actual move.
+        // Facing-turns share their predecessor's tile and occupy depth without one.
+        private bool HasMoveBacklog()
+        {
+            Step prev = Steps[0];
+
+            for (int i = 1; i < Steps.Count; i++)
+            {
+                Step s = Steps[i];
+
+                if (s.X != prev.X || s.Y != prev.Y)
+                {
+                    return true;
+                }
+
+                prev = s;
+            }
+
+            return false;
+        }
+
         public void ProcessSteps(out byte dir, bool evalutate = false)
         {
             dir = (byte)Direction;
@@ -716,18 +754,21 @@ namespace ClassicUO.Game.GameObjects
                     }
 
                     int delay = (int)Time.Ticks - (int)LastStepTime;
-                    bool mounted =
+                    bool actuallyMounted =
                         IsMounted
                         || SpeedMode == CharacterSpeedType.FastUnmount
                         || SpeedMode == CharacterSpeedType.FastUnmountAndCantRun
                         || IsFlying;
+                    bool mounted = actuallyMounted;
                     bool run = step.Run;
 
                     // Client auto movements sync.
                     // When server sends more than 1 packet in an amount of time less than 100ms if mounted (or 200ms if walking mount)
                     // we need to remove the "teleport" effect.
                     // When delay == 0 means that we received multiple movement packets in a single frame, so the patch becomes quite useless.
-                    if (!mounted && Serial != World.Player && Steps.Count > 1 && delay > 0)
+                    // Only a genuine movement backlog may compress; a queued facing-turn
+                    // occupies depth without one.
+                    if (!mounted && Serial != World.Player && Steps.Count > 1 && delay > 0 && HasMoveBacklog())
                     {
                         mounted =
                             delay
@@ -738,9 +779,23 @@ namespace ClassicUO.Game.GameObjects
                             );
                     }
 
-                    int maxDelay =
-                        MovementSpeed.TimeToCompleteMovement(run, mounted)
-                        - (int)Client.Game.FrameDelay[1];
+                    int stepTime = MovementSpeed.TimeToCompleteMovement(run, mounted);
+
+                    // Animate at the server's cadence while it is renderable (a mounted run
+                    // up to a walk): faster than nominal backs the queue up until steps drop
+                    // and the mobile snaps; slower than nominal stalls between steps. Beyond
+                    // a walk, keep the usual step-then-stand look. Bounded by the real
+                    // mounted state so the measured cadence outranks the backlog heuristic.
+                    if (
+                        Serial != World.Player
+                        && StepInterval > 0
+                        && StepInterval <= MovementSpeed.TimeToCompleteMovement(false, actuallyMounted)
+                    )
+                    {
+                        stepTime = Math.Max(StepInterval, MovementSpeed.STEP_DELAY_MOUNT_RUN);
+                    }
+
+                    int maxDelay = Math.Max(stepTime - (int)Client.Game.FrameDelay[1], 1);
 
                     bool removeStep = delay >= maxDelay;
                     bool directionChange = false;

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -123,7 +123,6 @@ namespace ClassicUO.Game.GameObjects
         public Deque<Step> Steps { get; } = new Deque<Step>(Constants.MAX_STEP_COUNT);
 
         // Interval between the last two step packets from the server (ms); 0 = unknown.
-        // Lets queued steps drain at the server's cadence instead of the nominal step time.
         public int StepInterval { get; private set; }
         private uint _lastStepArrival;
         private bool _turnSinceLastStep;
@@ -305,8 +304,7 @@ namespace ClassicUO.Game.GameObjects
             {
                 if (moveDir == Direction.NONE)
                 {
-                    // A facing-turn is not a step: it neither defines the cadence nor
-                    // resets the clock the next step is measured against.
+                    // A facing-turn neither defines the cadence nor restarts the clock.
                     _turnSinceLastStep = true;
                 }
                 else
@@ -315,11 +313,8 @@ namespace ClassicUO.Game.GameObjects
                     {
                         int elapsed = (int)(Time.Ticks - _lastStepArrival);
 
-                        // Servers that emit turns as their own packet pace the step after a
-                        // turn by the turn latency, not the step period (the client itself
-                        // steps 80 ms after a turn; some emulators charge a full period), so a
-                        // pair that spans a turn keeps the last estimate while it is still
-                        // renderable. Beyond a walk, measure: the mobile actually paused.
+                        // A pair spanning a turn includes the turn latency, not just the
+                        // period: keep the last estimate unless the mobile actually paused.
                         if (!_turnSinceLastStep || elapsed > MovementSpeed.STEP_DELAY_WALK)
                         {
                             StepInterval = elapsed;
@@ -729,10 +724,8 @@ namespace ClassicUO.Game.GameObjects
             LastAnimationChangeTime = Time.Ticks + currentDelay;
         }
 
-        // Milliseconds the first real move queued behind the in-flight step has waited,
-        // or -1 when there is no movement backlog. Counted from the tile the mobile
-        // stands on: the in-flight step plus a real move behind it. Facing-turns share
-        // their predecessor's tile and occupy depth without one.
+        // Wait (ms) of the first real move queued behind the in-flight step, or -1 when
+        // there is no movement backlog. Facing-turns share a tile and do not count.
         private int QueuedMoveWait()
         {
             int moves = 0;
@@ -795,8 +788,7 @@ namespace ClassicUO.Game.GameObjects
                     // When server sends more than 1 packet in an amount of time less than 100ms if mounted (or 200ms if walking mount)
                     // we need to remove the "teleport" effect.
                     // When delay == 0 means that we received multiple movement packets in a single frame, so the patch becomes quite useless.
-                    // Only a genuine movement backlog may compress; a queued facing-turn
-                    // occupies depth without one.
+                    // Only a genuine movement backlog may compress.
                     if (!mounted && delay > 0 && backlogWait >= 0)
                     {
                         mounted =
@@ -810,22 +802,17 @@ namespace ClassicUO.Game.GameObjects
 
                     int stepTime = MovementSpeed.TimeToCompleteMovement(run, mounted);
 
-                    // Animate at the server's cadence while it is renderable (the fastest
-                    // tuned creatures up to a walk): faster than nominal backs the queue up
-                    // until steps drop and the mobile snaps; slower than nominal stalls
-                    // between steps. Beyond a walk, keep the usual step-then-stand look.
-                    // Bounded by the real mounted state so the measured cadence outranks
-                    // the backlog heuristic.
+                    // Drain at the server's cadence while it is renderable (up to a walk);
+                    // beyond that keep the step-then-stand look. Bounded by the real mounted
+                    // state so the measurement outranks the backlog heuristic.
                     if (
                         Serial != World.Player
                         && StepInterval > 0
                         && StepInterval <= MovementSpeed.TimeToCompleteMovement(false, actuallyMounted)
                     )
                     {
-                        // A move waiting behind this step is a tile the server has that we have
-                        // not shown yet. Shorten the step by the wait so the queued move starts
-                        // on time: a packet a few ms early costs a few ms, a full packet of lag
-                        // runs the tail at double speed and halves the deficit every step.
+                        // Shorten by the queued move's wait so it starts on time; a full
+                        // packet of lag halves every step.
                         stepTime = Math.Max(StepInterval - Math.Max(backlogWait, 0), MovementSpeed.STEP_DELAY_MIN);
                     }
 

--- a/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
@@ -1079,9 +1079,10 @@ namespace ClassicUO.Game.GameObjects
                             }
                             else
                             {
+                                // A body without a run group keeps walking rather than sliding on its stand frames.
                                 result = animations.AnimationExists(graphic, 1)
-                                    ? (byte)1
-                                    : (byte)2;
+                                    ? (byte)(LowAnimationGroup.Run)
+                                    : (byte)(LowAnimationGroup.Walk);
                             }
                         }
                         else if (

--- a/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
@@ -1079,7 +1079,7 @@ namespace ClassicUO.Game.GameObjects
                             }
                             else
                             {
-                                // A body without a run group keeps walking rather than sliding on its stand frames.
+                                // No run group: walk rather than slide on the stand frames.
                                 result = animations.AnimationExists(graphic, 1)
                                     ? (byte)(LowAnimationGroup.Run)
                                     : (byte)(LowAnimationGroup.Walk);


### PR DESCRIPTION
### Summary

* **Steps drain at the server's measured cadence.** NPC steps are animated over a fixed nominal time selected by the run flag (400/200 ms on foot, 200/100 mounted). A server that steps on a different cadence renders badly either way: faster than nominal backs the step queue up until `EnqueueStep` drops packets and the mobile snaps forward; slower than nominal (e.g. a 300 ms cadence with the run flag) moves the mobile for 200 ms and stalls it for 100 ms, a visible stutter. This records the interval between consecutive *position-changing* step packets per mobile and animates each step over that interval whenever it lies in the band the client can follow — from a mounted run (100 ms) up to the walk time. Outside the band the nominal time for the flag applies, so slow wanderers keep the step-then-stand look. The player's own movement is untouched.
* **The backlog sync patch no longer fires on queued facing-turns.** The legacy compression heuristic keys on `Steps.Count > 1`, but a turn packet queued behind an in-flight step inflates the depth without any movement backlog — the arrival step of a chase (server turns the mobile to face its target) rendered in ~100 ms as a dart. Only entries that change position relative to their predecessor count as backlog now, and the cadence band is bounded by the mobile's real mounted/speed state rather than the one the heuristic fakes, so a measured cadence always outranks the guess. Genuine packet bursts still compress: their measured interval is itself small.
* **Animal (LOW group) bodies without a run animation group** fell back to their **stand** frames while moving, so they slid. They now use the walk group.

All changes are client-only: no protocol changes, no server-specific behavior.

### Testing

Verified with paired UTC-aligned traces (server step emission vs client `EnqueueStep`/`ProcessSteps`) plus frame-by-frame video tracking of a ModernUO lich chase (300 ms cadence):

* Before: the 200 ms-move / 100 ms-stall stutter mid-chase; ~100 ms dart on the arrival step whenever a facing-turn queued behind it.
* After: 158 of 159 rendered steps animate at the measured 250–350 ms cadence; the single fast render is the first step ever seen for the mobile (no interval measured yet, nominal-by-flag). Pets at ~100 ms and creatures at 125/300/450 ms cadences verified in-game.