### PR TITLE
Read gump art, item art and ground from a folder

### DIFF
--- a/src/ClassicUO.Assets/ArtLoader.cs
+++ b/src/ClassicUO.Assets/ArtLoader.cs
@@ -2,7 +2,9 @@
 
 using ClassicUO.IO;
 using ClassicUO.Utility;
+using ClassicUO.Utility.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -13,6 +15,22 @@ namespace ClassicUO.Assets
         private UOFile _file;
         public const int MAX_LAND_DATA_INDEX_COUNT = 0x4000;
         public const int MAX_STATIC_DATA_INDEX_COUNT = 0x14000;
+
+        /// <summary>
+        /// Art of the shard's own, as loose files, by the number the server asks for.
+        ///
+        /// Two dictionaries because they are two formats sharing one archive, and nothing but the
+        /// colour is common to them: a static is run-length with its size in front, a land tile is
+        /// 1,012 raw pixels of a diamond and nothing else at all.
+        ///
+        /// The archive uses 39,516 of the 81,920 static numbers and its highest is 62,763, so
+        /// there is room for close to twenty thousand of ours above it. Land is the other way
+        /// round: all 16,384 numbers exist and its highest is the last of them, so a land file
+        /// here can only ever replace ground the client already draws, never add new ground.
+        /// </summary>
+        private readonly Dictionary<int, string> _ourStatics = new Dictionary<int, string>();
+
+        private readonly Dictionary<int, string> _ourLand = new Dictionary<int, string>();
 
         public ArtLoader(UOFileManager fileManager) : base(fileManager)
         {
@@ -42,6 +60,133 @@ namespace ClassicUO.Assets
             }
 
             _file.FillEntries();
+
+            LoadOurs();
+        }
+
+        /// <summary>
+        /// Find the shard's own art once, at load, rather than asking the disk every time
+        /// something is drawn.
+        ///
+        /// A File.Exists per tile would be a disk hit for every square of ground on the screen,
+        /// which is several hundred of them, sixty times a second.
+        /// </summary>
+        private void LoadOurs()
+        {
+            _ourStatics.Clear();
+            _ourLand.Clear();
+
+            // Two folders and not one, keyed by the numbers a shard author actually types - the
+            // item id a `new Item(0x2818)` uses, and the land tile id. The archive's own indexing
+            // puts statics 0x4000 along from land in a single run, and nobody thinks in those.
+            Gather(Path.Combine(FileManager.BasePath, "Art", "Statics"),
+                   _ourStatics, MAX_STATIC_DATA_INDEX_COUNT - MAX_LAND_DATA_INDEX_COUNT);
+
+            Gather(Path.Combine(FileManager.BasePath, "Art", "Land"),
+                   _ourLand, MAX_LAND_DATA_INDEX_COUNT);
+
+            if (_ourStatics.Count > 0 || _ourLand.Count > 0)
+            {
+                Log.Trace($"{_ourStatics.Count} static(s) and {_ourLand.Count} land tile(s) of our own");
+            }
+        }
+
+        private static void Gather(string folder, Dictionary<int, string> into, int limit)
+        {
+            if (!Directory.Exists(folder))
+            {
+                return;
+            }
+
+            foreach (string path in Directory.EnumerateFiles(folder, "*.art"))
+            {
+                if (int.TryParse(Path.GetFileNameWithoutExtension(path), out int id)
+                    && id >= 0 && id < limit)
+                {
+                    into[id] = path;
+                }
+            }
+        }
+
+        private static byte[] Slurp(string path)
+        {
+            try
+            {
+                return System.IO.File.ReadAllBytes(path);
+            }
+            catch (IOException e)
+            {
+                Log.Warn($"could not read {path}: {e.Message}");
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// One static of ours off the disk: the same bytes the archive would have held.
+        ///
+        /// The file carries its own size, which is not a format of our own - it is exactly what
+        /// the archive stores, header and all, so the reader below is the archive's reader.
+        /// </summary>
+        private static uint[] OurArt(string path, out short width, out short height)
+        {
+            width = 0;
+            height = 0;
+
+            var raw = Slurp(path);
+
+            if (raw == null || raw.Length < 8)
+            {
+                Log.Warn($"{Path.GetFileName(path)} is too short to be static art");
+
+                return null;
+            }
+
+            width = (short)(raw[4] | (raw[5] << 8));
+            height = (short)(raw[6] | (raw[7] << 8));
+
+            // Believed, a bad size asks for a picture of some billions of pixels and takes the
+            // client down with it, from inside the drawing code and a long way from this file.
+            if (width <= 0 || height <= 0 || width > 1024 || height > 1024)
+            {
+                Log.Warn($"{Path.GetFileName(path)} claims to be {width}x{height}");
+
+                return null;
+            }
+
+            if (raw.Length < 8 + height * 2)
+            {
+                Log.Warn($"{Path.GetFileName(path)} has no room for {height} rows");
+
+                return null;
+            }
+
+            var buf = new byte[raw.Length - 8];
+            Array.Copy(raw, 8, buf, 0, buf.Length);
+
+            return Runs(buf, width, height);
+        }
+
+        /// <summary>One land tile of ours: 1,012 pixels of diamond and nothing else.</summary>
+        private static uint[] OurLand(string path)
+        {
+            var raw = Slurp(path);
+
+            if (raw == null)
+            {
+                return null;
+            }
+
+            // 44 x 44 is 1,936, and a land tile is not that. The four corners are outside the
+            // diamond and are not stored, so it is 1,012 pixels - 2,024 bytes, always.
+            if (raw.Length < 2024)
+            {
+                Log.Warn($"{Path.GetFileName(path)} is {raw.Length} bytes; a land tile is 2024");
+
+                return null;
+            }
+
+            return Diamond(raw);
         }
 
         // public Rectangle GetRealArtBounds(int index) =>
@@ -67,7 +212,28 @@ namespace ClassicUO.Assets
 
             file.Seek(entry.Offset, SeekOrigin.Begin);
 
-            var data = new uint[width * height];
+            var raw = new byte[2024];
+            file.Read(raw);
+
+            return Diamond(raw);
+        }
+
+        /// <summary>
+        /// The 1,012 pixels of a land tile, laid into a 44 by 44 square.
+        ///
+        /// Two triangles meeting in the middle: the top half widens by two pixels a row and the
+        /// bottom half narrows by two. The corners of the square are never written and stay
+        /// transparent, because they are not part of the tile.
+        ///
+        /// There is no transparency inside the diamond and no colour reserved for it, so a colour
+        /// of zero here is simply black - which is the one thing that differs from every other
+        /// picture format in the client, and the thing that quietly breaks an encoder that
+        /// assumes otherwise.
+        /// </summary>
+        private static uint[] Diamond(byte[] raw)
+        {
+            var data = new uint[44 * 44];
+            var at = 0;
 
             for (int i = 0; i < 22; ++i)
             {
@@ -75,9 +241,10 @@ namespace ClassicUO.Assets
                 int pos = i * 44 + start;
                 int end = start + ((i + 1) << 1);
 
-                for (int j = start; j < end; ++j)
+                for (int j = start; j < end; ++j, at += 2)
                 {
-                    data[pos++] = HuesHelper.Color16To32(file.ReadUInt16()) | 0xFF_00_00_00;
+                    data[pos++] = HuesHelper.Color16To32((ushort)(raw[at] | (raw[at + 1] << 8)))
+                                  | 0xFF_00_00_00;
                 }
             }
 
@@ -86,9 +253,10 @@ namespace ClassicUO.Assets
                 int pos = (i + 22) * 44 + i;
                 int end = i + ((22 - i) << 1);
 
-                for (int j = i; j < end; ++j)
+                for (int j = i; j < end; ++j, at += 2)
                 {
-                    data[pos++] = HuesHelper.Color16To32(file.ReadUInt16()) | 0xFF_00_00_00;
+                    data[pos++] = HuesHelper.Color16To32((ushort)(raw[at] | (raw[at + 1] << 8)))
+                                  | 0xFF_00_00_00;
                 }
             }
 
@@ -117,6 +285,22 @@ namespace ClassicUO.Assets
             var buf = new byte[entry.Length];
             file.Read(buf);
 
+            return Runs(buf, width, height);
+        }
+
+        /// <summary>
+        /// The rows of a static, from wherever they came from.
+        ///
+        /// A lookup of one 16-bit word per row saying where that row's runs begin, counted in
+        /// pairs of bytes from the end of the lookup itself; then, for each row, a gap and a run
+        /// length followed by that many colours, until a gap and run of zero end the row.
+        ///
+        /// The gap is a skip rather than a position, and transparency is those gaps - a static
+        /// stores no transparent pixel at all, which is why a tree costs so much less than the
+        /// box it stands in.
+        /// </summary>
+        private static unsafe uint[] Runs(byte[] buf, short width, short height)
+        {
             var data = new uint[width * height];
 
             fixed (byte* startPtr = buf)
@@ -207,8 +391,39 @@ namespace ClassicUO.Assets
 
         public ArtInfo GetArt(uint idx)
         {
+            var loadLand = idx < MAX_LAND_DATA_INDEX_COUNT;
+
+            // Ours first, so a file corrects art the archive already has rather than only filling
+            // a number it lacks. For land that is the only thing a file can do - every one of the
+            // sixteen thousand land numbers is already taken.
+            //
+            // A broken file falls through to the archive rather than leaving a hole, so a bad
+            // import shows the old art and a warning instead of a gap in the ground.
+            if (loadLand)
+            {
+                if (_ourLand.Count > 0 && _ourLand.TryGetValue((int)idx, out string land))
+                {
+                    var mine = OurLand(land);
+
+                    if (mine != null)
+                    {
+                        return new ArtInfo { Pixels = mine, Width = 44, Height = 44 };
+                    }
+                }
+            }
+            else if (_ourStatics.Count > 0
+                     && _ourStatics.TryGetValue((int)(idx - MAX_LAND_DATA_INDEX_COUNT),
+                                                out string statik))
+            {
+                var mine = OurArt(statik, out var mw, out var mh);
+
+                if (mine != null)
+                {
+                    return new ArtInfo { Pixels = mine, Width = mw, Height = mh };
+                }
+            }
+
             ref var entry = ref _file.GetValidRefEntry((int)idx);
-            var loadLand = idx < 0x4000;
             var pixels = loadLand ?
                 LoadLand(_file, in entry, out var width, out var height)
                 :

--- a/src/ClassicUO.Assets/GumpsLoader.cs
+++ b/src/ClassicUO.Assets/GumpsLoader.cs
@@ -2,7 +2,9 @@
 
 using ClassicUO.IO;
 using ClassicUO.Utility;
+using ClassicUO.Utility.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -13,6 +15,17 @@ namespace ClassicUO.Assets
     {
         public const int MAX_GUMP_DATA_INDEX_COUNT = 0x10000;
 
+        /// <summary>
+        /// Gump art of the shard's own, as loose files, by the number the server asks for.
+        ///
+        /// gump.def can only fill an empty slot - it skips anything the archive already has - so
+        /// it aliases and never replaces. These do both: a file here is used whether or not the
+        /// archive has that number, which is what makes correcting an existing gump possible.
+        ///
+        /// The archive uses 5,571 of the 65,536 numbers and its highest is 61,728, so there is
+        /// plenty of room to put ours somewhere nothing will ever collide with.
+        /// </summary>
+        private readonly Dictionary<int, string> _ours = new Dictionary<int, string>();
 
         private UOFile _file;
 
@@ -52,6 +65,8 @@ namespace ClassicUO.Assets
             }
 
             _file.FillEntries();
+
+            LoadOurs();
 
             string pathdef = FileManager.GetUOFilePath("gump.def");
 
@@ -106,8 +121,105 @@ namespace ClassicUO.Assets
             }
         }
 
+        /// <summary>
+        /// Find the shard's own gump art once, at load, rather than asking the disk every time
+        /// something is drawn.
+        ///
+        /// A File.Exists per gump would be a disk hit for every frame of every open window.
+        /// </summary>
+        private void LoadOurs()
+        {
+            _ours.Clear();
+
+            string folder = Path.Combine(FileManager.BasePath, "Gumps");
+
+            if (!Directory.Exists(folder))
+            {
+                return;
+            }
+
+            foreach (string path in Directory.EnumerateFiles(folder, "*.gump"))
+            {
+                if (int.TryParse(Path.GetFileNameWithoutExtension(path), out int id)
+                    && id >= 0 && id < MAX_GUMP_DATA_INDEX_COUNT)
+                {
+                    _ours[id] = path;
+                }
+            }
+
+            if (_ours.Count > 0)
+            {
+                Log.Trace($"{_ours.Count} gump(s) of our own in {folder}");
+            }
+        }
+
+        /// <summary>
+        /// One of ours off the disk.
+        ///
+        /// The file is the same run-length picture the archive stores, with its size in front:
+        /// two 32-bit numbers for width and height, then the rows. That is not a new format -
+        /// the archive's own compressed entries carry their size inline in exactly this way and
+        /// are read by exactly this code a few lines down. Writing it out is a matter of leaving
+        /// the size where the reader below already looks for it.
+        /// </summary>
+        private GumpInfo ReadOurs(string path)
+        {
+            byte[] raw;
+
+            try
+            {
+                raw = System.IO.File.ReadAllBytes(path);
+            }
+            catch (IOException e)
+            {
+                Log.Warn($"could not read {path}: {e.Message}");
+                return default;
+            }
+
+            if (raw.Length < 8)
+            {
+                Log.Warn($"{Path.GetFileName(path)} is too short to be a gump");
+                return default;
+            }
+
+            var reader = new StackDataReader(raw);
+            var w = reader.ReadUInt32LE();
+            var h = reader.ReadUInt32LE();
+
+            // A bad size is worth naming out loud. Believed, it asks for a picture of some
+            // billions of pixels and takes the client down with it.
+            if (w == 0 || h == 0 || w > 4096 || h > 4096)
+            {
+                Log.Warn($"{Path.GetFileName(path)} claims to be {w}x{h}");
+                return default;
+            }
+
+            if (reader.Remaining < h * 4)
+            {
+                Log.Warn($"{Path.GetFileName(path)} has no room for {h} rows");
+                return default;
+            }
+
+            return Decode(ref reader, w, h, 0);
+        }
+
         public GumpInfo GetGump(uint index)
         {
+            // Ours first, so a file can correct a gump the archive already has and not only fill
+            // a number it lacks.
+            if (_ours.Count > 0 && _ours.TryGetValue((int)index, out string ours))
+            {
+                GumpInfo mine = ReadOurs(ours);
+
+                if (mine.Width > 0)
+                {
+                    return mine;
+                }
+
+                // A broken file falls through to the archive rather than leaving a hole, so a bad
+                // import shows the old art and a warning instead of nothing at all.
+            }
+
             ref var entry = ref _file.GetValidRefEntry((int)index);
 
             if (entry.CompressionFlag != CompressionType.ZlibBwt && entry.Width <= 0 && entry.Height <= 0)
@@ -154,6 +266,18 @@ namespace ClassicUO.Assets
                     entry.Height = (int)h;
             }
 
+            return Decode(ref reader, w, h, color);
+        }
+
+        /// <summary>
+        /// The rows of a gump, from wherever they came from.
+        ///
+        /// A row lookup of one 32-bit word per row - an offset from the table's own beginning, in
+        /// units of four bytes - and then pairs of (colour, run), the colour being 16-bit with
+        /// zero meaning transparent, which is why a mostly-empty gump costs so little.
+        /// </summary>
+        private GumpInfo Decode(scoped ref StackDataReader reader, uint w, uint h, ushort color)
+        {
             Span<uint> pixels = new uint[w * h];
             var len = reader.Remaining;
             var halfLen = len >> 2;
@@ -181,6 +305,20 @@ namespace ClassicUO.Assets
                     if (value != 0)
                     {
                         rbga = HuesHelper.Color16To32(value) | 0xFF_00_00_00;
+                    }
+
+                    // A run that would spill past the end of the row means the file disagrees
+                    // with its own header. Trusting it walks off the end of the picture, and an
+                    // IndexOutOfRange thrown from inside the drawing code is a long way from the
+                    // file that caused it.
+                    if (pixelIndex + run > pixels.Length)
+                    {
+                        run = (ushort)Math.Max(0, pixels.Length - pixelIndex);
+
+                        if (run == 0)
+                        {
+                            break;
+                        }
                     }
 
                     pixels.Slice(pixelIndex, run).Fill(rbga);


### PR DESCRIPTION
The same thing as #1932, applied to the other two archives.

Gumps. gump.def can alias an id to another id but skips any id the
archive already fills, so it can add a picture and can never correct
one. Rewriting gumpartLegacyMUL.uop works and means shipping a hundred
megabytes to change one button. This looks in <client>/Gumps/<id>.gump
first, holding exactly the run-length rows the archive holds.

Art. Two formats under one archive, so two folders:
Art/Statics/<itemId>.art holds the same run-length bytes the archive
holds, and Art/Land/<landId>.art holds the 1,012 raw pixels of a
diamond. Keyed by the numbers a shard author types rather than by the
archive's own indices, in which a static sits 0x4000 along from land.

Neither is a new format - the archive's own entries are read by the
same code, which is now shared between the two rather than copied. A
bad file warns and falls through to the archive rather than leaving a
hole, and a run that would spill past the end of a row is clamped
rather than throwing a long way from the file that caused it.