### PR TITLE
Read the map patch counts in the order servers send them

### DIFF
--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -461,10 +461,23 @@ namespace ClassicUO.Assets
                     continue;
                 }
 
-                int mapPatchesCount = (int)reader.ReadUInt32BE();
-                MapPatchCount[i] = mapPatchesCount;
+                // Statics first, then land.
+                //
+                // This was the other way round, and it silently disabled land patching against
+                // every server that sends this packet. RunUO, ServUO and ModernUO all write the
+                // statics count first - ModernUO in OutgoingMapPackets.SendMapPatches - so
+                // reading land first takes the statics count as the land count and the land count
+                // as the statics count.
+                //
+                // The failure is invisible rather than loud: a shard that patches land and not
+                // statics sends (0, n), which reads as "no land patches" and n statics patches
+                // that then clamp to zero against an empty stadifl. Nothing throws, nothing logs,
+                // and the ground simply stays as it was while the server believes it changed. It
+                // has probably gone unnoticed because almost nothing ships map patches any more.
                 int staticPatchesCount = (int)reader.ReadUInt32BE();
                 StaticPatchCount[i] = staticPatchesCount;
+                int mapPatchesCount = (int)reader.ReadUInt32BE();
+                MapPatchCount[i] = mapPatchesCount;
 
                 int w = MapBlocksSize[i, 0];
                 int h = MapBlocksSize[i, 1];


### PR DESCRIPTION
The 0xBF 0x18 packet carries, per facet, a count of patched statics blocks and a count of patched land blocks. This read land first. RunUO, ServUO and ModernUO all write statics first - ModernUO in
OutgoingMapPackets.SendMapPatches - so the two counts arrive swapped.

The failure is silent, which is why it can sit here unnoticed. A shard that patches land and not statics sends (0, n). Read the wrong way round that is "no land patches" plus n statics patches, and those n then clamp to zero against an empty stadifl. Nothing throws, nothing is logged, and the ground stays exactly as it was while the server is certain it changed - so the server and the client disagree about the world with no symptom beyond players walking through scenery that is not there, or into scenery that is.

Found by patching a facet and watching the server report 52 patched land blocks while the client drew none of them.